### PR TITLE
perf: ISR revalidation, lazy-load FullScreenModal, fix revalidateTag profile

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -21,14 +21,14 @@ export async function POST(req: NextRequest) {
 
     // Revalidate single cache tag if provided
     if (tag && typeof tag === 'string') {
-      revalidateTag(tag, 'default');
+      revalidateTag(tag, 'max');
     }
 
     // Revalidate multiple cache tags if provided
     if (Array.isArray(tags)) {
       for (const t of tags) {
         if (typeof t === 'string') {
-          revalidateTag(t, 'default');
+          revalidateTag(t, 'max');
         }
       }
     }

--- a/app/components/Content/ContentBlockWithFullScreen.tsx
+++ b/app/components/Content/ContentBlockWithFullScreen.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type ReorderMove } from '@/app/(admin)/collection/manage/[[...slug]]/manageUtils';
-import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
 import { useFullScreenImage } from '@/app/hooks/useFullScreenImage';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import { type CollectionModel } from '@/app/types/Collection';
@@ -15,6 +15,14 @@ import {
 
 import Component from './Component';
 import styles from './ContentBlockWithFullScreen.module.scss';
+
+const FullScreenModal = dynamic(
+  () =>
+    import('@/app/components/FullScreenModal/FullScreenModal').then(
+      m => ({ default: m.FullScreenModal })
+    ),
+  { ssr: false }
+);
 
 const LOAD_MORE_THRESHOLD = '400px';
 const DEFAULT_CHUNK_SIZE = 50;

--- a/app/location/[slug]/page.tsx
+++ b/app/location/[slug]/page.tsx
@@ -38,6 +38,8 @@ async function resolveLocationFromSlug(slug: string): Promise<ResolvedLocation |
 
 const getCachedLocation = cache(resolveLocationFromSlug);
 
+export const revalidate = 3600;
+
 /**
  * Generate SEO metadata for location pages.
  */

--- a/app/metadata/page.tsx
+++ b/app/metadata/page.tsx
@@ -1,7 +1,7 @@
 import { MetadataPageClient } from '@/app/components/MetadataPage/MetadataPageClient';
 import { getMetadata } from '@/app/lib/api/collections';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 3600;
 
 export default async function MetadataPage() {
   const metadata = await getMetadata();

--- a/app/people/[slug]/page.tsx
+++ b/app/people/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { getAllPeople, searchImages } from '@/app/lib/api/content';
 
 const getCachedPeople = cache(() => getAllPeople());
 
+export const revalidate = 3600;
+
 interface PersonPageRouteProps {
   params: Promise<{ slug: string }>;
 }

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { getAllTags, searchImages } from '@/app/lib/api/content';
 
 const getCachedTags = cache(() => getAllTags());
 
+export const revalidate = 3600;
+
 interface TagPageRouteProps {
   params: Promise<{ slug: string }>;
 }


### PR DESCRIPTION
## Summary

- Fix `revalidateTag` second arg — Next.js 16 requires a profile; changed `'default'` → `'max'` (safe default; no `use cache` directives in app)
- `metadata/page.tsx`: `force-dynamic` → `revalidate = 3600` — stops paying a server round-trip per visitor
- `app/tag/[slug]/page.tsx`, `app/people/[slug]/page.tsx`, `app/location/[slug]/page.tsx`: add `export const revalidate = 3600` — all three slug pages were dynamic on every request
- Lazy-load `FullScreenModal` via `next/dynamic(..., { ssr: false })` — removes 258 lines from initial gallery bundle; named-export pattern used

## Test Plan

- [ ] Admin: trigger a collection update and confirm cache invalidation fires without error
- [ ] Visit `/tag/[any-slug]`, `/people/[any-slug]`, `/location/[any-slug]` — confirm pages load and ISR headers are present
- [ ] Open a gallery page, click an image — confirm FullScreenModal still opens (lazy load doesn't break it)
- [ ] Check `/metadata` page — confirm it loads and is no longer `force-dynamic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)