### PR TITLE
fix: hydration mismatch in SearchPage + Inter display:swap + themeColor

### DIFF
--- a/app/components/SearchPage/SearchPage.tsx
+++ b/app/components/SearchPage/SearchPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useMemo, useState } from 'react';
 
 import ContentFilter from '@/app/components/ContentFilter/ContentFilter';
@@ -63,15 +64,12 @@ function getMockSearchContent(): ContentImageModel[] {
  * Inner search page content — wrapped in Suspense for useSearchParams
  */
 function SearchPageContent() {
+  const searchParams = useSearchParams();
   const mockContent = useMemo(() => getMockSearchContent(), []);
 
   const [filteredContent, setFilteredContent] = useState<AnyContentModel[]>(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-      const criteria = parseFilterFromParams(params);
-      return filterContent(mockContent, criteria);
-    }
-    return mockContent;
+    const criteria = parseFilterFromParams(searchParams);
+    return filterContent(mockContent, criteria);
   });
 
   const handleFilterChange = useCallback((filtered: AnyContentModel[]) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import { type ReactNode } from 'react';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
 export const metadata: Metadata = {
   title: {
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  themeColor: '#000000',
+  themeColor: '#ffffff',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

- `SearchPage`: replace `window.location.search` in `useState` initializer with `useSearchParams()` — server rendered with `mockContent`, client hydrated with filtered result; mismatch caused a flash on every search page load
- `app/layout.tsx`: `Inter({ display: 'swap' })` — eliminates FOIT (flash of invisible text) when the Inter font loads
- `app/layout.tsx`: `themeColor: '#ffffff'` — browser chrome was black (`#000000`) on a light-background photography site

## Test Plan

- [ ] Visit `/search` — confirm no hydration warning in browser console
- [ ] Filter search results — confirm URL params work and initial render matches server
- [ ] Open on mobile Chrome — confirm browser toolbar matches white site background
- [ ] Throttle network, reload — confirm text is visible before Inter loads (system font fallback shown, not invisible text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)