### PR TITLE
fix(proxy): wrap request body in Uint8Array for compatibility with AW…

### DIFF
--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -129,7 +129,16 @@ async function handle(req: NextRequest, context: { params: Promise<{ path: strin
   // Buffer the body: NextRequest.body is a ReadableStream, and undici fetch
   // requires `duplex: 'half'` to forward streams. Buffering avoids the streaming
   // path and lets undici set Content-Length. Safe given the 16 KB cap above.
-  const body = ['GET', 'HEAD'].includes(method) ? undefined : await req.arrayBuffer();
+  //
+  // The body must be wrapped in a Uint8Array view rather than passed as a raw
+  // ArrayBuffer. AWS Amplify's SSR Lambda runtime ships an undici build that
+  // throws synchronously on bare ArrayBuffer bodies (manifesting as a 502
+  // "Bad Gateway" on every write through this proxy in production while the
+  // Next.js dev server accepts it fine). Uint8Array is what undici handles
+  // uniformly across all Node runtimes — local dev, Vercel, and Amplify.
+  const body = ['GET', 'HEAD'].includes(method)
+    ? undefined
+    : new Uint8Array(await req.arrayBuffer());
 
   const init: RequestInit = {
     method,


### PR DESCRIPTION
…S Amplify

Updated the proxy route to ensure that the request body is wrapped in a Uint8Array instead of passing a raw ArrayBuffer. This change addresses compatibility issues with AWS Amplify's SSR Lambda runtime, which throws errors on bare ArrayBuffer bodies, leading to 502 "Bad Gateway" responses in production. The new implementation ensures consistent handling across different Node runtimes.