### PR TITLE
fix(static-params): handle backend unreachability in generateStaticPa…

### DIFF
--- a/app/location/[slug]/page.tsx
+++ b/app/location/[slug]/page.tsx
@@ -41,8 +41,17 @@ const getCachedLocation = cache(resolveLocationFromSlug);
 export const revalidate = 3600;
 
 export async function generateStaticParams() {
-  const locations = await getAllLocations();
-  return (locations ?? []).map(location => ({ slug: location.slug }));
+  // Tolerate backend unreachability at build time. The Amplify build container
+  // can't fetch from this site's own not-yet-deployed proxy, so an empty list
+  // here means "no prerendered routes" — pages still render on first request
+  // and are cached by `revalidate = 3600`. Mirrors the home page pattern in
+  // app/[slug]/page.tsx, where getAllCollections() swallows fetch errors.
+  try {
+    const locations = await getAllLocations();
+    return (locations ?? []).map(location => ({ slug: location.slug }));
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/app/people/[slug]/page.tsx
+++ b/app/people/[slug]/page.tsx
@@ -10,8 +10,17 @@ const getCachedPeople = cache(() => getAllPeople());
 export const revalidate = 3600;
 
 export async function generateStaticParams() {
-  const people = await getAllPeople();
-  return (people ?? []).map(person => ({ slug: person.slug }));
+  // Tolerate backend unreachability at build time. The Amplify build container
+  // can't fetch from this site's own not-yet-deployed proxy, so an empty list
+  // here means "no prerendered routes" — pages still render on first request
+  // and are cached by `revalidate = 3600`. Mirrors the home page pattern in
+  // app/[slug]/page.tsx, where getAllCollections() swallows fetch errors.
+  try {
+    const people = await getAllPeople();
+    return (people ?? []).map(person => ({ slug: person.slug }));
+  } catch {
+    return [];
+  }
 }
 
 interface PersonPageRouteProps {

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -10,8 +10,17 @@ const getCachedTags = cache(() => getAllTags());
 export const revalidate = 3600;
 
 export async function generateStaticParams() {
-  const tags = await getAllTags();
-  return (tags ?? []).map(tag => ({ slug: tag.slug }));
+  // Tolerate backend unreachability at build time. The Amplify build container
+  // can't fetch from this site's own not-yet-deployed proxy, so an empty list
+  // here means "no prerendered routes" — pages still render on first request
+  // and are cached by `revalidate = 3600`. Mirrors the home page pattern in
+  // app/[slug]/page.tsx, where getAllCollections() swallows fetch errors.
+  try {
+    const tags = await getAllTags();
+    return (tags ?? []).map(tag => ({ slug: tag.slug }));
+  } catch {
+    return [];
+  }
 }
 
 interface TagPageRouteProps {


### PR DESCRIPTION
…rams

Updated generateStaticParams in location, people, and tag pages to tolerate backend unreachability during build time. Implemented try-catch blocks to return an empty list if fetching data fails, ensuring pages still render on first request and are cached appropriately. This change mirrors the existing pattern in app/[slug]/page.tsx for improved consistency.