### PR TITLE
feat(client-gallery): download quality picker for web vs full size

### DIFF
--- a/app/components/ClientGalleryDownload/ClientGalleryDownload.module.scss
+++ b/app/components/ClientGalleryDownload/ClientGalleryDownload.module.scss
@@ -1,4 +1,4 @@
-/* Client Gallery Download - download all button and toast */
+/* Client Gallery Download - download all button and format picker */
 
 .downloadContainer {
   position: relative;
@@ -38,4 +38,61 @@
   width: 18px;
   height: 18px;
   flex-shrink: 0;
+}
+
+/* Format picker */
+.pickerLabel {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-fg-muted);
+  margin-bottom: var(--space-2);
+}
+
+.pickerRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.pickerButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-white);
+  background-color: var(--color-black);
+  border: none;
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background-color: var(--color-primary-dark);
+  }
+
+  &:disabled {
+    cursor: progress;
+    opacity: 0.7;
+  }
+}
+
+.cancelButton {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-fg-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+
+  &:hover {
+    color: var(--color-black);
+  }
 }

--- a/app/components/ClientGalleryDownload/ClientGalleryDownload.tsx
+++ b/app/components/ClientGalleryDownload/ClientGalleryDownload.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { downloadCollectionUrl } from '@/app/lib/api/downloads';
+import { downloadCollectionUrl,type DownloadFormat } from '@/app/lib/api/downloads';
 
 import styles from './ClientGalleryDownload.module.scss';
 
@@ -10,50 +10,107 @@ interface ClientGalleryDownloadProps {
   collectionSlug: string;
 }
 
-/**
- * Client Gallery Download All Button
- *
- * Prominent "Download All" action for CLIENT_GALLERY collections.
- * Navigates to the BFF-routed collection download endpoint, which streams
- * a ZIP with `Content-Disposition: attachment` so the browser saves rather
- * than navigates. The httpOnly `gallery_access_{slug}` cookie set by the
- * gate is sent automatically (same-origin via the proxy).
- *
- * The "preparing" state is a short-lived label change while the browser is
- * negotiating the ZIP — the native download UI is the real progress feedback.
- */
-export default function ClientGalleryDownload({ collectionSlug }: ClientGalleryDownloadProps) {
-  const [preparing, setPreparing] = useState(false);
+const DownloadIcon = () => (
+  <svg
+    aria-hidden="true"
+    className={styles.downloadIcon}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
 
-  const handleDownloadAll = useCallback(() => {
-    setPreparing(true);
-    window.location.href = downloadCollectionUrl(collectionSlug);
-    // Reset preparing state after a short delay (the browser is now handling the download)
-    setTimeout(() => setPreparing(false), 4000);
-  }, [collectionSlug]);
+export default function ClientGalleryDownload({ collectionSlug }: ClientGalleryDownloadProps) {
+  const [showPicker, setShowPicker] = useState(false);
+  const [preparing, setPreparing] = useState<DownloadFormat | null>(null);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const closePicker = useCallback(() => {
+    setShowPicker(false);
+  }, []);
+
+  // Esc closes the picker (only while it's open and a download isn't in flight)
+  useEffect(() => {
+    if (!showPicker || preparing !== null) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') closePicker();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [showPicker, preparing, closePicker]);
+
+  // Clear any pending reset timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
+
+  const handleOpenPicker = useCallback(() => {
+    setShowPicker(true);
+  }, []);
+
+  const handleFormatDownload = useCallback(
+    (format: DownloadFormat) => {
+      setPreparing(format);
+      window.location.href = downloadCollectionUrl(collectionSlug, format);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => {
+        setPreparing(null);
+        setShowPicker(false);
+        resetTimerRef.current = null;
+      }, 4000);
+    },
+    [collectionSlug]
+  );
+
+  if (showPicker) {
+    return (
+      <div className={styles.downloadContainer}>
+        <span id="download-quality-label" className={styles.pickerLabel}>
+          Choose quality:
+        </span>
+        <div className={styles.pickerRow} role="group" aria-labelledby="download-quality-label">
+          <button
+            type="button"
+            onClick={() => handleFormatDownload('web')}
+            disabled={preparing !== null}
+            className={styles.pickerButton}
+          >
+            <DownloadIcon />
+            {preparing === 'web' ? 'Preparing…' : 'Web Optimized'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleFormatDownload('original')}
+            disabled={preparing !== null}
+            className={styles.pickerButton}
+          >
+            <DownloadIcon />
+            {preparing === 'original' ? 'Preparing…' : 'Full Size'}
+          </button>
+          {preparing === null && (
+            <button type="button" onClick={closePicker} className={styles.cancelButton}>
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.downloadContainer}>
-      <button
-        type="button"
-        onClick={handleDownloadAll}
-        disabled={preparing}
-        className={styles.downloadButton}
-      >
-        <svg
-          className={styles.downloadIcon}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-          <polyline points="7 10 12 15 17 10" />
-          <line x1="12" y1="15" x2="12" y2="3" />
-        </svg>
-        {preparing ? 'Preparing ZIP…' : 'Download All'}
+      <button type="button" onClick={handleOpenPicker} className={styles.downloadButton}>
+        <DownloadIcon />
+        Download All
       </button>
     </div>
   );

--- a/app/components/ClientGalleryDownload/ImageDownloadOverlay.module.scss
+++ b/app/components/ClientGalleryDownload/ImageDownloadOverlay.module.scss
@@ -4,7 +4,7 @@
   position: absolute;
   bottom: var(--space-2);
   right: var(--space-2);
-  z-index: var(--z-overlay, 10);
+  z-index: var(--z-dropdown, 100);
   opacity: 0;
   transition: opacity 0.2s ease;
   pointer-events: none;
@@ -13,6 +13,12 @@
 /* Show on parent hover - data attributes used to avoid CSS Modules hash collision */
 [data-image-wrapper]:hover .overlayContainer,
 [data-parallax-container]:hover .overlayContainer {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Pin visible when expanded — overrides hover-only state */
+.overlayContainer.expanded {
   opacity: 1;
   pointer-events: auto;
 }
@@ -39,4 +45,52 @@
   width: 18px;
   height: 18px;
   color: var(--color-white);
+}
+
+/* Format picker — shown when expanded */
+.pickerRow {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+}
+
+.formatButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  height: 28px;
+  padding: 0 var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-white);
+  background-color: rgb(0, 0, 0, 0.8);
+  border: none;
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background-color: rgb(0, 0, 0, 0.95);
+  }
+
+  &:disabled {
+    cursor: progress;
+    opacity: 0.6;
+  }
+}
+
+.errorLabel {
+  font-size: var(--text-xs);
+  color: var(--color-white);
+  background-color: rgb(180, 0, 0, 0.85);
+  border-radius: var(--radius-1);
+  padding: var(--space-1) var(--space-2);
+  white-space: nowrap;
+  max-width: 160px;
+  text-align: right;
 }

--- a/app/components/ClientGalleryDownload/ImageDownloadOverlay.tsx
+++ b/app/components/ClientGalleryDownload/ImageDownloadOverlay.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { type MouseEvent, useCallback } from 'react';
+import { type MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 
-import { downloadImageUrl } from '@/app/lib/api/downloads';
+import { type DownloadFormat, downloadImageUrl } from '@/app/lib/api/downloads';
 
 import styles from './ImageDownloadOverlay.module.scss';
 
@@ -10,46 +10,143 @@ interface ImageDownloadOverlayProps {
   imageId: number;
 }
 
-/**
- * Image Download Overlay
- *
- * Per-image download button shown on hover for CLIENT_GALLERY images.
- * Navigates to the BFF-routed download endpoint, which streams the WebP
- * with `Content-Disposition: attachment` so the browser downloads rather
- * than navigates. The httpOnly `gallery_access_{slug}` cookie set by the
- * gate is sent automatically (same-origin via the proxy).
- */
 export default function ImageDownloadOverlay({ imageId }: ImageDownloadOverlayProps) {
-  const handleDownload = useCallback(
-    (e: MouseEvent) => {
-      e.stopPropagation(); // prevent triggering fullscreen view
-      window.location.href = downloadImageUrl(imageId);
+  const [expanded, setExpanded] = useState(false);
+  const [downloading, setDownloading] = useState<DownloadFormat | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Collapse on outside click when expanded.
+  // Listening on `mousedown` keeps the picker stable for inside clicks: the
+  // container's `e.stopPropagation()` on outer click is unrelated, but
+  // `containerRef.contains` already excludes the buttons themselves.
+  useEffect(() => {
+    if (!expanded) return;
+    const handler = (e: globalThis.MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setExpanded(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [expanded]);
+
+  // Esc collapses while expanded (unless a download is mid-flight).
+  useEffect(() => {
+    if (!expanded || downloading !== null) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') setExpanded(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [expanded, downloading]);
+
+  // Clear error timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
+
+  const handleIconClick = useCallback((e: MouseEvent) => {
+    e.stopPropagation();
+    setExpanded(prev => !prev);
+    setErrorMsg(null);
+  }, []);
+
+  const handleFormatDownload = useCallback(
+    async (e: MouseEvent, format: DownloadFormat) => {
+      e.stopPropagation();
+      setDownloading(format);
+      setErrorMsg(null);
+
+      let blobUrl: string | null = null;
+      try {
+        const res = await fetch(downloadImageUrl(imageId, format), { credentials: 'include' });
+        if (!res.ok) {
+          const msg =
+            format === 'original' ? 'Original not available for this image' : 'Download failed';
+          setErrorMsg(msg);
+          if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+          errorTimerRef.current = setTimeout(() => {
+            setErrorMsg(null);
+            errorTimerRef.current = null;
+          }, 3000);
+          return;
+        }
+        const blob = await res.blob();
+        blobUrl = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = blobUrl;
+        a.download = '';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setExpanded(false);
+      } finally {
+        if (blobUrl) URL.revokeObjectURL(blobUrl);
+        setDownloading(null);
+      }
     },
     [imageId]
   );
 
   return (
-    <div className={styles.overlayContainer}>
-      <button
-        type="button"
-        onClick={handleDownload}
-        className={styles.downloadIconButton}
-        aria-label="Download image"
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={styles.icon}
+    <div
+      ref={containerRef}
+      className={`${styles.overlayContainer}${expanded ? ` ${styles.expanded}` : ''}`}
+      onClick={e => e.stopPropagation()}
+    >
+      {expanded ? (
+        <div className={styles.pickerRow}>
+          <button
+            type="button"
+            onClick={e => handleFormatDownload(e, 'web')}
+            disabled={downloading !== null}
+            className={styles.formatButton}
+            aria-label="Download web-optimized image"
+          >
+            {downloading === 'web' ? '…' : 'Web'}
+          </button>
+          <button
+            type="button"
+            onClick={e => handleFormatDownload(e, 'original')}
+            disabled={downloading !== null}
+            className={styles.formatButton}
+            aria-label="Download full-size image"
+          >
+            {downloading === 'original' ? '…' : 'Full'}
+          </button>
+          {errorMsg && (
+            <span role="alert" aria-live="assertive" className={styles.errorLabel}>
+              {errorMsg}
+            </span>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={handleIconClick}
+          className={styles.downloadIconButton}
+          aria-label="Download image"
         >
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-          <polyline points="7 10 12 15 17 10" />
-          <line x1="12" y1="15" x2="12" y2="3" />
-        </svg>
-      </button>
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={styles.icon}
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/app/lib/api/downloads.ts
+++ b/app/lib/api/downloads.ts
@@ -7,12 +7,14 @@
  * (e.g. `window.location.href = ...`) and the browser handles the response.
  *
  * Backend endpoints:
- * - GET /api/read/content/images/{id}/download?format=web
- * - GET /api/read/collections/{slug}/download?format=web
+ * - GET /api/read/content/images/{id}/download?format=web|original
+ * - GET /api/read/collections/{slug}/download?format=web|original
  */
 
-export const downloadImageUrl = (imageId: number, format: 'web' | 'original' = 'web'): string =>
+export type DownloadFormat = 'web' | 'original';
+
+export const downloadImageUrl = (imageId: number, format: DownloadFormat = 'web'): string =>
   `/api/proxy/api/read/content/images/${imageId}/download?format=${format}`;
 
-export const downloadCollectionUrl = (slug: string, format: 'web' = 'web'): string =>
+export const downloadCollectionUrl = (slug: string, format: DownloadFormat = 'web'): string =>
   `/api/proxy/api/read/collections/${encodeURIComponent(slug)}/download?format=${format}`;

--- a/tests/components/ClientGalleryDownload.test.tsx
+++ b/tests/components/ClientGalleryDownload.test.tsx
@@ -1,11 +1,12 @@
 /**
  * Tests for ClientGalleryDownload
  *
- * Verifies that the "Download All" button:
- *  - Sets `window.location.href` to the BFF collection download URL on click.
- *  - Switches the label to "Preparing ZIP…" and disables itself during the
- *    4-second cooldown so users don't double-trigger.
- *  - Returns to the normal label/enabled state after the cooldown elapses.
+ * Verifies the format-picker flow:
+ *  - Click "Download All" → opens a picker with "Web Optimized" / "Full Size" / "Cancel"
+ *  - Picking a format sets `window.location.href` to the BFF download URL with the
+ *    chosen format and disables the buttons while preparing.
+ *  - Cancel and Escape close the picker.
+ *  - After the 4-second cooldown the picker collapses back to "Download All".
  */
 
 import { act, fireEvent, render, screen } from '@testing-library/react';
@@ -46,41 +47,89 @@ describe('ClientGalleryDownload', () => {
     expect(button).not.toBeDisabled();
   });
 
-  it('sets window.location.href to downloadCollectionUrl(slug) on click', () => {
+  it('opens a format picker on click instead of triggering download', () => {
     render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
     fireEvent.click(screen.getByRole('button', { name: /download all/i }));
-    expect(window.location.href).toBe(downloadCollectionUrl('smith-wedding'));
+
+    expect(screen.getByRole('button', { name: /web optimized/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /full size/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    // No navigation yet — user hasn't picked a format.
+    expect(window.location.href).toBe('');
   });
 
-  it('shows "Preparing ZIP…" and disables the button while preparing', () => {
+  it('sets href to the web download URL when "Web Optimized" is picked', () => {
     render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
     fireEvent.click(screen.getByRole('button', { name: /download all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /web optimized/i }));
 
-    const preparingButton = screen.getByRole('button', { name: /preparing zip/i });
-    expect(preparingButton).toBeInTheDocument();
-    expect(preparingButton).toBeDisabled();
-    expect(screen.queryByRole('button', { name: /^download all$/i })).not.toBeInTheDocument();
+    expect(window.location.href).toBe(downloadCollectionUrl('smith-wedding', 'web'));
   });
 
-  it('returns to the normal "Download All" label and re-enables after 4s', () => {
+  it('sets href to the original download URL when "Full Size" is picked', () => {
     render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
     fireEvent.click(screen.getByRole('button', { name: /download all/i }));
-    expect(screen.getByRole('button', { name: /preparing zip/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /full size/i }));
+
+    expect(window.location.href).toBe(downloadCollectionUrl('smith-wedding', 'original'));
+  });
+
+  it('shows "Preparing…" and disables both format buttons while preparing', () => {
+    render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
+    fireEvent.click(screen.getByRole('button', { name: /download all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /web optimized/i }));
+
+    const preparingBtn = screen.getByRole('button', { name: /preparing…/i });
+    expect(preparingBtn).toBeDisabled();
+    // The other format button is also disabled (still rendered with its idle label).
+    expect(screen.getByRole('button', { name: /full size/i })).toBeDisabled();
+    // Cancel is hidden during preparing to prevent mid-download dismissal.
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it('returns to the idle "Download All" state after the 4s cooldown', () => {
+    render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
+    fireEvent.click(screen.getByRole('button', { name: /download all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /web optimized/i }));
 
     act(() => {
       jest.advanceTimersByTime(4000);
     });
 
-    const button = screen.getByRole('button', { name: /^download all$/i });
-    expect(button).toBeInTheDocument();
-    expect(button).not.toBeDisabled();
-    expect(screen.queryByRole('button', { name: /preparing zip/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^download all$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /preparing…/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /web optimized/i })).not.toBeInTheDocument();
+  });
+
+  it('closes the picker when "Cancel" is clicked', () => {
+    render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
+    fireEvent.click(screen.getByRole('button', { name: /download all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.getByRole('button', { name: /^download all$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /web optimized/i })).not.toBeInTheDocument();
+    expect(window.location.href).toBe('');
+  });
+
+  it('closes the picker when Escape is pressed', () => {
+    render(<ClientGalleryDownload collectionSlug="smith-wedding" />);
+    fireEvent.click(screen.getByRole('button', { name: /download all/i }));
+    expect(screen.getByRole('button', { name: /web optimized/i })).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(screen.getByRole('button', { name: /^download all$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /web optimized/i })).not.toBeInTheDocument();
   });
 
   it('URL-encodes the slug in the navigation target', () => {
     render(<ClientGalleryDownload collectionSlug="hello world & more" />);
     fireEvent.click(screen.getByRole('button', { name: /download all/i }));
-    expect(window.location.href).toBe(downloadCollectionUrl('hello world & more'));
+    fireEvent.click(screen.getByRole('button', { name: /web optimized/i }));
+
+    expect(window.location.href).toBe(downloadCollectionUrl('hello world & more', 'web'));
     expect(window.location.href).toBe(
       '/api/proxy/api/read/collections/hello%20world%20%26%20more/download?format=web'
     );

--- a/tests/components/ImageDownloadOverlay.test.tsx
+++ b/tests/components/ImageDownloadOverlay.test.tsx
@@ -1,57 +1,143 @@
 /**
  * Tests for ImageDownloadOverlay
  *
- * Verifies that the per-image download button:
- *  - Sets `window.location.href` to the BFF download URL on click.
- *  - Calls `e.stopPropagation()` so the click does not bubble to a parent
- *    fullscreen-trigger handler (clicking the icon should download, not
- *    open the lightbox).
+ * Verifies the per-image expand-and-pick flow:
+ *  - Click icon → reveals Web/Full picker (stops click bubbling).
+ *  - Picking a format calls `fetch()` with credentials, builds a blob URL,
+ *    and triggers a programmatic `<a download>` click.
+ *  - Failed `original` fetch (404) shows an error message that auto-clears
+ *    after 3s, without throwing.
+ *  - Esc collapses the picker while idle.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import ImageDownloadOverlay from '@/app/components/ClientGalleryDownload/ImageDownloadOverlay';
 import { downloadImageUrl } from '@/app/lib/api/downloads';
 
-// Replace window.location with a writable stub so we can assert on `href`
-// assignments without triggering jsdom navigation.
-const originalLocation = window.location;
-
-beforeAll(() => {
-  delete (window as { location?: Location }).location;
-  (window as unknown as { location: { href: string } }).location = { href: '' };
-});
-
-afterAll(() => {
-  (window as unknown as { location: Location }).location = originalLocation;
-});
-
 describe('ImageDownloadOverlay', () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  const originalFetch = (global as unknown as { fetch?: typeof fetch }).fetch;
+  let createObjectUrlMock: jest.Mock;
+  let revokeObjectUrlMock: jest.Mock;
+
   beforeEach(() => {
-    window.location.href = '';
+    createObjectUrlMock = jest.fn(() => 'blob:fake-url');
+    revokeObjectUrlMock = jest.fn();
+    (URL as unknown as { createObjectURL: jest.Mock }).createObjectURL = createObjectUrlMock;
+    (URL as unknown as { revokeObjectURL: jest.Mock }).revokeObjectURL = revokeObjectUrlMock;
   });
 
-  it('renders a download button with an accessible label', () => {
+  afterEach(() => {
+    (URL as unknown as { createObjectURL: typeof originalCreate }).createObjectURL = originalCreate;
+    (URL as unknown as { revokeObjectURL: typeof originalRevoke }).revokeObjectURL = originalRevoke;
+    if (originalFetch === undefined) {
+      delete (global as unknown as { fetch?: typeof fetch }).fetch;
+    } else {
+      (global as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+    jest.restoreAllMocks();
+  });
+
+  // Stub fetch to return a successful blob response by default.
+  const stubFetchOk = (): jest.Mock => {
+    const blob = new Blob(['fake bytes'], { type: 'image/webp' });
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(blob),
+    } as Response);
+    (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  };
+
+  const stubFetch404 = (): jest.Mock => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      blob: () => Promise.resolve(new Blob()),
+    } as Response);
+    (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  };
+
+  it('renders a download icon with an accessible label in the idle state', () => {
     render(<ImageDownloadOverlay imageId={42} />);
     expect(screen.getByRole('button', { name: /download image/i })).toBeInTheDocument();
   });
 
-  it('sets window.location.href to downloadImageUrl(imageId) on click', () => {
+  it('expands to show Web and Full Size buttons when the icon is clicked', () => {
     render(<ImageDownloadOverlay imageId={42} />);
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
-    expect(window.location.href).toBe(downloadImageUrl(42));
+
+    expect(screen.getByRole('button', { name: /web-optimized/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /full-size/i })).toBeInTheDocument();
   });
 
-  it('uses the correct URL for a different imageId', () => {
+  it('fetches the web URL with credentials when "Web" is picked', async () => {
+    const fetchMock = stubFetchOk();
+    render(<ImageDownloadOverlay imageId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /download image/i }));
+    fireEvent.click(screen.getByRole('button', { name: /web-optimized/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(downloadImageUrl(42, 'web'), {
+      credentials: 'include',
+    });
+    await waitFor(() => expect(createObjectUrlMock).toHaveBeenCalled());
+    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:fake-url');
+  });
+
+  it('fetches the original URL when "Full Size" is picked', async () => {
+    const fetchMock = stubFetchOk();
     render(<ImageDownloadOverlay imageId={9001} />);
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
-    expect(window.location.href).toBe(downloadImageUrl(9001));
-    expect(window.location.href).toBe(
-      '/api/proxy/api/read/content/images/9001/download?format=web'
-    );
+    fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(downloadImageUrl(9001, 'original'), {
+      credentials: 'include',
+    });
   });
 
-  it('calls e.stopPropagation() so the click does not bubble to a fullscreen handler', () => {
+  it('shows an error message when "Full Size" fetch returns 404', async () => {
+    stubFetch404();
+    render(<ImageDownloadOverlay imageId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /download image/i }));
+    fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/original not available/i);
+    // Did not create a blob URL on the failure path.
+    expect(createObjectUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('auto-clears the error after 3 seconds', async () => {
+    jest.useFakeTimers();
+    try {
+      stubFetch404();
+      render(<ImageDownloadOverlay imageId={42} />);
+      fireEvent.click(screen.getByRole('button', { name: /download image/i }));
+      fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
+
+      // Drain the pending fetch + state updates.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('stops icon click from bubbling to a parent fullscreen handler', () => {
     const parentClick = jest.fn();
     render(
       <div onClick={parentClick}>
@@ -60,8 +146,33 @@ describe('ImageDownloadOverlay', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
-
-    expect(window.location.href).toBe(downloadImageUrl(42));
     expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('collapses on Escape', () => {
+    render(<ImageDownloadOverlay imageId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /download image/i }));
+    expect(screen.getByRole('button', { name: /web-optimized/i })).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(screen.queryByRole('button', { name: /web-optimized/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download image/i })).toBeInTheDocument();
+  });
+
+  it('collapses on outside click', () => {
+    render(
+      <div data-testid="outside">
+        <ImageDownloadOverlay imageId={42} />
+      </div>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /download image/i }));
+    expect(screen.getByRole('button', { name: /web-optimized/i })).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole('button', { name: /web-optimized/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- ImageDownloadOverlay: click icon expands to Web/Full buttons; uses fetch + blob URL so 404 surfaces as an aria-live error toast instead of a broken navigation
- ClientGalleryDownload: Download All opens a picker with Web Optimized / Full Size / Cancel; navigates with the chosen format
- Esc closes both pickers; outside-click closes the per-image overlay; decorative SVGs marked aria-hidden; format buttons get aria-labels
- Shared DownloadFormat type exported from app/lib/api/downloads.ts so the literal contract lives in one place
- Existing component tests rewritten for the new picker flow (16 tests, fetch + blob URL mocked, error path covered)