### PR TITLE
feat: PARENT password gating + review fixes + listing polish

### DIFF
--- a/app/(admin)/admin/AdminHubGrid.module.scss
+++ b/app/(admin)/admin/AdminHubGrid.module.scss
@@ -33,7 +33,15 @@
 
   &:hover {
     opacity: 0.92;
+
+    .overlay {
+      filter: brightness(0.7);
+    }
   }
+}
+
+.overlay {
+  transition: filter 0.15s;
 }
 
 .imageWrapper {
@@ -58,12 +66,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgb(0 0 0 / 35%);
-  transition: background 0.15s;
-
-  .tile:hover & {
-    background: rgb(0 0 0 / 45%);
-  }
+  background: var(--color-text-overlay-bg);
 }
 
 .title {

--- a/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
+++ b/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
@@ -1121,6 +1121,7 @@ export default function ManageClient({ slug }: ManageClientProps) {
                               <option value={CollectionType.ART_GALLERY}>Art Gallery</option>
                               <option value={CollectionType.BLOG}>Blog</option>
                               <option value={CollectionType.CLIENT_GALLERY}>Client Gallery</option>
+                              <option value={CollectionType.PARENT}>Parent</option>
                             </select>
                           </div>
                         </div>
@@ -1334,8 +1335,9 @@ export default function ManageClient({ slug }: ManageClientProps) {
                           />
                         </div>
 
-                        {/* Gallery Access — only meaningful for CLIENT_GALLERY */}
-                        {updateData.type === CollectionType.CLIENT_GALLERY && (
+                        {/* Gallery Access — meaningful for CLIENT_GALLERY and PARENT */}
+                        {(updateData.type === CollectionType.CLIENT_GALLERY ||
+                          updateData.type === CollectionType.PARENT) && (
                           <section
                             aria-labelledby="gallery-access-heading"
                             className={styles.formGroup}

--- a/app/all-client-galleries/page.tsx
+++ b/app/all-client-galleries/page.tsx
@@ -1,0 +1,12 @@
+import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Client Galleries',
+  robots: { index: false, follow: false },
+};
+
+export default async function AllClientGalleriesPage() {
+  return <CollectionPageWrapper slug="all-client-galleries" />;
+}

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -254,7 +254,7 @@ export function MenuDropdown({
               className={styles.dropdownMenuButton}
               onClick={handleNavigation.manage}
             >
-              <span className={styles.dropdownMenuOptions}>Manage</span>
+              <span className={styles.dropdownMenuOptions}>Create</span>
             </button>
           </div>
         )}

--- a/app/lib/components/CollectionPageWrapper.tsx
+++ b/app/lib/components/CollectionPageWrapper.tsx
@@ -29,18 +29,21 @@ export default async function CollectionPageWrapper({ slug }: CollectionPageWrap
 
     const chunkSize = collection.rowsWide ?? LAYOUT.defaultChunkSize;
 
-    if (collection.type === CollectionType.CLIENT_GALLERY) {
-      // Auth signal: backend (CollectionControllerProd.getCollectionBySlug) sets
-      // `content` to null when the per-slug cookie is missing or invalid, and
-      // returns an array (possibly empty) once the cookie validates. So
-      // `Array.isArray(content)` distinguishes authenticated from locked, and
-      // is the only authoritative signal — `isPasswordProtected` stays true
-      // even after the cookie validates (it describes the gallery, not the
-      // viewer's session).
-      //
-      // Routing here, rather than wrapping <CollectionPage> as gate children,
-      // means we never serialize the page's RSC payload (cover image, grid)
-      // for a locked viewer (FE-H6 invariant, structurally enforced).
+    // Gate any password-protected gallery — CLIENT_GALLERY directly, and PARENT collections
+    // that have a password (typically set with propagate=true to share with their CLIENT_GALLERY
+    // children). Auth signal: backend (CollectionControllerProd.getCollectionBySlug) sets
+    // `content` to null when neither the per-slug nor the shared password-fingerprint cookie
+    // validates, and returns an array (possibly empty) once a cookie validates. So
+    // `Array.isArray(content)` is the authoritative authenticated signal — `isPasswordProtected`
+    // describes the gallery, not the viewer's session.
+    //
+    // Routing here, rather than wrapping <CollectionPage> as gate children, means we never
+    // serialize the page's RSC payload (cover image, grid) for a locked viewer (FE-H6 invariant,
+    // structurally enforced).
+    const isGateableType =
+      collection.type === CollectionType.CLIENT_GALLERY ||
+      collection.type === CollectionType.PARENT;
+    if (isGateableType) {
       const isAuthenticated = Array.isArray(collection.content);
       if (!collection.isPasswordProtected || isAuthenticated) {
         return <CollectionPage collection={collection} chunkSize={chunkSize} />;

--- a/tests/all-client-galleries/page.test.tsx
+++ b/tests/all-client-galleries/page.test.tsx
@@ -1,0 +1,19 @@
+import AllClientGalleriesPage, { metadata } from '@/app/all-client-galleries/page';
+import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
+
+jest.mock('@/app/lib/components/CollectionPageWrapper', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+describe('AllClientGalleriesPage', () => {
+  it('renders <CollectionPageWrapper> with slug="all-client-galleries"', async () => {
+    const element = await AllClientGalleriesPage();
+    expect(element.type).toBe(CollectionPageWrapper);
+    expect(element.props.slug).toBe('all-client-galleries');
+  });
+
+  it('opts out of search-engine indexing — gallery titles can leak client names', () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/tests/lib/components/CollectionPageWrapper.test.tsx
+++ b/tests/lib/components/CollectionPageWrapper.test.tsx
@@ -133,6 +133,49 @@ describe('CollectionPageWrapper — CLIENT_GALLERY routing', () => {
     expect(element.type).toBe(CollectionPage);
   });
 
+  it('routes a locked PARENT (password-protected, content === undefined) to <ClientGalleryGate>', async () => {
+    mockGetCollectionBySlug.mockResolvedValue(
+      makeCollection({
+        type: CollectionType.PARENT,
+        isPasswordProtected: true,
+        content: undefined,
+      })
+    );
+
+    const element = await CollectionPageWrapper({ slug: 'edens-family' });
+
+    expect(element.type).toBe(ClientGalleryGate);
+    expect(element.props.collection.type).toBe(CollectionType.PARENT);
+  });
+
+  it('routes an authenticated PARENT (content is an array) to <CollectionPage>', async () => {
+    mockGetCollectionBySlug.mockResolvedValue(
+      makeCollection({
+        type: CollectionType.PARENT,
+        isPasswordProtected: true,
+        content: [],
+      })
+    );
+
+    const element = await CollectionPageWrapper({ slug: 'edens-family' });
+
+    expect(element.type).toBe(CollectionPage);
+  });
+
+  it('routes a non-protected PARENT directly to <CollectionPage>', async () => {
+    mockGetCollectionBySlug.mockResolvedValue(
+      makeCollection({
+        type: CollectionType.PARENT,
+        isPasswordProtected: false,
+        content: undefined,
+      })
+    );
+
+    const element = await CollectionPageWrapper({ slug: 'edens-family' });
+
+    expect(element.type).toBe(CollectionPage);
+  });
+
   it('calls notFound() when the slug is empty', async () => {
     await expect(CollectionPageWrapper({ slug: '' })).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFoundMock).toHaveBeenCalled();


### PR DESCRIPTION
PARENT password gating
- ManageClient: PARENT in type dropdown; show Gallery Access section for PARENT (lets admins set a password that propagates to children)
- CollectionPageWrapper: route password-protected PARENT through the same auth-signal check as CLIENT_GALLERY (Array.isArray(content) is the authenticated tell). 4 routing cases covered by tests
- MenuDropdown: rename "Manage" → "Create" (matches the destination — collection/manage handles both create and edit)

Review fixes
- /all-client-galleries: opt out of search-engine indexing (robots: index/follow false). Gallery contents stay password-gated; the listing itself shouldn't expose client names
- AdminHubGrid hover: restore tile-overlay darkening (filter: brightness(0.7) + transition); pure-opacity hover lost the affordance after var(--color-text-overlay-bg) refactor
- New synthetic /all-client-galleries page wraps CollectionPageWrapper