### PR TITLE
feat(collection): info+filter bar with single-value chips; hide home …

### DIFF
--- a/app/(admin)/all-collections/page.tsx
+++ b/app/(admin)/all-collections/page.tsx
@@ -3,5 +3,6 @@ import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
 export const dynamic = 'force-dynamic';
 
 export default async function AllCollectionsPage() {
-  return <CollectionPageWrapper slug="all-collections" />;
+  // `home` is a standalone page, not browsable in a list — exclude it from the synthetic PARENT.
+  return <CollectionPageWrapper slug="all-collections" excludeContentSlugs={['home']} />;
 }

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -561,6 +561,28 @@
   background-color: rgb(0 0 0 / 6%);
 }
 
+/* ── Info chip — non-clickable labeled fact ── */
+.filterBarInfo {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--color-black);
+  letter-spacing: 0.02em;
+  font-family: inherit;
+  white-space: nowrap;
+  opacity: 0.75;
+  cursor: default;
+}
+
+.filterBarInfoLabel {
+  opacity: 0.55;
+  font-weight: 400;
+}
+
 .filterBarChevron {
   font-size: 0.55rem;
   line-height: 1;

--- a/app/components/ContentCollection/CollectionFilterBar.tsx
+++ b/app/components/ContentCollection/CollectionFilterBar.tsx
@@ -10,7 +10,7 @@ import {
 
 import cbStyles from '../Content/ContentComponent.module.scss';
 import {
-  type CollectionFilterOptions,
+  type CollectionInfoOptions,
   type FilteredAvailableOptions,
 } from './CollectionFilterContext';
 
@@ -19,12 +19,22 @@ type ArrayFilterKey =
   | 'selectedPeople'
   | 'selectedCameras'
   | 'selectedLenses'
-  | 'selectedLensTypes';
+  | 'selectedLensTypes'
+  | 'selectedLocations';
 
 const LENS_TYPE_LABELS: Record<string, string> = {
   wide: 'Wide',
   normal: 'Normal',
   telephoto: 'Telephoto',
+};
+
+// Location intentionally omitted: the collection page already surfaces a single
+// location at the top of the collection, so a redundant "Location: X" chip would
+// duplicate it. Multi-value locations still appear as a filter dropdown below.
+const INFO_DIMENSIONS = ['cameras', 'lenses'] as const;
+const INFO_LABELS: Record<(typeof INFO_DIMENSIONS)[number], string> = {
+  cameras: 'Camera',
+  lenses: 'Lens',
 };
 
 export function toggleArrayFilter(
@@ -60,7 +70,7 @@ function FilterDropdown({ label, isActive, isOpen, onToggle, children }: FilterD
       >
         {label}
         <span className={cbStyles.filterBarChevron} aria-hidden="true">
-          {isOpen ? '\u25B4' : '\u25BE'}
+          {isOpen ? '▴' : '▾'}
         </span>
       </button>
       {isOpen && <div className={cbStyles.filterBarPanel}>{children}</div>}
@@ -72,7 +82,7 @@ function FilterDropdown({ label, isActive, isOpen, onToggle, children }: FilterD
 
 interface CollectionFilterBarProps {
   filterState: CollectionFilterState;
-  filterOptions: CollectionFilterOptions;
+  filterOptions: CollectionInfoOptions;
   filteredAvailable: FilteredAvailableOptions;
   onFilterChange: (update: Partial<CollectionFilterState>) => void;
 }
@@ -94,12 +104,13 @@ export default function CollectionFilterBar({
   // ── Availability check (3-state logic) ──
   const isAvailable = (key: ArrayFilterKey, value: string): boolean => {
     if (!filteredAvailable) return true;
-    const map: Record<ArrayFilterKey, string[]> = {
+    const map: Record<ArrayFilterKey, readonly string[]> = {
       selectedPeople: filteredAvailable.people,
       selectedCameras: filteredAvailable.cameras,
       selectedLenses: filteredAvailable.lenses,
       selectedLensTypes: filteredAvailable.lensTypes,
       selectedTags: filteredAvailable.tags,
+      selectedLocations: filteredAvailable.locations,
     };
     return map[key].includes(value);
   };
@@ -132,8 +143,8 @@ export default function CollectionFilterBar({
 
   // ── Date toggle ──
   const dateSortLabels: Record<CollectionFilterState['dateSortDirection'], string> = {
-    asc: 'Date \u2191',
-    desc: 'Date \u2193',
+    asc: 'Date ↑',
+    desc: 'Date ↓',
     off: 'Date',
   };
 
@@ -145,14 +156,16 @@ export default function CollectionFilterBar({
     onFilterChange({ dateSortDirection: next[filterState.dateSortDirection] });
   };
 
-  // ── Which dropdowns exist ──
-  const hasPeople = filterOptions.people.length > 0;
-  const hasTags = filterOptions.tags.length > 0;
-  const hasCameras = filterOptions.cameras.length > 0;
-  // Lens dropdown shown if we have lens names OR lens types
-  const hasLensNames = filterOptions.lenses.length > 0;
-  const hasLensTypes = filterOptions.lensTypes.length > 0;
+  // ── Which dropdowns exist (filterable + non-empty) ──
+  const hasPeople = filterOptions.people.filterable && filterOptions.people.values.length > 0;
+  const hasTags = filterOptions.tags.filterable && filterOptions.tags.values.length > 0;
+  const hasCameras = filterOptions.cameras.filterable && filterOptions.cameras.values.length > 0;
+  const hasLensNames = filterOptions.lenses.filterable && filterOptions.lenses.values.length > 0;
+  const hasLensTypes =
+    filterOptions.lensTypes.filterable && filterOptions.lensTypes.values.length > 0;
   const hasLens = hasLensNames || hasLensTypes;
+  const hasLocations =
+    filterOptions.locations.filterable && filterOptions.locations.values.length > 0;
 
   // Active state per dropdown (has any selection)
   const isPeopleActive = filterState.selectedPeople.length > 0;
@@ -160,6 +173,7 @@ export default function CollectionFilterBar({
   const isCamerasActive = filterState.selectedCameras.length > 0;
   const isLensActive =
     filterState.selectedLenses.length > 0 || filterState.selectedLensTypes.length > 0;
+  const isLocationsActive = filterState.selectedLocations.length > 0;
 
   const hasActiveFilters =
     filterState.dateSortDirection !== 'off' ||
@@ -167,7 +181,8 @@ export default function CollectionFilterBar({
     isPeopleActive ||
     isTagsActive ||
     isCamerasActive ||
-    isLensActive;
+    isLensActive ||
+    isLocationsActive;
 
   const resetAll = () => {
     onFilterChange({ ...INITIAL_COLLECTION_FILTER_STATE });
@@ -196,6 +211,18 @@ export default function CollectionFilterBar({
         </button>
       )}
 
+      {/* Info chips — non-clickable labeled facts about the collection */}
+      {INFO_DIMENSIONS.map(key => {
+        const dim = filterOptions[key];
+        if (dim.filterable || dim.values.length === 0) return null;
+        return (
+          <span key={`info-${key}`} className={cbStyles.filterBarInfo}>
+            <span className={cbStyles.filterBarInfoLabel}>{INFO_LABELS[key]}:</span>
+            {dim.values[0]}
+          </span>
+        );
+      })}
+
       {/* People dropdown */}
       {hasPeople && (
         <FilterDropdown
@@ -204,7 +231,7 @@ export default function CollectionFilterBar({
           isOpen={openDropdown === 'people'}
           onToggle={() => toggle('people')}
         >
-          {filterOptions.people.map(p =>
+          {filterOptions.people.values.map(p =>
             renderChip('selectedPeople', p, filterState.selectedPeople)
           )}
         </FilterDropdown>
@@ -218,7 +245,9 @@ export default function CollectionFilterBar({
           isOpen={openDropdown === 'tags'}
           onToggle={() => toggle('tags')}
         >
-          {filterOptions.tags.map(t => renderChip('selectedTags', t, filterState.selectedTags))}
+          {filterOptions.tags.values.map(t =>
+            renderChip('selectedTags', t, filterState.selectedTags)
+          )}
         </FilterDropdown>
       )}
 
@@ -230,7 +259,7 @@ export default function CollectionFilterBar({
           isOpen={openDropdown === 'cameras'}
           onToggle={() => toggle('cameras')}
         >
-          {filterOptions.cameras.map(c =>
+          {filterOptions.cameras.values.map(c =>
             renderChip('selectedCameras', c, filterState.selectedCameras)
           )}
         </FilterDropdown>
@@ -245,7 +274,7 @@ export default function CollectionFilterBar({
           onToggle={() => toggle('lens')}
         >
           {hasLensTypes &&
-            filterOptions.lensTypes.map(lt =>
+            filterOptions.lensTypes.values.map(lt =>
               renderChip(
                 'selectedLensTypes',
                 lt,
@@ -255,9 +284,23 @@ export default function CollectionFilterBar({
             )}
           {hasLensTypes && hasLensNames && <div className={cbStyles.filterBarPanelDivider} />}
           {hasLensNames &&
-            filterOptions.lenses.map(l =>
+            filterOptions.lenses.values.map(l =>
               renderChip('selectedLenses', l, filterState.selectedLenses)
             )}
+        </FilterDropdown>
+      )}
+
+      {/* Locations dropdown */}
+      {hasLocations && (
+        <FilterDropdown
+          label="Location"
+          isActive={isLocationsActive}
+          isOpen={openDropdown === 'locations'}
+          onToggle={() => toggle('locations')}
+        >
+          {filterOptions.locations.values.map(l =>
+            renderChip('selectedLocations', l, filterState.selectedLocations)
+          )}
         </FilterDropdown>
       )}
 

--- a/app/components/ContentCollection/CollectionFilterContext.tsx
+++ b/app/components/ContentCollection/CollectionFilterContext.tsx
@@ -4,27 +4,38 @@ import { createContext, useContext } from 'react';
 
 import { type CollectionFilterState, type LensType } from '@/app/types/GalleryFilter';
 
-export interface CollectionFilterOptions {
-  tags: string[];
-  people: string[];
-  cameras: string[];
-  lenses: string[];
-  lensTypes: LensType[];
+/**
+ * Per-dimension data used by the collection filter bar.
+ * `filterable` drives rendering: true -> filter dropdown, false -> inline info chip.
+ */
+export interface DimensionData<T = string> {
+  values: readonly T[];
+  filterable: boolean;
+}
+
+export interface CollectionInfoOptions {
+  tags: DimensionData;
+  people: DimensionData;
+  cameras: DimensionData;
+  lenses: DimensionData;
+  locations: DimensionData;
+  lensTypes: DimensionData<LensType>;
   showHighlyRated: boolean;
 }
 
 /** Subset of options available after current filters are applied (for grey-out logic). null = no active filters. */
 export type FilteredAvailableOptions = {
-  tags: string[];
-  people: string[];
-  cameras: string[];
-  lenses: string[];
-  lensTypes: LensType[];
+  tags: readonly string[];
+  people: readonly string[];
+  cameras: readonly string[];
+  lenses: readonly string[];
+  lensTypes: readonly LensType[];
+  locations: readonly string[];
 } | null;
 
 interface CollectionFilterContextValue {
   filterState: CollectionFilterState;
-  filterOptions: CollectionFilterOptions;
+  filterOptions: CollectionInfoOptions;
   filteredAvailable: FilteredAvailableOptions;
   onFilterChange: (update: Partial<CollectionFilterState>) => void;
 }

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -16,7 +16,9 @@ import { isContentCollection } from '@/app/utils/contentTypeGuards';
 import { getLensType } from '@/app/utils/focalLength';
 import { sortByDate } from '@/app/utils/sortByDate';
 
-import { CollectionFilterProvider } from './CollectionFilterContext';
+import { CollectionFilterProvider, type CollectionInfoOptions } from './CollectionFilterContext';
+
+type CollectionDimensions = Omit<CollectionInfoOptions, 'showHighlyRated'>;
 
 interface CollectionPageClientProps {
   collection: CollectionModel;
@@ -25,28 +27,21 @@ interface CollectionPageClientProps {
 
 /**
  * Extracts filter options specific to collection pages.
- * Uses the shared extractFilterOptions with 90% tag exclusion, plus
- * the >1 distinct rule for cameras/lenses and lens type categories.
+ *
+ * Returns per-dimension data with a `filterable` flag. When a dimension has
+ * exactly one value and the dimension's policy allows info-mode (cameras /
+ * lenses / locations), filterable is set to false so the bar renders it as
+ * an inline info chip instead of a dropdown.
  */
 function extractCollectionFilterOptions(
   images: ContentImageModel[],
   collectionRefs: ContentCollectionModel[] = []
-): {
-  tags: string[];
-  people: string[];
-  cameras: string[];
-  lenses: string[];
-  lensTypes: LensType[];
-} {
+): CollectionDimensions {
   // Pass images + refs together so extractFilterOptions can aggregate filter
   // dimensions from collection refs too. This is what populates the filter bar
   // on synthetic PARENT pages whose `content` is 100% collection refs and 0
   // images (e.g. /all-collections, /all-blog).
   const baseOptions = extractFilterOptions([...images, ...collectionRefs], 0.9);
-
-  // Cameras/lenses: only show if more than 1 distinct
-  const cameras = baseOptions.cameras.length > 1 ? baseOptions.cameras : [];
-  const lenses = baseOptions.lenses.length > 1 ? baseOptions.lenses : [];
 
   // Lens types: only show if 2+ distinct categories present (image-only signal)
   const lensTypeSet = new Set<LensType>();
@@ -57,8 +52,18 @@ function extractCollectionFilterOptions(
   const typeOrder: LensType[] = ['wide', 'normal', 'telephoto'];
   const lensTypes = lensTypeSet.size >= 2 ? typeOrder.filter(t => lensTypeSet.has(t)) : [];
 
-  return { tags: baseOptions.tags, people: baseOptions.people, cameras, lenses, lensTypes };
+  return {
+    tags: { values: baseOptions.tags, filterable: true },
+    people: { values: baseOptions.people, filterable: true },
+    cameras: { values: baseOptions.cameras, filterable: baseOptions.cameras.length >= 2 },
+    lenses: { values: baseOptions.lenses, filterable: baseOptions.lenses.length >= 2 },
+    locations: { values: baseOptions.locations, filterable: baseOptions.locations.length >= 2 },
+    lensTypes: { values: lensTypes, filterable: true },
+  };
 }
+
+const EMPTY_STRING_DIM = { values: [] as readonly string[], filterable: true };
+const EMPTY_LENSTYPE_DIM = { values: [] as readonly LensType[], filterable: true };
 
 export default function CollectionPageClient({ collection, chunkSize }: CollectionPageClientProps) {
   const [filterState, setFilterState] = useState<CollectionFilterState>(
@@ -76,19 +81,18 @@ export default function CollectionPageClient({ collection, chunkSize }: Collecti
   // are suppressed since the page's purpose is browsing sub-collections, not filtering images.
   const isCollectionDominant = allCollections.length > allImages.length;
 
-  const baseCollectionOptions = useMemo(() => {
-    // On collection-dominant pages we still want tags/people aggregated from
-    // collection refs, so we always pass refs through. The post-filter below
-    // suppresses image-only dimensions (cameras/lenses/lensTypes) on those
-    // pages, but keeps tags AND people from collection-ref aggregation.
+  const baseCollectionOptions = useMemo<CollectionDimensions>(() => {
+    // On collection-dominant pages we still want tags/people/locations aggregated
+    // from collection refs, so we always pass refs through. The post-filter below
+    // suppresses image-only dimensions (cameras/lenses/lensTypes) on those pages,
+    // but keeps tags, people, AND locations from collection-ref aggregation.
     const options = extractCollectionFilterOptions(allImages, allCollections);
     if (isCollectionDominant) {
       return {
-        tags: options.tags,
-        people: options.people,
-        cameras: [],
-        lenses: [],
-        lensTypes: [] as LensType[],
+        ...options,
+        cameras: EMPTY_STRING_DIM,
+        lenses: EMPTY_STRING_DIM,
+        lensTypes: EMPTY_LENSTYPE_DIM,
       };
     }
     return options;
@@ -110,6 +114,9 @@ export default function CollectionPageClient({ collection, chunkSize }: Collecti
       ...(filterState.selectedLenses.length > 0
         ? { lenses: filterState.selectedLenses, lensMatchMode: 'AND' as const }
         : {}),
+      ...(filterState.selectedLocations.length > 0
+        ? { locations: filterState.selectedLocations }
+        : {}),
     }),
     [filterState]
   );
@@ -121,7 +128,8 @@ export default function CollectionPageClient({ collection, chunkSize }: Collecti
       filterState.selectedPeople.length > 0 ||
       filterState.selectedCameras.length > 0 ||
       filterState.selectedLenses.length > 0 ||
-      filterState.selectedLensTypes.length > 0,
+      filterState.selectedLensTypes.length > 0 ||
+      filterState.selectedLocations.length > 0,
     [filterState]
   );
 
@@ -161,11 +169,19 @@ export default function CollectionPageClient({ collection, chunkSize }: Collecti
     if (!hasActiveFilters) return null;
     // Collection refs aren't filtered (image-only filters don't touch them),
     // so the full collection-ref list still contributes to "available" tags.
-    return extractCollectionFilterOptions(filteredImages, allCollections);
+    const dims = extractCollectionFilterOptions(filteredImages, allCollections);
+    return {
+      tags: dims.tags.values,
+      people: dims.people.values,
+      cameras: dims.cameras.values,
+      lenses: dims.lenses.values,
+      lensTypes: dims.lensTypes.values,
+      locations: dims.locations.values,
+    };
   }, [hasActiveFilters, filteredImages, allCollections]);
 
   // All base options are always shown; filteredAvailableOptions determines grey-out state
-  const availableOptions = useMemo(
+  const availableOptions = useMemo<CollectionInfoOptions>(
     () => ({
       ...baseCollectionOptions,
       showHighlyRated,
@@ -215,11 +231,15 @@ export default function CollectionPageClient({ collection, chunkSize }: Collecti
   const hasOptions =
     showHighlyRated ||
     hasDateVariance ||
-    baseCollectionOptions.tags.length > 0 ||
-    baseCollectionOptions.people.length > 0 ||
-    baseCollectionOptions.cameras.length > 0 ||
-    baseCollectionOptions.lenses.length > 0 ||
-    baseCollectionOptions.lensTypes.length > 0;
+    baseCollectionOptions.tags.values.length > 0 ||
+    baseCollectionOptions.people.values.length > 0 ||
+    baseCollectionOptions.cameras.values.length > 0 ||
+    baseCollectionOptions.lenses.values.length > 0 ||
+    baseCollectionOptions.lensTypes.values.length > 0 ||
+    // Locations contributes only when multi-value (filterable) — single-value
+    // locations are intentionally not surfaced (see CollectionFilterBar
+    // INFO_DIMENSIONS comment) and so should not trigger the bar on their own.
+    baseCollectionOptions.locations.filterable;
 
   const content = (
     <>

--- a/app/components/LocationPage/LocationPageClient.tsx
+++ b/app/components/LocationPage/LocationPageClient.tsx
@@ -67,6 +67,7 @@ export default function LocationPageClient({ images, collections }: LocationPage
         people: {},
         cameras: {},
         lenses: {},
+        locations: {},
       };
     }
   }, [images, criteria, availableOptions]);

--- a/app/lib/components/CollectionPageWrapper.tsx
+++ b/app/lib/components/CollectionPageWrapper.tsx
@@ -8,6 +8,12 @@ import { CollectionType } from '@/app/types/Collection';
 
 interface CollectionPageWrapperProps {
   slug: string;
+  /**
+   * Slugs of child collection refs to drop from `collection.content` before
+   * rendering. Used by synthetic listing pages (e.g. /all-collections) to hide
+   * collections that exist as standalone pages but shouldn't appear in lists.
+   */
+  excludeContentSlugs?: readonly string[];
 }
 
 /**
@@ -19,13 +25,26 @@ interface CollectionPageWrapperProps {
  * @param slug - Collection slug to fetch and display
  * @returns Server component rendering the collection page
  */
-export default async function CollectionPageWrapper({ slug }: CollectionPageWrapperProps) {
+export default async function CollectionPageWrapper({
+  slug,
+  excludeContentSlugs,
+}: CollectionPageWrapperProps) {
   if (!slug) {
     notFound();
   }
 
   try {
-    const collection = await getCollectionBySlug(slug, 0, 500);
+    const fetched = await getCollectionBySlug(slug, 0, 500);
+
+    const collection =
+      excludeContentSlugs && excludeContentSlugs.length > 0 && Array.isArray(fetched.content)
+        ? {
+            ...fetched,
+            content: fetched.content.filter(
+              item => item.contentType !== 'COLLECTION' || !excludeContentSlugs.includes(item.slug)
+            ),
+          }
+        : fetched;
 
     const chunkSize = collection.rowsWide ?? LAYOUT.defaultChunkSize;
 

--- a/app/types/GalleryFilter.ts
+++ b/app/types/GalleryFilter.ts
@@ -31,6 +31,7 @@ export interface CollectionFilterState {
   readonly selectedPeople: readonly string[];
   readonly selectedCameras: readonly string[];
   readonly selectedLenses: readonly string[];
+  readonly selectedLocations: readonly string[];
   highlyRatedOnly: boolean;
   dateSortDirection: 'asc' | 'desc' | 'off';
   readonly selectedLensTypes: readonly LensType[];
@@ -43,6 +44,7 @@ export const INITIAL_COLLECTION_FILTER_STATE: CollectionFilterState = Object.fre
   selectedPeople: Object.freeze([] as readonly string[]),
   selectedCameras: Object.freeze([] as readonly string[]),
   selectedLenses: Object.freeze([] as readonly string[]),
+  selectedLocations: Object.freeze([] as readonly string[]),
   highlyRatedOnly: false,
   dateSortDirection: 'off' as const,
   selectedLensTypes: Object.freeze([] as readonly LensType[]),

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -371,6 +371,7 @@ export interface FilterCounts {
   people: Record<string, number>;
   cameras: Record<string, number>;
   lenses: Record<string, number>;
+  locations: Record<string, number>;
 }
 
 /**
@@ -401,6 +402,7 @@ export function computeFilterCounts(
   const { people: _people, peopleMatchMode: _pm, ...withoutPeople } = criteria;
   const { cameras: _cameras, cameraMatchMode: _cm, ...withoutCameras } = criteria;
   const { lenses: _lenses, lensMatchMode: _lm, ...withoutLenses } = criteria;
+  const { locations: _locations, ...withoutLocations } = criteria;
 
   const baseWithoutRating = filterContent(content, withoutRating);
   const baseWithoutFilm = filterContent(content, withoutFilm);
@@ -409,6 +411,7 @@ export function computeFilterCounts(
   const baseWithoutPeople = filterContent(content, withoutPeople);
   const baseWithoutCameras = filterContent(content, withoutCameras);
   const baseWithoutLenses = filterContent(content, withoutLenses);
+  const baseWithoutLocations = filterContent(content, withoutLocations);
 
   let highlyRated = 0;
   for (const item of baseWithoutRating) {
@@ -469,7 +472,16 @@ export function computeFilterCounts(
     }
   }
 
-  return { highlyRated, film, digital, collections, tags, people, cameras, lenses };
+  const locations: Record<string, number> = {};
+  for (const loc of availableOptions.locations) locations[loc] = 0;
+  for (const item of baseWithoutLocations) {
+    if (!isImageContent(item)) continue;
+    for (const l of item.locations ?? []) {
+      if (l.name in locations) locations[l.name] = (locations[l.name] ?? 0) + 1;
+    }
+  }
+
+  return { highlyRated, film, digital, collections, tags, people, cameras, lenses, locations };
 }
 
 /**

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -459,7 +459,13 @@ describe('extractFilterOptions', () => {
     const images = Array.from({ length: 12 }, (_, i) =>
       makeImage({
         id: i + 1,
-        tags: [{ id: i + 1, name: `tag-${String(i + 1).padStart(2, '0')}`, slug: `tag-${String(i + 1).padStart(2, '0')}` }],
+        tags: [
+          {
+            id: i + 1,
+            name: `tag-${String(i + 1).padStart(2, '0')}`,
+            slug: `tag-${String(i + 1).padStart(2, '0')}`,
+          },
+        ],
       })
     );
     // Add extra images for first 3 tags to give them higher frequency
@@ -771,7 +777,54 @@ describe('computeFilterCounts', () => {
       expect(counts.tags).toEqual({});
       expect(counts.people).toEqual({});
       expect(counts.collections).toEqual({});
+      expect(counts.locations).toEqual({});
     });
+  });
+});
+
+describe('computeFilterCounts locations', () => {
+  const images = [
+    makeImage({
+      id: 1,
+      rating: 5,
+      isFilm: true,
+      locations: [{ id: 1, name: 'Dolomites', slug: 'dolomites' }],
+    }),
+    makeImage({
+      id: 2,
+      rating: 3,
+      isFilm: true,
+      locations: [{ id: 1, name: 'Dolomites', slug: 'dolomites' }],
+    }),
+    makeImage({
+      id: 3,
+      rating: 4,
+      isFilm: false,
+      locations: [{ id: 2, name: 'Iceland', slug: 'iceland' }],
+    }),
+  ];
+
+  const availableOptions = extractFilterOptions(images);
+
+  it('counts images per location with no other filters active', () => {
+    const counts = computeFilterCounts(images, {}, availableOptions);
+    expect(counts.locations['Dolomites']).toBe(2);
+    expect(counts.locations['Iceland']).toBe(1);
+  });
+
+  it('strips current locations filter when computing per-location counts', () => {
+    // With 'Dolomites' active, the per-location counts should reflect what's
+    // available if the user toggled — so 'Iceland' should still report 1.
+    const counts = computeFilterCounts(images, { locations: ['Dolomites'] }, availableOptions);
+    expect(counts.locations['Iceland']).toBe(1);
+    expect(counts.locations['Dolomites']).toBe(2);
+  });
+
+  it('respects other active filters when computing location counts', () => {
+    // With isFilm: true active, only images 1 and 2 (both Dolomites) remain.
+    const counts = computeFilterCounts(images, { isFilm: true }, availableOptions);
+    expect(counts.locations['Dolomites']).toBe(2);
+    expect(counts.locations['Iceland']).toBe(0);
   });
 });
 


### PR DESCRIPTION
…from /all-collections

Unifies the collection filter bar into a single CollectionInfoOptions type where each dimension carries { values, filterable }. Cameras/lenses with exactly one distinct value across a collection now render as inline labeled info chips (e.g. "Camera: Hasselblad 500cm") instead of being hidden, while multi-value dimensions keep the existing dropdown UX. Locations becomes a real filter dimension on collection pages (multi-value only — single locations are already shown at the top of the collection so the chip would duplicate).

Side: /all-collections now hides the home page via a new optional excludeContentSlugs prop on CollectionPageWrapper. Home is a standalone page, not a tile users browse to in a list.

- New: DimensionData<T>, selectedLocations state, locations counts in computeFilterCounts, .filterBarInfo SCSS classes
- Tests: 3 new computeFilterCounts.locations cases (107/107 pass)