### PR TITLE
feat(content): unify GIF/MP4 as first-class content alongside images

### DIFF
--- a/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
+++ b/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
@@ -32,7 +32,7 @@ import {
   updateCollection,
   updateCollectionRating,
 } from '@/app/lib/api/collections';
-import { createImages, createTextContent, updateImages } from '@/app/lib/api/content';
+import { createGif, createImages, createTextContent, updateImages } from '@/app/lib/api/content';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import {
   type CollectionCreateRequest,
@@ -50,13 +50,19 @@ import {
   CollectionVisibility,
 } from '@/app/types/CollectionVisibility';
 import {
+  type ContentGifModel,
   type ContentImageModel,
   type ContentImageUpdateRequest,
   type ContentImageUpdateResponse,
 } from '@/app/types/Content';
 import { handleApiError } from '@/app/utils/apiUtils';
 import { processContentBlocks } from '@/app/utils/contentLayout';
-import { isContentCollection, isContentImage, isParentType } from '@/app/utils/contentTypeGuards';
+import {
+  isContentCollection,
+  isContentImage,
+  isGifContent,
+  isParentType,
+} from '@/app/utils/contentTypeGuards';
 import { convertLocationsToModels, createLocationsUpdate } from '@/app/utils/locationUtils';
 
 import styles from './ManageClient.module.scss';
@@ -75,6 +81,13 @@ import { useImageClickHandler } from './useImageClickHandler';
 
 interface ManageClientProps {
   slug?: string; // Collection slug for UPDATE mode, undefined for CREATE mode
+}
+
+const ANIMATED_MEDIA_MIME_TYPES = new Set(['image/gif', 'video/mp4', 'video/quicktime']);
+const ANIMATED_MEDIA_EXTENSION_REGEX = /\.(gif|mp4|mov)$/i;
+
+function isAnimatedMediaFile(file: File): boolean {
+  return ANIMATED_MEDIA_MIME_TYPES.has(file.type) || ANIMATED_MEDIA_EXTENSION_REGEX.test(file.name);
 }
 
 export default function ManageClient({ slug }: ManageClientProps) {
@@ -111,7 +124,7 @@ export default function ManageClient({ slug }: ManageClientProps) {
   });
 
   const {
-    editingImage,
+    editingContent,
     scrollPosition,
     openEditor,
     closeEditor: baseCloseEditor,
@@ -128,10 +141,10 @@ export default function ManageClient({ slug }: ManageClientProps) {
   }, [isMultiSelectMode, baseCloseEditor]);
 
   useEffect(() => {
-    if (!editingImage && !isMultiSelectMode) {
+    if (!editingContent && !isMultiSelectMode) {
       setSelectedImageIds([]);
     }
-  }, [editingImage, isMultiSelectMode]);
+  }, [editingContent, isMultiSelectMode]);
 
   const isCreateMode = !slug;
   const collection = currentState?.collection ?? null;
@@ -307,12 +320,26 @@ export default function ManageClient({ slug }: ManageClientProps) {
     }, []),
   });
 
-  const imagesToEdit = useMemo(
+  /**
+   * Content blocks the metadata modal should edit. Mixes images and GIFs so the unified modal can
+   * dispatch to the right backend endpoint based on the previewed type. Bulk-edit semantics still
+   * key off the IMAGE subset — the modal greys out IMAGE-only fields when the previewed block is
+   * a GIF.
+   */
+  const contentToEdit = useMemo(
     () =>
       (collection?.content?.filter(
-        contentItem => isContentImage(contentItem) && selectedImageIds.includes(contentItem.id)
-      ) as ContentImageModel[]) || [],
+        contentItem =>
+          (isContentImage(contentItem) || isGifContent(contentItem)) &&
+          selectedImageIds.includes(contentItem.id)
+      ) as (ContentImageModel | ContentGifModel)[]) || [],
     [selectedImageIds, collection?.content]
+  );
+
+  /** Back-compat alias for the IMAGE-only subset, used where the older flow still expects it. */
+  const imagesToEdit = useMemo(
+    () => contentToEdit.filter(c => isContentImage(c)) as ContentImageModel[],
+    [contentToEdit]
   );
 
   const isParent = isParentType(updateData.type);
@@ -504,12 +531,11 @@ export default function ManageClient({ slug }: ManageClientProps) {
       // gallery in one shot. Confirm with the user (default Yes) before flipping
       // the propagate flag — clearing a password never propagates.
       const isParent = collection.type === CollectionType.PARENT;
-      const propagateToChildren =
-        isParent
-          ? window.confirm(
-              'Share this password with all child client galleries? They will use the same password and one unlock will cover all of them.'
-            )
-          : false;
+      const propagateToChildren = isParent
+        ? window.confirm(
+            'Share this password with all child client galleries? They will use the same password and one unlock will cover all of them.'
+          )
+        : false;
       const result = await saveGalleryAccess(collection.id, {
         password: galleryPassword,
         emails,
@@ -554,9 +580,15 @@ export default function ManageClient({ slug }: ManageClientProps) {
   }, [collection]);
 
   /**
-   * Handle image upload
+   * Handle media upload. Partitions the selected files by type:
+   *   - gif/mp4/mov → POST /content/{id}/gifs (one request per file)
+   *   - everything else → POST /content/images/{id} (single multipart batch)
+   *
+   * The two pipelines exist because the backend stores animated media as a
+   * GIF entity with an ffmpeg-extracted poster frame, while still images
+   * run through the EXIF + dedupe pipeline.
    */
-  const handleImageUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+  const handleMediaUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     if (!collection || !event.target.files || event.target.files.length === 0) return;
 
     try {
@@ -564,16 +596,27 @@ export default function ManageClient({ slug }: ManageClientProps) {
       setError(null);
 
       const files = Array.from(event.target.files);
-
-      const formData = new FormData();
-      for (const file of files) {
-        formData.append('files', file); // Backend expects 'files' field
-      }
+      const animatedFiles = files.filter(isAnimatedMediaFile);
+      const imageFiles = files.filter(f => !isAnimatedMediaFile(f));
+      const gifFailures: string[] = [];
 
       const response = await refreshCollectionAfterOperation(
         collection.slug,
         async () => {
-          await createImages(collection.id, formData);
+          if (imageFiles.length > 0) {
+            const formData = new FormData();
+            for (const file of imageFiles) {
+              formData.append('files', file); // Backend expects 'files' field
+            }
+            await createImages(collection.id, formData);
+          }
+          for (const file of animatedFiles) {
+            try {
+              await createGif(collection.id, file);
+            } catch (gifError) {
+              gifFailures.push(`${file.name}: ${handleApiError(gifError, 'upload failed')}`);
+            }
+          }
         },
         getCollectionUpdateMetadata,
         collectionStorage
@@ -584,9 +627,13 @@ export default function ManageClient({ slug }: ManageClientProps) {
         collection: response.collection,
       }));
 
+      if (gifFailures.length > 0) {
+        setError(`Some files failed to upload:\n${gifFailures.join('\n')}`);
+      }
+
       event.target.value = '';
     } catch (error) {
-      setError(handleApiError(error, 'Failed to upload images'));
+      setError(handleApiError(error, 'Failed to upload media'));
     } finally {
       setOperationLoading(false);
     }
@@ -612,6 +659,18 @@ export default function ManageClient({ slug }: ManageClientProps) {
     const firstImage = selectedImages[0];
     if (firstImage) {
       openEditor(firstImage);
+      return;
+    }
+
+    // No images in the selection — fall back to editing the first selected GIF/MP4.
+    // The GIF modal is single-content for now; a future phase will add a real bulk flow.
+    const selectedGif = collection.content.find(
+      (block): block is ContentGifModel =>
+        isGifContent(block) && selectedImageIds.includes(block.id)
+    );
+    const firstGif = selectedGif;
+    if (firstGif) {
+      openEditor(firstGif);
     }
   }, [selectedImageIds, collection, openEditor]);
 
@@ -671,6 +730,31 @@ export default function ManageClient({ slug }: ManageClientProps) {
         setIsMultiSelectMode(false);
       } catch (error) {
         setError(handleApiError(error, 'An error occurred. Try reloading the page.'));
+      }
+    },
+    [currentState]
+  );
+
+  /**
+   * Handle successful GIF metadata save — refreshes the collection so the new rating
+   * flows into getSlotWidth and the row layout reflows.
+   */
+  const handleGifSaveSuccess = useCallback(
+    async (updated: ContentGifModel) => {
+      if (!currentState?.collection.slug) return;
+      try {
+        const slug = currentState.collection.slug;
+        const fullResponse = await getCollectionUpdateMetadata(slug);
+        if (fullResponse !== null) {
+          setCurrentState(fullResponse);
+          collectionStorage.update(slug, fullResponse.collection);
+          collectionStorage.updateFull(slug, fullResponse);
+          await revalidateCollectionCache(slug);
+        }
+        setSelectedImageIds([]);
+        setIsMultiSelectMode(false);
+      } catch (error) {
+        setError(handleApiError(error, `Failed to refresh after GIF ${updated.id} update`));
       }
     },
     [currentState]
@@ -1060,9 +1144,7 @@ export default function ManageClient({ slug }: ManageClientProps) {
                                 name="visibility"
                                 value={v}
                                 checked={updateData.visibility === v}
-                                onChange={() =>
-                                  setUpdateData(prev => ({ ...prev, visibility: v }))
-                                }
+                                onChange={() => setUpdateData(prev => ({ ...prev, visibility: v }))}
                               />
                               <span className={styles.visibilityRadioName}>
                                 {COLLECTION_VISIBILITY_LABELS[v]}
@@ -1487,16 +1569,16 @@ export default function ManageClient({ slug }: ManageClientProps) {
                             </div>
                           )}
 
-                          {/* Upload Images + Add Text Block — non-parent only */}
+                          {/* Upload Media + Add Text Block — non-parent only */}
                           {!isParent && (
                             <div className={styles.mediaSection}>
                               <div className={styles.uploadSection}>
-                                <label className={styles.formLabel}>Upload Images</label>
+                                <label className={styles.formLabel}>Upload Media</label>
                                 <input
                                   type="file"
                                   multiple
-                                  accept="image/*"
-                                  onChange={handleImageUpload}
+                                  accept="image/*,video/mp4,video/quicktime,.gif,.mp4,.mov"
+                                  onChange={handleMediaUpload}
                                   disabled={isLoading}
                                   className={styles.uploadInput}
                                 />
@@ -1543,38 +1625,45 @@ export default function ManageClient({ slug }: ManageClientProps) {
                         />
 
                         {/* Home: rate child collections inline. Click is immediate (no save button). */}
-                        {slug === 'home' && (collection.content?.some(isContentCollection) ?? false) && (
-                          <section aria-labelledby="children-rating-heading" className={styles.formGroup}>
-                            <h3 id="children-rating-heading" className={styles.formLabel}>
-                              Children (rating)
-                            </h3>
-                            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-                              {(collection.content ?? [])
-                                .filter(isContentCollection)
-                                .map(child => (
-                                  <li
-                                    key={child.id}
-                                    style={{
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'space-between',
-                                      gap: '8px',
-                                      padding: '6px 0',
-                                    }}
-                                  >
-                                    <span>{child.title ?? child.slug}</span>
-                                    <RatingStars
-                                      initialRating={child.rating ?? null}
-                                      onChange={async next => {
-                                        await updateCollectionRating(child.referencedCollectionId, next);
+                        {slug === 'home' &&
+                          (collection.content?.some(isContentCollection) ?? false) && (
+                            <section
+                              aria-labelledby="children-rating-heading"
+                              className={styles.formGroup}
+                            >
+                              <h3 id="children-rating-heading" className={styles.formLabel}>
+                                Children (rating)
+                              </h3>
+                              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                                {(collection.content ?? [])
+                                  .filter(isContentCollection)
+                                  .map(child => (
+                                    <li
+                                      key={child.id}
+                                      style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                        gap: '8px',
+                                        padding: '6px 0',
                                       }}
-                                      ariaLabel={`Rate ${child.title ?? child.slug}`}
-                                    />
-                                  </li>
-                                ))}
-                            </ul>
-                          </section>
-                        )}
+                                    >
+                                      <span>{child.title ?? child.slug}</span>
+                                      <RatingStars
+                                        initialRating={child.rating ?? null}
+                                        onChange={async next => {
+                                          await updateCollectionRating(
+                                            child.referencedCollectionId,
+                                            next
+                                          );
+                                        }}
+                                        ariaLabel={`Rate ${child.title ?? child.slug}`}
+                                      />
+                                    </li>
+                                  ))}
+                              </ul>
+                            </section>
+                          )}
                       </div>
                     </div>
                   </form>
@@ -1633,13 +1722,17 @@ export default function ManageClient({ slug }: ManageClientProps) {
         </main>
       </div>
 
-      {/* Image Metadata Editor Modal */}
-      {editingImage && imagesToEdit && imagesToEdit.length > 0 && (
+      {/* Unified metadata editor — handles IMAGE and GIF/MP4 content. The modal renders a
+          <video> preview and dispatches save/delete to the GIF endpoints when the previewed
+          block is a GIF; image-only fields are greyed out in that branch. */}
+      {editingContent && contentToEdit.length > 0 && (
         <ImageMetadataModal
           scrollPosition={scrollPosition}
           onClose={closeEditor}
           onSaveSuccess={handleMetadataSaveSuccess}
+          onGifSaveSuccess={handleGifSaveSuccess}
           onDeleteSuccess={handleDeleteSuccess}
+          onRemoveFromCollectionSuccess={handleDeleteSuccess}
           availableTags={currentState?.tags || []}
           availablePeople={currentState?.people || []}
           availableCameras={currentState?.cameras || []}
@@ -1649,7 +1742,7 @@ export default function ManageClient({ slug }: ManageClientProps) {
           availableCollections={allCollections}
           availableLocations={currentState?.locations || []}
           selectedImageIds={selectedImageIds}
-          selectedImages={imagesToEdit}
+          selectedImages={contentToEdit}
           currentCollectionId={collection?.id}
         />
       )}

--- a/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
+++ b/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
@@ -12,10 +12,11 @@ import {
 import {
   type AnyContentModel,
   type ContentCollectionModel,
+  type ContentGifModel,
   type ContentImageModel,
   type ContentImageUpdateResponse,
 } from '@/app/types/Content';
-import { isContentCollection, isContentImage } from '@/app/utils/contentTypeGuards';
+import { isContentCollection, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
 import { isLocalEnvironment } from '@/app/utils/environment';
 
 export const COVER_IMAGE_FLASH_DURATION = 500; // milliseconds
@@ -221,13 +222,12 @@ export function handleSingleImageEdit(
   imageId: number,
   content: AnyContentModel[] | undefined,
   processedContent: AnyContentModel[]
-): ContentImageModel | null {
-  const imageBlock =
-    content?.find(block => block.id === imageId) ||
-    processedContent.find(block => block.id === imageId);
+): ContentImageModel | ContentGifModel | null {
+  const block =
+    content?.find(b => b.id === imageId) || processedContent.find(b => b.id === imageId);
 
-  if (imageBlock && isContentImage(imageBlock)) {
-    return imageBlock;
+  if (block && (isContentImage(block) || isGifContent(block))) {
+    return block;
   }
 
   return null;

--- a/app/(admin)/collection/manage/[[...slug]]/useImageClickHandler.ts
+++ b/app/(admin)/collection/manage/[[...slug]]/useImageClickHandler.ts
@@ -4,7 +4,11 @@ import { useRouter } from 'next/navigation';
 import { type Dispatch, type SetStateAction, useCallback } from 'react';
 
 import { type CollectionModel } from '@/app/types/Collection';
-import { type AnyContentModel, type ContentImageModel } from '@/app/types/Content';
+import {
+  type AnyContentModel,
+  type ContentGifModel,
+  type ContentImageModel,
+} from '@/app/types/Content';
 
 import { handleCollectionNavigation, handleSingleImageEdit } from './manageUtils';
 
@@ -15,7 +19,7 @@ interface UseImageClickHandlerParams {
   handleMultiSelectToggle: (imageId: number) => void;
   collection: CollectionModel | null;
   processedContent: AnyContentModel[];
-  openEditor: (image: ContentImageModel) => void;
+  openEditor: (content: ContentImageModel | ContentGifModel) => void;
   setSelectedImageIds: Dispatch<SetStateAction<number[]>>;
   setIsMultiSelectMode: Dispatch<SetStateAction<boolean>>;
 }

--- a/app/components/Content/BoxRenderer.tsx
+++ b/app/components/Content/BoxRenderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type ReorderMove } from '@/app/(admin)/collection/manage/[[...slug]]/manageUtils';
-import type { ContentImageModel, ContentParallaxImageModel } from '@/app/types/Content';
+import type { ViewableContent } from '@/app/types/Content';
 import { type CollectionContentRendererProps } from '@/app/types/ContentRenderer';
 import { determineContentRendererProps } from '@/app/utils/contentRendererUtils';
 import { logger } from '@/app/utils/logger';
@@ -18,7 +18,7 @@ interface BoxRendererProps {
   /** Pass-through props for child renderers */
   onImageClick?: (imageId: number) => void;
   enableFullScreenView?: boolean;
-  onFullScreenImageClick?: (image: ContentImageModel | ContentParallaxImageModel) => void;
+  onFullScreenImageClick?: (image: ViewableContent) => void;
   selectedImageIds?: number[];
   currentCollectionId?: number;
   isSelectingCoverImage?: boolean;

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -12,7 +12,11 @@ import CollectionFilterBar, {
 } from '@/app/components/ContentCollection/CollectionFilterBar';
 import { useCollectionFilter } from '@/app/components/ContentCollection/CollectionFilterContext';
 import { useParallax } from '@/app/hooks/useParallax';
-import { type ContentImageModel, type ContentParallaxImageModel } from '@/app/types/Content';
+import {
+  type ContentGifModel,
+  type ContentImageModel,
+  type ViewableContent,
+} from '@/app/types/Content';
 import { type CollectionContentRendererProps } from '@/app/types/ContentRenderer';
 import {
   checkImageVisibility,
@@ -106,14 +110,27 @@ export default function CollectionContentRenderer({
       return;
     }
 
-    const fullScreenContent: ContentImageModel | ContentParallaxImageModel = {
-      id: contentId,
-      contentType: contentType === 'GIF' ? 'GIF' : 'IMAGE',
-      imageUrl: imageUrl || '',
-      title: alt,
-      orderIndex: 0,
-      visible: true,
-    } as ContentImageModel;
+    // Synthetic stand-in passed up to ContentBlockWithFullScreen — that wrapper looks the real
+    // block up by id from its source array and forwards full metadata into the modal. We just
+    // need id + contentType to be honest; everything else is best-effort fallback.
+    const fullScreenContent: ViewableContent =
+      contentType === 'GIF'
+        ? ({
+            id: contentId,
+            contentType: 'GIF',
+            gifUrl: imageUrl || '',
+            title: alt,
+            orderIndex: 0,
+            visible: true,
+          } as ContentGifModel)
+        : ({
+            id: contentId,
+            contentType: 'IMAGE',
+            imageUrl: imageUrl || '',
+            title: alt,
+            orderIndex: 0,
+            visible: true,
+          } as ContentImageModel);
 
     const handler = createContentClickHandler(
       contentId,

--- a/app/components/Content/Component.tsx
+++ b/app/components/Content/Component.tsx
@@ -6,11 +6,7 @@ import { type ReorderMove } from '@/app/(admin)/collection/manage/[[...slug]]/ma
 import { LAYOUT } from '@/app/constants';
 import { useViewport } from '@/app/hooks/useViewport';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
-import {
-  type AnyContentModel,
-  type ContentImageModel,
-  type ContentParallaxImageModel,
-} from '@/app/types/Content';
+import { type AnyContentModel, type ViewableContent } from '@/app/types/Content';
 import {
   type CalculatedContentSize,
   isContentVisibleInCollection,
@@ -76,8 +72,8 @@ export interface ContentComponentProps {
   priorityIndex?: number;
   /** Enable full-screen image viewing on click */
   enableFullScreenView?: boolean;
-  /** Accepts any image type (normalized in renderer) */
-  onFullScreenImageClick?: (image: ContentImageModel | ContentParallaxImageModel) => void;
+  /** Accepts any viewable content (image, parallax image, or GIF/MP4 — normalized in renderer) */
+  onFullScreenImageClick?: (image: ViewableContent) => void;
   /** Array of selected image IDs for bulk editing */
   selectedImageIds?: number[];
   /** ID of current collection (for checking collection-specific visibility) */

--- a/app/components/Content/ContentBlockWithFullScreen.tsx
+++ b/app/components/Content/ContentBlockWithFullScreen.tsx
@@ -7,20 +7,16 @@ import { type ReorderMove } from '@/app/(admin)/collection/manage/[[...slug]]/ma
 import { useFullScreenImage } from '@/app/hooks/useFullScreenImage';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import { type CollectionModel } from '@/app/types/Collection';
-import {
-  type AnyContentModel,
-  type ContentImageModel,
-  type ContentParallaxImageModel,
-} from '@/app/types/Content';
+import { type AnyContentModel, type ViewableContent } from '@/app/types/Content';
 
 import Component from './Component';
 import styles from './ContentBlockWithFullScreen.module.scss';
 
 const FullScreenModal = dynamic(
   () =>
-    import('@/app/components/FullScreenModal/FullScreenModal').then(
-      m => ({ default: m.FullScreenModal })
-    ),
+    import('@/app/components/FullScreenModal/FullScreenModal').then(m => ({
+      default: m.FullScreenModal,
+    })),
   { ssr: false }
 );
 
@@ -97,15 +93,26 @@ export default function ContentBlockWithFullScreen({
     }
   }, [collectionSlug, collectionData]);
 
-  const imageBlocks = useMemo(() => {
+  /**
+   * Every content block that can open in the fullscreen viewer — still images, parallax images,
+   * and animated GIF/MP4 blocks. The fullscreen prev/next navigation walks this list, so adding
+   * GIFs here means they get the same swipe/arrow-key flow as images.
+   */
+  const viewableBlocks = useMemo(() => {
     return allBlocks.filter(
-      (block): block is ContentImageModel | ContentParallaxImageModel =>
-        block.contentType === 'IMAGE'
+      (block): block is ViewableContent =>
+        block.contentType === 'IMAGE' || block.contentType === 'GIF'
     );
   }, [allBlocks]);
 
-  const handleFullScreenImageClick = (image: ContentImageModel | ContentParallaxImageModel) => {
-    showImage(image, imageBlocks);
+  /**
+   * The image arg may be a synthetic from {@link CollectionContentRenderer}'s click handler — it
+   * only carries id + contentType + imageUrl/gifUrl. Look up the real block in {@link allBlocks}
+   * so the modal has full metadata (title, locations, captureDate, etc).
+   */
+  const handleFullScreenImageClick = (image: ViewableContent) => {
+    const real = viewableBlocks.find(b => b.id === image.id);
+    showImage(real ?? image, viewableBlocks);
   };
 
   const [visibleCount, setVisibleCount] = useState(

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -8,15 +8,19 @@ import { createPortal } from 'react-dom';
 import { IMAGE } from '@/app/constants';
 import styles from '@/app/styles/fullscreen-image.module.scss';
 import type { CollectionModel } from '@/app/types/Collection';
-import type { ContentImageModel, ContentParallaxImageModel } from '@/app/types/Content';
+import type { ContentGifModel, ViewableContent } from '@/app/types/Content';
 
-type ImageBlock = ContentImageModel | ContentParallaxImageModel;
+type ImageBlock = ViewableContent;
 
 type FullScreenState = {
   images: ImageBlock[];
   currentIndex: number;
   scrollPosition: number;
 };
+
+function isGifBlock(block: ImageBlock): block is ContentGifModel {
+  return block.contentType === 'GIF';
+}
 
 interface FullScreenModalProps {
   fullScreenState: FullScreenState | null;
@@ -53,13 +57,20 @@ export function FullScreenModal({
   const currentImage = fullScreenState.images[fullScreenState.currentIndex];
   if (!currentImage) return null;
 
-  // Resolve locations: image locations take priority, fall back to collection locations
-  const displayLocations = currentImage.locations?.length
-    ? currentImage.locations
+  const isGif = isGifBlock(currentImage);
+
+  // Resolve locations: image locations take priority, fall back to collection locations.
+  // GIF blocks don't carry locations today — fall straight through to the collection.
+  const imageLocations = !isGif ? currentImage.locations : undefined;
+  const displayLocations = imageLocations?.length
+    ? imageLocations
     : (collectionData?.locations ?? []);
 
-  // Resolve date: image captureDate takes priority, fall back to collection collectionDate
-  const displayDate = currentImage.captureDate ?? collectionData?.collectionDate ?? null;
+  // Resolve date: image captureDate takes priority, fall back to collection collectionDate.
+  // GIFs don't have captureDate — fall back immediately.
+  const displayDate = !isGif
+    ? (currentImage.captureDate ?? collectionData?.collectionDate ?? null)
+    : (collectionData?.collectionDate ?? null);
 
   const currentImageLoaded = loadedImageIds.has(currentImage.id);
   const hasPrevious = fullScreenState.currentIndex > 0;
@@ -72,28 +83,51 @@ export function FullScreenModal({
   };
 
   const modalContent = (
-    <div ref={modalRef} className={styles.imageFullScreenWrapper} role="dialog" aria-modal="true" aria-label="Image viewer">
+    <div
+      ref={modalRef}
+      className={styles.imageFullScreenWrapper}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image viewer"
+    >
       <div className={styles.overlayContainer} onClick={handleOverlayClick}>
         <div
           className={`${styles.imageWrapper} ${currentImageLoaded ? styles.imageWrapperLoaded : ''}`}
         >
-          <Image
-            key={currentImage.id}
-            src={currentImage.imageUrl}
-            alt={currentImage.title || currentImage.caption || 'Full screen image'}
-            width={currentImage.imageWidth || IMAGE.defaultWidth}
-            height={currentImage.imageHeight || IMAGE.defaultHeight}
-            className={`${styles.fullScreenImage} ${currentImageLoaded ? styles.fullScreenImageLoaded : ''}`}
-            priority
-            onLoad={() => {
-              setLoadedImageIds(prev => {
-                if (prev.has(currentImage.id)) return prev;
-                const newSet = new Set(prev);
-                newSet.add(currentImage.id);
-                return newSet;
-              });
-            }}
-          />
+          {isGif ? (
+            <video
+              key={currentImage.id}
+              autoPlay
+              loop
+              muted
+              playsInline
+              controls={false}
+              poster={currentImage.thumbnailUrl ?? undefined}
+              width={currentImage.width || IMAGE.defaultWidth}
+              height={currentImage.height || IMAGE.defaultHeight}
+              className={`${styles.fullScreenImage} ${currentImageLoaded ? styles.fullScreenImageLoaded : ''}`}
+            >
+              <source src={currentImage.gifUrl} type="video/mp4" />
+            </video>
+          ) : (
+            <Image
+              key={currentImage.id}
+              src={currentImage.imageUrl}
+              alt={currentImage.title || currentImage.caption || 'Full screen image'}
+              width={currentImage.imageWidth || IMAGE.defaultWidth}
+              height={currentImage.imageHeight || IMAGE.defaultHeight}
+              className={`${styles.fullScreenImage} ${currentImageLoaded ? styles.fullScreenImageLoaded : ''}`}
+              priority
+              onLoad={() => {
+                setLoadedImageIds(prev => {
+                  if (prev.has(currentImage.id)) return prev;
+                  const newSet = new Set(prev);
+                  newSet.add(currentImage.id);
+                  return newSet;
+                });
+              }}
+            />
+          )}
 
           {currentImageLoaded && (
             <div
@@ -136,7 +170,7 @@ export function FullScreenModal({
                       ))}
                     </div>
                   )}
-                  {(currentImage.camera || currentImage.lens) && (
+                  {!isGif && (currentImage.camera || currentImage.lens) && (
                     <div className={styles.metadataItem}>
                       {currentImage.camera && <span>{currentImage.camera.name}</span>}
                       {currentImage.camera && currentImage.lens && (
@@ -145,18 +179,19 @@ export function FullScreenModal({
                       {currentImage.lens && <span>{currentImage.lens.name}</span>}
                     </div>
                   )}
-                  {(currentImage.iso ||
-                    currentImage.fStop ||
-                    currentImage.shutterSpeed ||
-                    currentImage.focalLength) && (
-                    <div className={styles.metadataSettingsRow}>
-                      {currentImage.iso && <span>{currentImage.iso}</span>}
-                      {currentImage.shutterSpeed && <span>{currentImage.shutterSpeed}</span>}
-                      {currentImage.fStop && <span>{currentImage.fStop}</span>}
-                      {currentImage.focalLength && <span>{currentImage.focalLength}</span>}
-                    </div>
-                  )}
-                  {currentImage.people && currentImage.people.length > 0 && (
+                  {!isGif &&
+                    (currentImage.iso ||
+                      currentImage.fStop ||
+                      currentImage.shutterSpeed ||
+                      currentImage.focalLength) && (
+                      <div className={styles.metadataSettingsRow}>
+                        {currentImage.iso && <span>{currentImage.iso}</span>}
+                        {currentImage.shutterSpeed && <span>{currentImage.shutterSpeed}</span>}
+                        {currentImage.fStop && <span>{currentImage.fStop}</span>}
+                        {currentImage.focalLength && <span>{currentImage.focalLength}</span>}
+                      </div>
+                    )}
+                  {!isGif && currentImage.people && currentImage.people.length > 0 && (
                     <div className={styles.metadataSection}>
                       <div className={styles.metadataSectionRow}>
                         <div className={styles.metadataSectionHeader}>People</div>
@@ -170,7 +205,7 @@ export function FullScreenModal({
                       </div>
                     </div>
                   )}
-                  {currentImage.collections && currentImage.collections.length > 0 && (
+                  {!isGif && currentImage.collections && currentImage.collections.length > 0 && (
                     <div className={styles.metadataSection}>
                       <div className={styles.metadataSectionRow}>
                         <div className={styles.metadataSectionHeader}>Collections</div>

--- a/app/components/ImageMetadata/ImageMetadataModal.module.scss
+++ b/app/components/ImageMetadata/ImageMetadataModal.module.scss
@@ -265,7 +265,8 @@
 /* Buttons */
 .saveButton,
 .cancelButton,
-.deleteButton {
+.deleteButton,
+.removeButton {
   padding: 12px 24px;
   font-size: 14px;
   font-weight: 600;
@@ -318,6 +319,22 @@
   &:hover:not(:disabled) {
     background: rgb(220, 38, 38, 0.3);
     border-color: var(--color-danger-dark);
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+}
+
+.removeButton {
+  background: rgb(234, 179, 8, 0.15);
+  color: rgb(250, 204, 21);
+  border: 1px solid rgb(202, 138, 4, 0.6);
+
+  &:hover:not(:disabled) {
+    background: rgb(234, 179, 8, 0.25);
+    border-color: rgb(202, 138, 4);
     transform: translateY(-1px);
   }
 

--- a/app/components/ImageMetadata/ImageMetadataModal.tsx
+++ b/app/components/ImageMetadata/ImageMetadataModal.tsx
@@ -6,9 +6,17 @@ import { type SubmitEvent, useCallback, useEffect, useMemo, useState } from 'rea
 import CollectionListSelector from '@/app/components/CollectionListSelector/CollectionListSelector';
 import { LoadingSpinner } from '@/app/components/LoadingSpinner/LoadingSpinner';
 import { IMAGE } from '@/app/constants';
-import { createCamera, deleteImages, updateImages } from '@/app/lib/api/content';
+import {
+  type ContentGifUpdateRequest,
+  createCamera,
+  deleteGif,
+  deleteImages,
+  updateGif,
+  updateImages,
+} from '@/app/lib/api/content';
 import { type CollectionListModel, type LocationModel } from '@/app/types/Collection';
 import {
+  type ContentGifModel,
   type ContentImageModel,
   type ContentImageUpdateRequest,
   type ContentImageUpdateResponse,
@@ -21,11 +29,13 @@ import {
   type ContentTagModel,
   type FilmFormatDTO,
 } from '@/app/types/ImageMetadata';
+import { isGifContent } from '@/app/utils/contentTypeGuards';
 import { convertLocationsToModels } from '@/app/utils/locationUtils';
 import { hasObjectChanges } from '@/app/utils/objectComparison';
 
 import styles from './ImageMetadataModal.module.scss';
 import {
+  buildImageUpdateDiff,
   buildImageUpdateForSingleEdit,
   buildImageUpdatesForBulkEdit,
   computeCameraSelectionUpdate,
@@ -34,15 +44,90 @@ import {
 } from './imageMetadataUtils';
 import UnifiedMetadataSelector from './UnifiedMetadataSelector';
 
-type ImageUpdateState = Partial<ContentImageModel> & {
-  id: number;
-};
+/**
+ * Local edit-state shape. We allow GIF fields too because the same modal now edits both — image-
+ * only fields are disabled in the JSX when the current selection is a GIF.
+ */
+type ImageUpdateState = Partial<ContentImageModel> &
+  Partial<Pick<ContentGifModel, 'gifUrl' | 'thumbnailUrl' | 'rating'>> & {
+    id: number;
+  };
+
+/** Any content the modal can edit — images and animated GIF/MP4 blocks. */
+type EditableContent = ContentImageModel | ContentGifModel;
+
+/**
+ * Render the single-item preview: looping `<video>` for GIF/MP4, `<Image>` for stills. Extracted
+ * so the inline JSX doesn't trigger the unicorn/no-nested-ternary rule, and so the same render
+ * can be reused if we ever introduce a single-preview header above the bulk grid.
+ */
+function renderSinglePreview({
+  isGif,
+  previewImageAsGif,
+  previewImageAsImage,
+}: {
+  isGif: boolean;
+  previewImageAsGif: ContentGifModel | null;
+  previewImageAsImage: ContentImageModel | null;
+}) {
+  if (isGif && previewImageAsGif) {
+    return (
+      <video
+        key={previewImageAsGif.gifUrl}
+        autoPlay
+        loop
+        muted
+        playsInline
+        controls={false}
+        poster={previewImageAsGif.thumbnailUrl ?? undefined}
+        width={previewImageAsGif.width || IMAGE.defaultWidth}
+        height={previewImageAsGif.height || IMAGE.defaultHeight}
+        style={{
+          maxWidth: '100%',
+          maxHeight: '100%',
+          width: 'auto',
+          height: 'auto',
+          objectFit: 'contain',
+        }}
+      >
+        <source src={previewImageAsGif.gifUrl} type="video/mp4" />
+      </video>
+    );
+  }
+  if (previewImageAsImage) {
+    return (
+      <Image
+        src={previewImageAsImage.imageUrl}
+        alt={previewImageAsImage.alt || previewImageAsImage.title || 'Image preview'}
+        width={previewImageAsImage.imageWidth || IMAGE.defaultWidth}
+        height={previewImageAsImage.imageHeight || IMAGE.defaultHeight}
+        style={{
+          maxWidth: '100%',
+          maxHeight: '100%',
+          width: 'auto',
+          height: 'auto',
+          objectFit: 'contain',
+        }}
+        priority
+        unoptimized
+      />
+    );
+  }
+  return null;
+}
 
 interface ImageMetadataModalProps {
   scrollPosition: number;
   onClose: () => void;
   onSaveSuccess?: (response: ContentImageUpdateResponse) => void;
+  /**
+   * Fired after a single-GIF save. Separate from `onSaveSuccess` because the GIF update endpoint
+   * returns one record instead of the batched ImageUpdate response. ManageClient hands these to
+   * the same collection-refresh handler that GIF saves used to call from `GifMetadataModal`.
+   */
+  onGifSaveSuccess?: (gif: ContentGifModel) => void;
   onDeleteSuccess?: (deletedIds: number[]) => void;
+  onRemoveFromCollectionSuccess?: (removedImageIds: number[]) => void;
   availableTags?: ContentTagModel[];
   availablePeople?: ContentPersonModel[];
   availableCameras?: ContentCameraModel[];
@@ -51,8 +136,13 @@ interface ImageMetadataModalProps {
   availableFilmFormats?: FilmFormatDTO[];
   availableCollections?: CollectionListModel[];
   availableLocations?: LocationModel[];
-  selectedImageIds: number[]; // Array of selected image IDs (1 for single edit, N for bulk edit)
-  selectedImages: ContentImageModel[]; // Images to edit (already filtered in parent)
+  selectedImageIds: number[]; // Array of selected content IDs (1 for single edit, N for bulk edit)
+  /**
+   * Content blocks to edit. May include images and GIF/MP4 blocks. Bulk edit only operates on
+   * the IMAGE subset (the EXIF-heavy fields don't have GIF analogs); when the selection is a
+   * single GIF the modal routes title/rating/tags/collections through `updateGif()`.
+   */
+  selectedImages: EditableContent[];
   currentCollectionId?: number; // ID of the collection being edited (for visibility checkbox)
 }
 
@@ -67,7 +157,9 @@ export default function ImageMetadataModal({
   scrollPosition,
   onClose,
   onSaveSuccess,
+  onGifSaveSuccess,
   onDeleteSuccess,
+  onRemoveFromCollectionSuccess,
   availableTags = [],
   availablePeople = [],
   availableCameras = [],
@@ -82,38 +174,37 @@ export default function ImageMetadataModal({
 }: ImageMetadataModalProps) {
   const isBulkEdit = selectedImageIds.length > 1;
 
-  const [updateState, setUpdateState] = useState<ImageUpdateState>(() => {
+  // `getCommonValues` was authored for ContentImageModel only — for GIF blocks we slot the union
+  // in but the bulk-edit code path only ever runs on images (ManageClient.handleBulkEdit splits
+  // mixed selections), so the cast here is safe at runtime.
+  const imageSubset = selectedImages.filter(
+    (c): c is ContentImageModel => c.contentType === 'IMAGE'
+  );
+
+  const buildInitialState = (): ImageUpdateState => {
     if (selectedImages.length === 1) {
-      const img = selectedImages[0]!;
+      const item = selectedImages[0]!;
+      const itemLocations = 'locations' in item ? item.locations : undefined;
       return {
-        ...img,
-        locations: convertLocationsToModels(img.locations, availableLocations),
-      };
-    } else {
-      const common = getCommonValues(selectedImages);
-      return {
-        id: 0,
-        ...common,
-        locations: convertLocationsToModels(common.locations, availableLocations),
-      };
+        ...item,
+        locations: convertLocationsToModels(itemLocations, availableLocations),
+      } as ImageUpdateState;
     }
-  });
+    const common = getCommonValues(imageSubset);
+    return {
+      id: 0,
+      ...common,
+      locations: convertLocationsToModels(common.locations, availableLocations),
+    };
+  };
+
+  const [updateState, setUpdateState] = useState<ImageUpdateState>(buildInitialState);
 
   useEffect(() => {
-    if (selectedImages.length === 1) {
-      const img = selectedImages[0]!;
-      setUpdateState({
-        ...img,
-        locations: convertLocationsToModels(img.locations, availableLocations),
-      });
-    } else {
-      const common = getCommonValues(selectedImages);
-      setUpdateState({
-        id: 0,
-        ...common,
-        locations: convertLocationsToModels(common.locations, availableLocations),
-      });
-    }
+    setUpdateState(buildInitialState());
+    // buildInitialState closes over selectedImages + availableLocations only; everything else is
+    // stable. Listing the function in deps would just churn on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedImages, availableLocations]);
 
   const updateStateField = (updates: Partial<ImageUpdateState>) => {
@@ -122,12 +213,14 @@ export default function ImageMetadataModal({
 
   const hasChanges = useMemo(() => {
     if (isBulkEdit) {
-      const common = getCommonValues(selectedImages);
+      const common = getCommonValues(imageSubset);
       return hasObjectChanges(updateState, { id: 0, ...common });
     } else {
       const original = selectedImages[0]!;
       return hasObjectChanges(updateState, original);
     }
+    // imageSubset is derived from selectedImages each render; reflect that in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateState, selectedImages, isBulkEdit]);
 
   const [saving, setSaving] = useState(false);
@@ -191,6 +284,15 @@ export default function ImageMetadataModal({
     return null;
   }
 
+  /**
+   * Type-narrowing helpers so the JSX below can stay readable. When `isGif` is true the GIF-
+   * specific fields are available on the union; when false the image-specific ones are. The
+   * disabled-input pattern (rather than rendering nothing) keeps the layout stable.
+   */
+  const isGif = isGifContent(previewImage);
+  const previewImageAsImage = !isGif ? (previewImage as ContentImageModel) : null;
+  const previewImageAsGif = isGif ? (previewImage as ContentGifModel) : null;
+
   const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -203,20 +305,62 @@ export default function ImageMetadataModal({
       setSaving(true);
       setError(null);
 
+      // Single GIF: route through the GIF patch endpoint. Bulk-edit on GIF is not supported yet —
+      // selectedImages was already filtered upstream in ManageClient.handleBulkEdit so a mixed
+      // selection won't reach here as a "GIF edit"; we treat anything non-IMAGE as a single-gif
+      // edit and reject batch.
+      if (!isBulkEdit && isGif && previewImageAsGif) {
+        const original = previewImageAsGif;
+        const payload: ContentGifUpdateRequest = {};
+        if ((updateState.title ?? '') !== (original.title ?? '')) {
+          payload.title = updateState.title ?? '';
+        }
+        if (updateState.rating !== undefined && updateState.rating !== (original.rating ?? null)) {
+          payload.rating = updateState.rating ?? 0;
+        }
+        // Collections: build prev/newValue/remove from originalCollectionIds vs current selection
+        const currentCollectionIds = new Set(
+          (updateState.collections || []).map(c => c.collectionId)
+        );
+        const add = (updateState.collections || []).filter(
+          c => !originalCollectionIds.has(c.collectionId)
+        );
+        const remove: number[] = [];
+        for (const id of originalCollectionIds) {
+          if (!currentCollectionIds.has(id)) remove.push(id);
+        }
+        if (add.length > 0 || remove.length > 0) {
+          payload.collections = {
+            newValue: add.length > 0 ? add : undefined,
+            remove: remove.length > 0 ? remove : undefined,
+          };
+        }
+
+        const updated =
+          Object.keys(payload).length > 0 ? await updateGif(original.id, payload) : original;
+        if (updated) {
+          onGifSaveSuccess?.(updated as ContentGifModel);
+          onClose();
+        }
+        return;
+      }
+
       const imageUpdates: ContentImageUpdateRequest[] = isBulkEdit
         ? buildImageUpdatesForBulkEdit(
             updateState as Partial<ContentImageModel> & {
               id: number;
               location?: LocationModel | null;
             },
-            selectedImages,
+            selectedImages.filter(
+              (s): s is ContentImageModel => s.contentType === 'IMAGE'
+            ) as ContentImageModel[],
             selectedImageIds,
             availableFilmTypes
           )
         : [
             buildImageUpdateForSingleEdit(
               updateState as ContentImageModel & { location?: LocationModel | null },
-              selectedImages[0]!,
+              selectedImages[0] as ContentImageModel,
               availableFilmTypes
             ),
           ];
@@ -246,10 +390,12 @@ export default function ImageMetadataModal({
 
   const handleDelete = async () => {
     const imageCount = selectedImageIds.length;
+    const noun = isGif ? 'GIF/MP4' : 'image';
+    const nounPlural = isGif ? 'GIFs/MP4s' : 'images';
     const confirmMessage =
       imageCount === 1
-        ? 'Are you sure you want to delete this image? This will remove it from S3 and the database. This action cannot be undone.'
-        : `Are you sure you want to delete ${imageCount} images? This will remove them from S3 and the database. This action cannot be undone.`;
+        ? `Are you sure you want to delete this ${noun}? This will remove it from S3 and the database. This action cannot be undone.`
+        : `Are you sure you want to delete ${imageCount} ${nounPlural}? This will remove them from S3 and the database. This action cannot be undone.`;
 
     const confirmed = window.confirm(confirmMessage);
     if (!confirmed) return;
@@ -257,6 +403,17 @@ export default function ImageMetadataModal({
     try {
       setSaving(true);
       setError(null);
+
+      // Single GIF: route to the GIF delete endpoint. Bulk-gif delete isn't supported yet — we
+      // process the single visible selection only.
+      if (!isBulkEdit && isGif && previewImageAsGif) {
+        const result = await deleteGif(previewImageAsGif.id);
+        if (result?.deletedId != null) {
+          onDeleteSuccess?.([result.deletedId]);
+          onClose();
+        }
+        return;
+      }
 
       const response = await deleteImages(selectedImageIds);
 
@@ -266,6 +423,50 @@ export default function ImageMetadataModal({
       }
     } catch (error_) {
       setError(error_ instanceof Error ? error_.message : 'Failed to delete images');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemoveFromCollection = async () => {
+    if (!currentCollectionId) return;
+
+    const imageCount = selectedImageIds.length;
+    const confirmMessage =
+      imageCount === 1
+        ? 'Remove this image from the current collection? The image and its metadata will remain in the system.'
+        : `Remove ${imageCount} images from the current collection? Images and their metadata will remain in the system.`;
+
+    const confirmed = window.confirm(confirmMessage);
+    if (!confirmed) return;
+
+    try {
+      setSaving(true);
+      setError(null);
+
+      // "Remove from collection" only operates on IMAGE blocks today — the bulk diff helper is
+      // typed to ContentImageModel. Skip GIF entries; they'll be a follow-up.
+      const imageUpdates: ContentImageUpdateRequest[] = imageSubset.map(img => {
+        const trimmedCollections = (img.collections || []).filter(
+          c => c.collectionId !== currentCollectionId
+        );
+        return buildImageUpdateDiff(
+          { id: img.id, collections: trimmedCollections },
+          img,
+          availableFilmTypes
+        );
+      });
+
+      const response = await updateImages(imageUpdates);
+
+      if (response !== null) {
+        onRemoveFromCollectionSuccess?.(selectedImageIds);
+        onClose();
+      }
+    } catch (error_) {
+      setError(
+        error_ instanceof Error ? error_.message : 'Failed to remove images from collection'
+      );
     } finally {
       setSaving(false);
     }
@@ -296,8 +497,14 @@ export default function ImageMetadataModal({
             }}
           >
             {selectedImageIds.map(imageId => {
-              const img = selectedImages.find(i => i.id === imageId);
-              if (!img) return null;
+              const item = selectedImages.find(i => i.id === imageId);
+              if (!item) return null;
+              // Bulk-edit thumbnail src: image uses imageUrl, GIF uses thumbnailUrl (still WebP).
+              const thumbSrc =
+                item.contentType === 'GIF'
+                  ? (item.thumbnailUrl ?? '')
+                  : ((item as ContentImageModel).imageUrl ?? '');
+              if (!thumbSrc) return null;
               return (
                 <div
                   key={imageId}
@@ -310,8 +517,8 @@ export default function ImageMetadataModal({
                   }}
                 >
                   <Image
-                    src={img.imageUrl}
-                    alt={img.alt || img.title || 'Selected image'}
+                    src={thumbSrc}
+                    alt={item.alt || item.title || 'Selected media'}
                     fill
                     style={{
                       objectFit: 'cover',
@@ -324,21 +531,7 @@ export default function ImageMetadataModal({
             })}
           </div>
         ) : (
-          <Image
-            src={previewImage.imageUrl}
-            alt={previewImage.alt || previewImage.title || 'Image preview'}
-            width={previewImage.imageWidth || IMAGE.defaultWidth}
-            height={previewImage.imageHeight || IMAGE.defaultHeight}
-            style={{
-              maxWidth: '100%',
-              maxHeight: '100%',
-              width: 'auto',
-              height: 'auto',
-              objectFit: 'contain',
-            }}
-            priority
-            unoptimized
-          />
+          renderSinglePreview({ isGif, previewImageAsGif, previewImageAsImage })
         )}
       </div>
 
@@ -370,7 +563,12 @@ export default function ImageMetadataModal({
               />
             </div>
 
-            <div className={styles.formGroup}>
+            <div
+              className={styles.formGroup}
+              style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
+              aria-disabled={isGif}
+              title={isGif ? 'Caption is not supported on GIF/MP4 content.' : undefined}
+            >
               <label className={styles.formLabel}>Caption</label>
               <textarea
                 value={updateState.caption ?? ''}
@@ -378,6 +576,7 @@ export default function ImageMetadataModal({
                 className={styles.formTextarea}
                 placeholder="Enter caption"
                 rows={3}
+                disabled={isGif}
               />
             </div>
 
@@ -403,40 +602,46 @@ export default function ImageMetadataModal({
               />
             </div>
 
-            <UnifiedMetadataSelector<LocationModel>
-              label="Locations"
-              multiSelect
-              options={availableLocations}
-              selectedValues={updateState.locations ?? []}
-              onChange={value => {
-                let locations: LocationModel[];
-                if (Array.isArray(value)) {
-                  locations = value;
-                } else if (value) {
-                  locations = [value];
-                } else {
-                  locations = [];
-                }
-                updateStateField({ locations });
-              }}
-              allowAddNew
-              onAddNew={data => {
-                const newLocation = { id: 0, name: data.name as string, slug: '' };
-                updateStateField({ locations: [...(updateState.locations ?? []), newLocation] });
-              }}
-              addNewFields={[
-                {
-                  name: 'name',
-                  label: 'Location Name',
-                  type: 'text',
-                  placeholder: 'e.g., Seattle, WA',
-                  required: true,
-                },
-              ]}
-              getDisplayName={location => location?.name || ''}
-              showNewIndicator
-              emptyText="No locations set"
-            />
+            <div
+              style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
+              aria-disabled={isGif}
+              title={isGif ? 'Locations are not yet supported on GIF/MP4 content.' : undefined}
+            >
+              <UnifiedMetadataSelector<LocationModel>
+                label="Locations"
+                multiSelect
+                options={availableLocations}
+                selectedValues={updateState.locations ?? []}
+                onChange={value => {
+                  let locations: LocationModel[];
+                  if (Array.isArray(value)) {
+                    locations = value;
+                  } else if (value) {
+                    locations = [value];
+                  } else {
+                    locations = [];
+                  }
+                  updateStateField({ locations });
+                }}
+                allowAddNew
+                onAddNew={data => {
+                  const newLocation = { id: 0, name: data.name as string, slug: '' };
+                  updateStateField({ locations: [...(updateState.locations ?? []), newLocation] });
+                }}
+                addNewFields={[
+                  {
+                    name: 'name',
+                    label: 'Location Name',
+                    type: 'text',
+                    placeholder: 'e.g., Seattle, WA',
+                    required: true,
+                  },
+                ]}
+                getDisplayName={location => location?.name || ''}
+                showNewIndicator
+                emptyText="No locations set"
+              />
+            </div>
 
             <div className={styles.formGroup}>
               <label className={styles.formLabel}>Rating</label>
@@ -511,8 +716,13 @@ export default function ImageMetadataModal({
             )}
           </div>
 
-          {/* Camera Metadata */}
-          <div className={styles.formSection}>
+          {/* Camera Metadata — image-only, greyed out for GIF/MP4 blocks. */}
+          <div
+            className={styles.formSection}
+            style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
+            aria-disabled={isGif}
+            title={isGif ? 'Camera/EXIF metadata is not supported on GIF/MP4 content.' : undefined}
+          >
             <h3 className={styles.sectionHeading}>Camera Settings</h3>
 
             <UnifiedMetadataSelector<ContentCameraModel>
@@ -796,37 +1006,43 @@ export default function ImageMetadataModal({
               emptyText="No tags selected"
             />
 
-            <UnifiedMetadataSelector<ContentPersonModel>
-              label="People"
-              multiSelect
-              options={availablePeople}
-              selectedValues={updateState.people || []}
-              onChange={value => {
-                const people = (value as ContentPersonModel[] | null) ?? [];
-                updateStateField({ people });
-              }}
-              allowAddNew
-              onAddNew={data => {
-                const newPerson: ContentPersonModel = {
-                  id: 0,
-                  name: data.name as string,
-                  slug: '',
-                };
-                const currentPeople = updateState.people || [];
-                updateStateField({ people: [...currentPeople, newPerson] });
-              }}
-              addNewFields={[
-                {
-                  name: 'name',
-                  label: 'Person Name',
-                  type: 'text',
-                  placeholder: 'Enter person name',
-                  required: true,
-                },
-              ]}
-              getDisplayName={person => person.name}
-              emptyText="No people selected"
-            />
+            <div
+              style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
+              aria-disabled={isGif}
+              title={isGif ? 'People are not yet supported on GIF/MP4 content.' : undefined}
+            >
+              <UnifiedMetadataSelector<ContentPersonModel>
+                label="People"
+                multiSelect
+                options={availablePeople}
+                selectedValues={updateState.people || []}
+                onChange={value => {
+                  const people = (value as ContentPersonModel[] | null) ?? [];
+                  updateStateField({ people });
+                }}
+                allowAddNew
+                onAddNew={data => {
+                  const newPerson: ContentPersonModel = {
+                    id: 0,
+                    name: data.name as string,
+                    slug: '',
+                  };
+                  const currentPeople = updateState.people || [];
+                  updateStateField({ people: [...currentPeople, newPerson] });
+                }}
+                addNewFields={[
+                  {
+                    name: 'name',
+                    label: 'Person Name',
+                    type: 'text',
+                    placeholder: 'Enter person name',
+                    required: true,
+                  },
+                ]}
+                getDisplayName={person => person.name}
+                emptyText="No people selected"
+              />
+            </div>
           </div>
 
           {/* Collections */}
@@ -860,6 +1076,24 @@ export default function ImageMetadataModal({
                   `Delete ${isBulkEdit ? `${selectedImageIds.length} Images` : 'Image'}`
                 )}
               </button>
+              {currentCollectionId && (
+                <button
+                  type="button"
+                  onClick={handleRemoveFromCollection}
+                  disabled={saving}
+                  className={styles.removeButton}
+                  title="Remove from current collection (image stays in the system)"
+                >
+                  {saving ? (
+                    <>
+                      <LoadingSpinner size="small" color="white" />
+                      <span style={{ marginLeft: '8px' }}>Removing...</span>
+                    </>
+                  ) : (
+                    `Remove ${isBulkEdit ? `${selectedImageIds.length} Images` : 'Image'}`
+                  )}
+                </button>
+              )}
             </div>
             <div className={styles.buttonRowRight}>
               <button

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -1,16 +1,29 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { type Dispatch, type MouseEvent, type RefObject, type SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type Dispatch,
+  type MouseEvent,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { INTERACTION } from '@/app/constants';
 import { useBodyScrollLock } from '@/app/hooks/useBodyScrollLock';
 import styles from '@/app/styles/fullscreen-image.module.scss';
-import type { ContentImageModel, ContentParallaxImageModel } from '@/app/types/Content';
+import type { ViewableContent } from '@/app/types/Content';
 
 const SCROLL_BLOCKING_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', ' ', 'Home', 'End'];
 
-export type ImageBlock = ContentImageModel | ContentParallaxImageModel;
+/**
+ * Backwards-compatible alias for the union of content types that can open in the fullscreen
+ * viewer. Now includes GIF/MP4 — see {@link ViewableContent}.
+ */
+export type ImageBlock = ViewableContent;
 
 export type FullScreenState = {
   images: ImageBlock[];
@@ -99,9 +112,21 @@ export function useFullScreenImage(): {
     if (!currentImage) return;
 
     const checkImageLoaded = () => {
-      const imgElement = document.querySelector(
-        `img[src="${currentImage.imageUrl}"]`
-      ) as HTMLImageElement;
+      // GIF/MP4 blocks render as <video>, not <img> — mark them loaded immediately so the
+      // modal's loaded-state UI doesn't stall waiting for an image that never appears.
+      if (currentImage.contentType === 'GIF') {
+        setLoadedImageIds(prev => {
+          if (prev.has(currentImage.id)) return prev;
+          const newSet = new Set(prev);
+          newSet.add(currentImage.id);
+          return newSet;
+        });
+        return;
+      }
+
+      const imgSrc = 'imageUrl' in currentImage ? currentImage.imageUrl : undefined;
+      if (!imgSrc) return;
+      const imgElement = document.querySelector(`img[src="${imgSrc}"]`) as HTMLImageElement;
 
       if (imgElement?.complete && imgElement?.naturalHeight !== 0) {
         setLoadedImageIds(prev => {

--- a/app/hooks/useImageMetadataEditor.tsx
+++ b/app/hooks/useImageMetadataEditor.tsx
@@ -3,42 +3,50 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { useBodyScrollLock } from '@/app/hooks/useBodyScrollLock';
-import type { ContentImageModel } from '@/app/types/Content';
+import type { ContentGifModel, ContentImageModel } from '@/app/types/Content';
 
 /**
- * Hook for managing image metadata editor state
+ * Any content block that owns first-class metadata (title, rating, etc.) and should open the
+ * metadata editor on click. Today: still images and animated GIF/MP4 blocks. Adding new rated
+ * content types means adding them here, not at every callsite — the click handler and modal
+ * dispatch already key off the runtime contentType.
+ */
+export type EditableContent = ContentImageModel | ContentGifModel;
+
+/**
+ * Hook for managing metadata editor state.
  *
  * Handles:
- * - Opening/closing the metadata editor modal
+ * - Opening/closing the metadata editor modal (image or gif)
  * - Scroll position management
  * - Body scroll prevention while modal is open
  *
  * @returns Editor state and control functions
  */
 export function useImageMetadataEditor() {
-  const [editingImage, setEditingImage] = useState<ContentImageModel | null>(null);
+  const [editingContent, setEditingContent] = useState<EditableContent | null>(null);
   const [scrollPosition, setScrollPosition] = useState(0);
 
   /**
-   * Open the metadata editor for a specific image
+   * Open the metadata editor for a specific content block (image or gif).
    */
-  const openEditor = useCallback((image: ContentImageModel) => {
+  const openEditor = useCallback((content: EditableContent) => {
     const currentScroll = window.scrollY;
     setScrollPosition(currentScroll);
-    setEditingImage(image);
+    setEditingContent(content);
   }, []);
 
   /**
-   * Close the metadata editor
+   * Close the metadata editor.
    */
   const closeEditor = useCallback(() => {
-    setEditingImage(null);
+    setEditingContent(null);
   }, []);
 
-  useBodyScrollLock(!!editingImage);
+  useBodyScrollLock(!!editingContent);
 
   useEffect(() => {
-    if (!editingImage) return;
+    if (!editingContent) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -51,13 +59,15 @@ export function useImageMetadataEditor() {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [editingImage, closeEditor]);
+  }, [editingContent, closeEditor]);
 
   return {
-    editingImage,
+    editingContent,
+    /** @deprecated use `editingContent` — kept for back-compat until callers migrate. */
+    editingImage: editingContent,
     scrollPosition,
     openEditor,
     closeEditor,
-    isOpen: !!editingImage,
+    isOpen: !!editingContent,
   };
 }

--- a/app/lib/api/content.ts
+++ b/app/lib/api/content.ts
@@ -14,6 +14,7 @@ import {
   fetchAdminPostJsonApi,
   fetchReadApi,
 } from '@/app/lib/api/core';
+import { type CollectionUpdate, type TagUpdate } from '@/app/types/Collection';
 import {
   type ContentGifModel,
   type ContentImageModel,
@@ -193,6 +194,42 @@ export async function createGif(collectionId: number, file: File): Promise<Conte
 }
 
 /**
+ * Patch payload for {@link updateGif}. Only non-null fields are applied on the backend.
+ *
+ * Mirrors the slice of {@link ContentImageUpdateRequest} that makes sense for animated content —
+ * no EXIF/equipment fields. `tags` and `collections` use the prev/newValue/remove pattern so a
+ * single request can add, remove, and re-order memberships at once.
+ */
+export interface ContentGifUpdateRequest {
+  title?: string;
+  rating?: number;
+  tags?: TagUpdate;
+  collections?: CollectionUpdate;
+}
+
+/**
+ * DELETE /api/admin/content/gifs/{id}
+ * Delete a GIF/MP4 content block. Cleans up the S3 objects + DB rows. Returns the deleted id
+ * on success, or `null` if the backend reported the GIF was not found. The endpoint takes the
+ * id as a path param; the empty body satisfies the shared admin DELETE helper.
+ */
+export async function deleteGif(id: number): Promise<{ deletedId: number } | null> {
+  return fetchAdminDeleteJsonApi<{ deletedId: number }>(`/content/gifs/${id}`, {});
+}
+
+/**
+ * PATCH /api/admin/content/gifs/{id}
+ * Update title/rating on an existing GIF/MP4 content block. The backend mirrors the IMAGE
+ * update slice that makes sense for animated content — no EXIF/equipment fields.
+ */
+export async function updateGif(
+  id: number,
+  request: ContentGifUpdateRequest
+): Promise<ContentGifModel | null> {
+  return fetchAdminPatchJsonApi<ContentGifModel>(`/content/gifs/${id}`, request);
+}
+
+/**
  * POST /api/admin/content/content
  * Create text or code content
  */
@@ -320,7 +357,9 @@ export async function getAllImages(params: GetAllImagesParams = {}): Promise<Pag
     const totalPages =
       typeof env.totalPages === 'number'
         ? env.totalPages
-        : (size > 0 ? Math.ceil(totalElements / size) : 1);
+        : (size > 0
+          ? Math.ceil(totalElements / size)
+          : 1);
     const number = typeof env.number === 'number' ? env.number : page;
     const last = typeof env.last === 'boolean' ? env.last : number >= totalPages - 1;
     return { items, page: number, totalPages, totalElements, isLast: last };

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -154,7 +154,20 @@ export interface ContentGifModel extends Content {
   height?: number;
   author?: string | null;
   createDate?: string | null;
+  /**
+   * Layout rating (0-5 or null). Drives slot-width selection in the row grid:
+   * horizontal GIF rating >= 4 takes the full row; rating 3 takes half a row;
+   * lower ratings take a single slot. New uploads default to 4. Vertical content
+   * (AR <= 1) gets a -1 effective-rating penalty.
+   */
+  rating?: number | null;
   tags?: ContentTagModel[];
+  /**
+   * Collections this GIF/MP4 belongs to. Many-to-many via the same `collection_content` join
+   * table that images use. Used by the metadata modal's collection selector so the admin can
+   * surface a single GIF in multiple galleries.
+   */
+  collections?: ChildCollection[];
 }
 
 /**
@@ -195,6 +208,14 @@ export type AnyContentModel =
   | ContentTextModel
   | ContentGifModel
   | ContentCollectionModel;
+
+/**
+ * Content blocks that participate in the click-to-fullscreen viewer: still images, parallax
+ * images, and animated GIF/MP4 blocks. TEXT and COLLECTION blocks have their own click semantics
+ * (collection navigation) and are excluded here. Use this everywhere a "viewable" content piece
+ * flows through the fullscreen pipeline.
+ */
+export type ViewableContent = ContentImageModel | ContentParallaxImageModel | ContentGifModel;
 /**
  * Camera update using prev/newValue/remove pattern
  * - prev: ID of existing camera to use

--- a/app/types/ContentRenderer.ts
+++ b/app/types/ContentRenderer.ts
@@ -4,11 +4,7 @@
  * This eliminates the need for type checking inside the renderer component
  */
 
-import {
-  type ContentImageModel,
-  type ContentParallaxImageModel,
-  type TextBlockItem,
-} from './Content';
+import { type TextBlockItem, type ViewableContent } from './Content';
 
 /**
  * Base props that all content renderers receive
@@ -79,7 +75,12 @@ export interface CollectionContentRendererProps extends ContentRendererProps {
   // Click handlers
   onImageClick?: (imageId: number) => void;
   enableFullScreenView?: boolean;
-  onFullScreenImageClick?: (image: ContentImageModel | ContentParallaxImageModel) => void;
+  /**
+   * Open the fullscreen viewer for any visual content block — images, parallax images, or
+   * animated GIF/MP4 blocks. The viewer renders the correct element (<Image> vs <video>)
+   * based on contentType.
+   */
+  onFullScreenImageClick?: (image: ViewableContent) => void;
 
   // Image-specific overlays (only for IMAGE type)
   selectedImageIds?: number[];

--- a/app/utils/contentComponentHandlers.ts
+++ b/app/utils/contentComponentHandlers.ts
@@ -8,7 +8,7 @@
  * - Handler creators are higher-order functions that return event handlers
  */
 
-import { type ContentImageModel, type ContentParallaxImageModel } from '@/app/types/Content';
+import { type ContentImageModel, type ViewableContent } from '@/app/types/Content';
 
 /**
  * Check if an image is not visible (either globally or collection-specific)
@@ -56,8 +56,8 @@ export function createContentClickHandler(
   contentId: number,
   onContentClick?: (contentId: number) => void,
   enableFullScreenView?: boolean,
-  onFullScreenClick?: (content: ContentImageModel | ContentParallaxImageModel) => void,
-  fullScreenContent?: ContentImageModel | ContentParallaxImageModel
+  onFullScreenClick?: (content: ViewableContent) => void,
+  fullScreenContent?: ViewableContent
 ): (() => void) | undefined {
   if (onContentClick) {
     return () => onContentClick(contentId);

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -7,7 +7,7 @@
 
 import { BASE_WEIGHT, REFERENCE_AR } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
-import { getAspectRatio, isContentImage } from '@/app/utils/contentTypeGuards';
+import { getAspectRatio, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
 
 /**
  * Check if an item is a collection card (converted from ContentCollectionModel or CollectionModel)
@@ -33,10 +33,12 @@ export function getRating(item: AnyContentModel, asStarValue: boolean = false): 
     return 4;
   }
 
-  if (!isContentImage(item)) {
+  // Animated GIF/MP4 blocks carry a backend-persisted rating with the same 0-5 semantics as
+  // images. Treat them identically here so the row layout doesn't squash them.
+  if (!isContentImage(item) && !isGifContent(item)) {
     return asStarValue ? 1 : 0;
   }
-  const rating = item.rating || 0;
+  const rating = (item as { rating?: number | null }).rating ?? 0;
   if (asStarValue) {
     return rating === 0 || rating === 1 ? 1 : rating;
   }
@@ -66,11 +68,14 @@ export function getEffectiveRating(item: AnyContentModel): number {
     return 4;
   }
 
-  if (!isContentImage(item)) {
+  // Animated GIF/MP4 blocks share the image rating semantics (0-5 with vertical penalty). The
+  // earlier `return 1` short-circuit here is what made GIFs always pack as low-priority filler in
+  // the row algorithm even after we added rating to the backend.
+  if (!isContentImage(item) && !isGifContent(item)) {
     return 1;
   }
 
-  const baseRating = item.rating || 0;
+  const baseRating = (item as { rating?: number | null }).rating ?? 0;
   const ratio = getAspectRatio(item);
   const isVertical = ratio <= 1.0;
 

--- a/app/utils/contentTypeGuards.ts
+++ b/app/utils/contentTypeGuards.ts
@@ -132,7 +132,10 @@ export function getAspectRatio(item: Content): number {
 /**
  * Get slot width for content item based on aspect ratio and rating.
  *
- * Square images (ratio == 1:1) are considered vertical, not horizontal.
+ * Square images (ratio == 1:1) are considered vertical, not horizontal. Vertical
+ * content (AR <= 1) gets an effective-rating penalty of -1 before applying the
+ * rules below — keeps the same shape semantics whether the source is an IMAGE
+ * or an animated GIF/MP4.
  *
  * Slot width rules:
  * - Collection cards (has slug): chunkSize/2 (pair up on catalog pages)
@@ -141,9 +144,13 @@ export function getAspectRatio(item: Content): number {
  * - 5-star horizontal: chunkSize (standalone)
  * - 4-star horizontal: chunkSize (standalone)
  * - 3-star (any orientation): chunkSize/2
- * - Vertical 4-5 star: chunkSize/2
+ * - Vertical 4-5 star: chunkSize/2 (penalty drops them to 3-4 → halfSlot)
  * - Vertical 1-2 star: 1 (normal)
  * - Horizontal 1-2 star: 1 (normal)
+ *
+ * GIF/MP4 uses the same rating-driven logic as IMAGE. New uploads default to
+ * rating 4 on the backend, so an animated block reads as feature media unless
+ * the admin lowers it.
  */
 export function getSlotWidth(contentItem: Content, chunkSize: number): number {
   const halfSlot = Math.floor(chunkSize / 2);
@@ -162,8 +169,9 @@ export function getSlotWidth(contentItem: Content, chunkSize: number): number {
 
   if (ratio <= 0.5) return 1;
 
-  if (isContentImage(contentItem)) {
-    const rating = contentItem.rating || 0;
+  const ratedItem = getRatedContentItem(contentItem);
+  if (ratedItem !== null) {
+    const rating = ratedItem.rating ?? 0;
 
     if (isHorizontal) {
       if (rating >= 4) return chunkSize;
@@ -175,6 +183,17 @@ export function getSlotWidth(contentItem: Content, chunkSize: number): number {
   }
 
   return 1;
+}
+
+/**
+ * Return the content item if it carries a layout rating (IMAGE or GIF), or
+ * null otherwise. Centralizes the rating-eligibility check so getSlotWidth
+ * treats animated and still media uniformly.
+ */
+function getRatedContentItem(item: Content): { rating?: number | null } | null {
+  if (isContentImage(item)) return item;
+  if (isGifContent(item)) return item;
+  return null;
 }
 
 /**

--- a/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
+++ b/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
@@ -44,6 +44,7 @@ import {
   type ContentTextModel,
 } from '@/app/types/Content';
 import { handleApiError } from '@/app/utils/apiUtils';
+import { isContentImage } from '@/app/utils/contentTypeGuards';
 import { createImageContent } from '@/tests/fixtures/contentFixtures';
 
 // Test fixtures
@@ -512,9 +513,15 @@ describe('handleSingleImageEdit', () => {
       const result = handleSingleImageEdit(1, content, processedContent);
 
       expect(result).toEqual(fullImage);
-      expect(result?.imageUrl).toBe('test.jpg');
-      expect(result?.imageWidth).toBe(1920);
-      expect(result?.rating).toBe(5);
+      // Narrow to the IMAGE branch — handleSingleImageEdit now returns
+      // ContentImageModel | ContentGifModel | null so image-only fields require a guard.
+      if (result && isContentImage(result)) {
+        expect(result.imageUrl).toBe('test.jpg');
+        expect(result.imageWidth).toBe(1920);
+        expect(result.rating).toBe(5);
+      } else {
+        throw new Error('expected result to be a ContentImageModel');
+      }
     });
   });
 

--- a/tests/utils/contentTypeGuards.test.ts
+++ b/tests/utils/contentTypeGuards.test.ts
@@ -500,11 +500,56 @@ describe('getSlotWidth', () => {
     });
   });
 
-  describe('GIF content', () => {
-    it('returns 1 for a standard GIF (falls through isContentImage check)', () => {
-      const gif = createGifContent(1, { width: 800, height: 600 });
-      // GIF has ratio > 1 but is not ContentImageModel, so falls through to return 1
-      expect(getSlotWidth(gif, CHUNK)).toBe(1);
+  describe('GIF content by rating (uses same logic as IMAGE)', () => {
+    describe('horizontal GIF (800x450, AR ~1.78)', () => {
+      it('returns chunkSize for rating 5', () => {
+        const gif = createGifContent(1, { width: 800, height: 450, rating: 5 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(CHUNK);
+      });
+
+      it('returns chunkSize for rating 4 (default for new uploads)', () => {
+        const gif = createGifContent(1, { width: 800, height: 450, rating: 4 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(CHUNK);
+      });
+
+      it('returns halfSlot for rating 3', () => {
+        const gif = createGifContent(1, { width: 800, height: 450, rating: 3 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(HALF);
+      });
+
+      it('returns 1 for rating 2', () => {
+        const gif = createGifContent(1, { width: 800, height: 450, rating: 2 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(1);
+      });
+
+      it('returns 1 for unrated GIF (rating null)', () => {
+        const gif = createGifContent(1, { width: 800, height: 450, rating: null });
+        expect(getSlotWidth(gif, CHUNK)).toBe(1);
+      });
+
+      it('returns 1 for unrated GIF (rating undefined)', () => {
+        const gif = createGifContent(1, { width: 800, height: 450 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(1);
+      });
+    });
+
+    describe('vertical GIF (450x800, AR ~0.56)', () => {
+      it('returns halfSlot for rating 4 (vertical penalty applied)', () => {
+        const gif = createGifContent(1, { width: 450, height: 800, rating: 4 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(HALF);
+      });
+
+      it('returns 1 for rating 2', () => {
+        const gif = createGifContent(1, { width: 450, height: 800, rating: 2 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(1);
+      });
+    });
+
+    describe('panorama GIF (1600x600, AR 2.67)', () => {
+      it('returns chunkSize regardless of rating', () => {
+        const gif = createGifContent(1, { width: 1600, height: 600, rating: 0 });
+        expect(getSlotWidth(gif, CHUNK)).toBe(CHUNK);
+      });
     });
   });
 });


### PR DESCRIPTION
- Type system: ViewableContent union, ContentGifModel gains collections + tags
- API: createGif/updateGif/deleteGif with ContentGifUpdateRequest in lib/api/content.ts
- Rating layout: getRating + getEffectiveRating widened to include GIFs so the row algorithm stops squashing them as priority-1 filler
- Type guards: add isGifContent, centralize rated-content lookup via getRatedContentItem
- Upload routing: ManageClient.handleMediaUpload partitions gif/mp4/mov through createGif() while still routing images through createImages()
- Click + fullscreen: ContentBlockWithFullScreen looks up real model by id; FullScreenModal renders <video autoPlay loop muted playsInline> for GIF; useFullScreenImage marks GIF loaded immediately
- Unified metadata modal: single ImageMetadataModal accepts (ContentImageModel | ContentGifModel)[] — renders looping <video> preview for GIFs, greys out Caption / Locations / People / Camera Settings (active for: Title, Alt, Author, Rating, Tags, Collections). Save/delete routes single-GIF actions to updateGif/deleteGif; otherwise existing batch image flow
- Tests: contentTypeGuards + manageUtils updated for GIF coverage