### PR TITLE
fix(fullscreen): keep mobile full-screen treatment on landscape phones

### DIFF
--- a/app/styles/fullscreen-image.module.scss
+++ b/app/styles/fullscreen-image.module.scss
@@ -1,3 +1,5 @@
+// Mobile-first. Desktop overrides also require height >= 600px (not just width
+// >= 768px) so a landscape phone — wide but short — keeps the mobile treatment. (0142)
 .imageFullScreenWrapper {
   position: fixed;
   top: 0;
@@ -20,7 +22,7 @@
   overscroll-behavior: none;
   touch-action: pan-x;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     flex-direction: row;
   }
 }
@@ -38,7 +40,7 @@
 
   touch-action: pan-x;
 
-  @media (width >= 768px) {
+  @media (width >= 768px) and (height >= 600px) {
     padding: var(--default-padding);
   }
 }
@@ -68,7 +70,7 @@
   background-color: white;
 
   // Use consistent padding for all screens larger than mobile
-  @media (width >= 768px) {
+  @media (width >= 768px) and (height >= 600px) {
     padding: 40px;
   }
 }
@@ -95,7 +97,7 @@
   user-select: none; /* Standard - prevents selection */
   pointer-events: auto; /* Keep interactions enabled for swipe detection */
 
-  @media (width >= 768px) {
+  @media (width >= 768px) and (height >= 600px) {
     max-width: calc(100vw - calc(var(--default-padding) * 2));
     max-height: calc(100vh - calc(var(--default-padding) * 2));
   }
@@ -107,7 +109,7 @@
   max-width: calc(100vw - 16px); // 8px padding * 2 for frame
   max-height: calc(100vh - calc(var(--default-padding) * 2) - 16px);
 
-  @media (width >= 768px) {
+  @media (width >= 768px) and (height >= 600px) {
     max-width: calc(100vw - calc(var(--default-padding) * 2) - 80px); // 40px padding * 2
     max-height: calc(100vh - calc(var(--default-padding) * 2) - 80px);
   }
@@ -159,7 +161,7 @@
   user-select: none; /* Prevents text selection on mobile */
   -webkit-tap-highlight-color: transparent; /* Removes iOS tap highlight */
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     width: 40px;
     height: 40px;
     font-size: 20px;
@@ -195,7 +197,7 @@
   margin-bottom: 0;
   margin-right: 0;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     padding: 16px 56px 16px 16px;
     font-size: 13px;
     max-height: 60vh;
@@ -219,7 +221,7 @@
   margin-bottom: 8px;
   color: white;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     font-size: 17px;
     margin-bottom: 10px;
   }
@@ -229,7 +231,7 @@
   margin-bottom: 6px;
   color: var(--color-overlay-light-90);
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     margin-bottom: 8px;
   }
 }
@@ -247,7 +249,7 @@
   padding-top: 8px;
   border-top: 1px solid var(--color-overlay-light-20);
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     gap: 16px;
     margin-bottom: 16px;
     padding-top: 10px;
@@ -263,7 +265,7 @@
   padding-top: 12px;
   border-top: 1px solid var(--color-overlay-light-20);
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     margin-top: 16px;
     padding-top: 16px;
   }
@@ -275,7 +277,7 @@
   align-items: center;
   gap: 8px;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     gap: 10px;
   }
 }
@@ -289,7 +291,7 @@
   margin-bottom: 0;
   flex-shrink: 0;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     font-size: 12px;
     margin-bottom: 0;
   }
@@ -301,7 +303,7 @@
   gap: 8px;
   align-items: center;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     gap: 10px;
   }
 }
@@ -314,7 +316,7 @@
   color: var(--color-overlay-light-90);
   user-select: none;
 
-  @media (width > 768px) {
+  @media (width > 768px) and (height >= 600px) {
     padding: 6px 10px;
     font-size: 12px;
   }
@@ -379,7 +381,7 @@
     outline: none;
   }
 
-  @media (width >= 768px) {
+  @media (width >= 768px) and (height >= 600px) {
     width: 56px;
     height: 80px;
     font-size: 44px;


### PR DESCRIPTION
## What

On mobile, rotating to landscape made a full-screen image show the **desktop** frame — a thick 40px white border, all-side padding, and a shrunk image — instead of the mobile full-screen treatment. This makes landscape full-screen match portrait full-screen.

## Root cause

Every "desktop" override in `app/styles/fullscreen-image.module.scss` was keyed on viewport **width** alone (`@media (width >= 768px)`). A phone in landscape is wide (>768px) but short (~390–430px tall), so it tripped the desktop branch:

- `.imageWrapperLoaded`: white frame 8px → **40px**
- `.overlayContainer`: padding vertical-only → **all sides**
- image `max-width`/`max-height` shrunk by 80px to make room for the 40px frame

Portrait phones (~390px wide) correctly stayed on the mobile base. It is pure CSS — the modal component has no JS orientation logic.

## Fix

Add `and (height >= 600px)` to the 16 desktop media queries (operators preserved). Landscape phones (≤450px tall) now keep the mobile treatment; tablets/desktops (≥600px tall) are unchanged. 600px sits in the empty gap between phone-landscape heights (≤450) and tablet-landscape heights (≥768).

## Verification (in-browser, computed styles on /chamonix modal)

| Viewport | Frame padding | Overlay padding | Flex |
|---|---|---|---|
| Portrait phone 390×844 | 8px | vertical-only | column |
| Landscape phone 844×390 — **after** | **8px** | vertical-only | column |
| Landscape phone 844×390 — before | 40px | all-sides | row |
| Desktop 1280×800 | 40px (unchanged) | all-sides | row |

Stylelint + Prettier clean.

## Scope note

This branch is stacked on the unmerged work line, so this PR against `main` includes ~32 commits / 28 files (gif, layout, contact-messages, etc.). The change specific to this MR is the single top commit `fix(fullscreen): keep mobile full-screen treatment on landscape phones`, touching only `app/styles/fullscreen-image.module.scss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
