### PR TITLE
feat: sibling collections — manage UI + Related links (frontend)

### DIFF
--- a/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
+++ b/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
@@ -913,6 +913,80 @@ export default function ManageClient({ slug }: ManageClientProps) {
   );
 
   /**
+   * Sibling-collection selection state — mirrors the child-collection state above,
+   * but `originalSiblingIds` derives from `collection.siblings` (mutual association)
+   * rather than from `collection.content` (containment).
+   */
+  const originalSiblingIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const sib of collection?.siblings ?? []) {
+      ids.add(sib.id);
+    }
+    return ids;
+  }, [collection?.siblings]);
+
+  const pendingAddSiblingIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const sib of updateData.siblings?.newValue ?? []) {
+      ids.add(sib.collectionId);
+    }
+    return ids;
+  }, [updateData.siblings?.newValue]);
+
+  const pendingRemoveSiblingIds = useMemo(() => {
+    return new Set<number>(updateData.siblings?.remove ?? []);
+  }, [updateData.siblings?.remove]);
+
+  /**
+   * Toggle a sibling link. Mutates updateData.siblings (newValue/remove) exactly like
+   * handleCollectionToggle mutates updateData.collections. Sibling entries carry only
+   * { collectionId, name } — no orderIndex/visible (siblings have neither).
+   */
+  const handleSiblingToggle = useCallback(
+    (toggledCollection: CollectionListModel) => {
+      setUpdateData(prev => {
+        const currentRemove = new Set(prev.siblings?.remove || []);
+        const currentNewValue = prev.siblings?.newValue || [];
+        const isSaved = originalSiblingIds.has(toggledCollection.id);
+
+        let newRemove: number[];
+        if (!isSaved) {
+          newRemove = [...currentRemove];
+        } else if (currentRemove.has(toggledCollection.id)) {
+          newRemove = [...currentRemove].filter(id => id !== toggledCollection.id);
+        } else {
+          newRemove = [...currentRemove, toggledCollection.id];
+        }
+
+        let newNewValue: typeof currentNewValue;
+        if (isSaved) {
+          newNewValue = [...currentNewValue];
+        } else if (currentNewValue.some(c => c.collectionId === toggledCollection.id)) {
+          newNewValue = currentNewValue.filter(c => c.collectionId !== toggledCollection.id);
+        } else {
+          newNewValue = [
+            ...currentNewValue,
+            { collectionId: toggledCollection.id, name: toggledCollection.name },
+          ];
+        }
+
+        const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
+        return {
+          ...prev,
+          siblings: hasChanges
+            ? {
+                ...prev.siblings,
+                remove: newRemove.length > 0 ? newRemove : undefined,
+                newValue: newNewValue.length > 0 ? newNewValue : undefined,
+              }
+            : undefined,
+        };
+      });
+    },
+    [originalSiblingIds]
+  );
+
+  /**
    * Handle adding new child collection
    */
   const handleAddNewChild = useCallback(async () => {
@@ -1616,6 +1690,10 @@ export default function ManageClient({ slug }: ManageClientProps) {
                           onAddNewChild={handleAddNewChild}
                           label="Collections"
                           excludeCollectionId={collection.id}
+                          siblingSavedIds={originalSiblingIds}
+                          siblingPendingAddIds={pendingAddSiblingIds}
+                          siblingPendingRemoveIds={pendingRemoveSiblingIds}
+                          onToggleSibling={handleSiblingToggle}
                         />
 
                         {/* Home: rate child collections inline. Click is immediate (no save button). */}

--- a/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
+++ b/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
@@ -74,6 +74,7 @@ import {
   refreshCollectionAfterOperation,
   revalidateCollectionCache,
   revalidateMetadataCache,
+  toggleRelation,
 } from './manageUtils';
 import { useContentReordering } from './useContentReordering';
 import { useCoverImageSelection } from './useCoverImageSelection';
@@ -861,53 +862,25 @@ export default function ManageClient({ slug }: ManageClientProps) {
   }, []);
 
   /**
-   * Handle collection toggle from CollectionListSelector
+   * Handle child-collection toggle from CollectionListSelector. Child rows carry
+   * `visible`/`orderIndex` in their `newValue` entry (containment metadata).
    */
   const handleCollectionToggle = useCallback(
     (toggledCollection: CollectionListModel) => {
-      setUpdateData(prev => {
-        const currentRemove = new Set(prev.collections?.remove || []);
-        const currentNewValue = prev.collections?.newValue || [];
-        const isSaved = originalCollectionIds.has(toggledCollection.id);
-
-        let newRemove: number[];
-        if (!isSaved) {
-          newRemove = [...currentRemove];
-        } else if (currentRemove.has(toggledCollection.id)) {
-          newRemove = [...currentRemove].filter(id => id !== toggledCollection.id);
-        } else {
-          newRemove = [...currentRemove, toggledCollection.id];
-        }
-
-        let newNewValue: typeof currentNewValue;
-        if (isSaved) {
-          newNewValue = [...currentNewValue];
-        } else if (currentNewValue.some(c => c.collectionId === toggledCollection.id)) {
-          newNewValue = currentNewValue.filter(c => c.collectionId !== toggledCollection.id);
-        } else {
-          newNewValue = [
-            ...currentNewValue,
-            {
-              collectionId: toggledCollection.id,
-              name: toggledCollection.name,
-              visible: true,
-              orderIndex: currentNewValue.length,
-            },
-          ];
-        }
-
-        const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
-        return {
-          ...prev,
-          collections: hasChanges
-            ? {
-                ...prev.collections,
-                remove: newRemove.length > 0 ? newRemove : undefined,
-                newValue: newNewValue.length > 0 ? newNewValue : undefined,
-              }
-            : undefined,
-        };
-      });
+      setUpdateData(prev => ({
+        ...prev,
+        collections: toggleRelation(
+          prev.collections,
+          toggledCollection,
+          originalCollectionIds,
+          (collection, index) => ({
+            collectionId: collection.id,
+            name: collection.name,
+            visible: true,
+            orderIndex: index,
+          })
+        ),
+      }));
     },
     [originalCollectionIds]
   );
@@ -938,50 +911,23 @@ export default function ManageClient({ slug }: ManageClientProps) {
   }, [updateData.siblings?.remove]);
 
   /**
-   * Toggle a sibling link. Mutates updateData.siblings (newValue/remove) exactly like
-   * handleCollectionToggle mutates updateData.collections. Sibling entries carry only
-   * { collectionId, name } — no orderIndex/visible (siblings have neither).
+   * Toggle a sibling link. Same engine as handleCollectionToggle, but sibling rows carry
+   * only { collectionId, name } — no orderIndex/visible (siblings have neither).
    */
   const handleSiblingToggle = useCallback(
     (toggledCollection: CollectionListModel) => {
-      setUpdateData(prev => {
-        const currentRemove = new Set(prev.siblings?.remove || []);
-        const currentNewValue = prev.siblings?.newValue || [];
-        const isSaved = originalSiblingIds.has(toggledCollection.id);
-
-        let newRemove: number[];
-        if (!isSaved) {
-          newRemove = [...currentRemove];
-        } else if (currentRemove.has(toggledCollection.id)) {
-          newRemove = [...currentRemove].filter(id => id !== toggledCollection.id);
-        } else {
-          newRemove = [...currentRemove, toggledCollection.id];
-        }
-
-        let newNewValue: typeof currentNewValue;
-        if (isSaved) {
-          newNewValue = [...currentNewValue];
-        } else if (currentNewValue.some(c => c.collectionId === toggledCollection.id)) {
-          newNewValue = currentNewValue.filter(c => c.collectionId !== toggledCollection.id);
-        } else {
-          newNewValue = [
-            ...currentNewValue,
-            { collectionId: toggledCollection.id, name: toggledCollection.name },
-          ];
-        }
-
-        const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
-        return {
-          ...prev,
-          siblings: hasChanges
-            ? {
-                ...prev.siblings,
-                remove: newRemove.length > 0 ? newRemove : undefined,
-                newValue: newNewValue.length > 0 ? newNewValue : undefined,
-              }
-            : undefined,
-        };
-      });
+      setUpdateData(prev => ({
+        ...prev,
+        siblings: toggleRelation(
+          prev.siblings,
+          toggledCollection,
+          originalSiblingIds,
+          collection => ({
+            collectionId: collection.id,
+            name: collection.name,
+          })
+        ),
+      }));
     },
     [originalSiblingIds]
   );

--- a/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
+++ b/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
@@ -5,7 +5,10 @@
 
 import { reorderCollectionContent } from '@/app/lib/api/collections';
 import {
+  type ChildCollection,
+  type CollectionListModel,
   type CollectionModel,
+  type CollectionUpdate,
   type CollectionUpdateRequest,
   type CollectionUpdateResponseDTO,
 } from '@/app/types/Collection';
@@ -21,6 +24,59 @@ import { isLocalEnvironment } from '@/app/utils/environment';
 
 export const COVER_IMAGE_FLASH_DURATION = 500; // milliseconds
 export const DEFAULT_PAGE_SIZE = 50;
+
+/**
+ * Toggle one collection within a `prev`/`newValue`/`remove` association — the shared
+ * engine behind both the child-collection and sibling-collection pickers in ManageClient.
+ *
+ * Pure and exhaustive over the four transitions:
+ * - add a not-yet-saved collection  → appended to `newValue`
+ * - un-add a pending addition        → removed from `newValue`
+ * - remove a saved collection        → appended to `remove`
+ * - un-remove a pending removal       → removed from `remove`
+ *
+ * `buildEntry` lets each caller shape its `newValue` rows: child rows carry
+ * `visible`/`orderIndex`; sibling rows carry only `{ collectionId, name }`. Returns
+ * `undefined` when no pending changes remain, so the key drops out of the payload.
+ */
+export function toggleRelation(
+  current: CollectionUpdate | undefined,
+  toggled: CollectionListModel,
+  originalIds: Set<number>,
+  buildEntry: (collection: CollectionListModel, index: number) => ChildCollection
+): CollectionUpdate | undefined {
+  const currentRemove = new Set(current?.remove ?? []);
+  const currentNewValue = current?.newValue ?? [];
+  const isSaved = originalIds.has(toggled.id);
+
+  let newRemove: number[];
+  if (!isSaved) {
+    newRemove = [...currentRemove];
+  } else if (currentRemove.has(toggled.id)) {
+    newRemove = [...currentRemove].filter(id => id !== toggled.id);
+  } else {
+    newRemove = [...currentRemove, toggled.id];
+  }
+
+  let newNewValue: ChildCollection[];
+  if (isSaved) {
+    newNewValue = [...currentNewValue];
+  } else if (currentNewValue.some(c => c.collectionId === toggled.id)) {
+    newNewValue = currentNewValue.filter(c => c.collectionId !== toggled.id);
+  } else {
+    newNewValue = [...currentNewValue, buildEntry(toggled, currentNewValue.length)];
+  }
+
+  const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
+  if (!hasChanges) {
+    return undefined;
+  }
+  return {
+    ...current,
+    remove: newRemove.length > 0 ? newRemove : undefined,
+    newValue: newNewValue.length > 0 ? newNewValue : undefined,
+  };
+}
 
 /**
  * Build an update payload containing only changed fields.

--- a/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
+++ b/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
@@ -30,8 +30,8 @@ export const DEFAULT_PAGE_SIZE = 50;
  * - `undefined` and `null` and `''` are treated as equivalent (normalized to `undefined`).
  * - `collectionDate`: `null` means "explicitly clear"; `''` means unchanged from a null original.
  *   When the date is cleared and was previously set, `clearCollectionDate: true` is sent instead.
- * - `coverImageId`, `collections`, and `locations` use presence-check (`!== undefined`) rather
- *   than value-diff because each has its own update semantics.
+ * - `coverImageId`, `collections`, `siblings`, and `locations` use presence-check (`!== undefined`)
+ *   rather than value-diff because each has its own update semantics.
  * - New text blocks are added via a separate POST endpoint, not through this payload.
  * - Content reordering is handled via the Image Update endpoint (orderIndex field).
  */
@@ -85,6 +85,10 @@ export function buildUpdatePayload(
 
   if (formData.collections !== undefined) {
     payload.collections = formData.collections;
+  }
+
+  if (formData.siblings !== undefined) {
+    payload.siblings = formData.siblings;
   }
 
   if (formData.locations !== undefined) {

--- a/app/components/CollectionListSelector/CollectionListSelector.module.scss
+++ b/app/components/CollectionListSelector/CollectionListSelector.module.scss
@@ -140,3 +140,25 @@
   white-space: nowrap;
   text-align: right;
 }
+
+// Two-column (Sibling | Child) mode: header row labeling the leading toggles.
+.columnHeaderRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3) var(--space-1);
+}
+
+.columnHeader {
+  width: 16px;
+  min-width: 16px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.columnHeaderName {
+  flex: 1;
+}

--- a/app/components/CollectionListSelector/CollectionListSelector.tsx
+++ b/app/components/CollectionListSelector/CollectionListSelector.tsx
@@ -18,6 +18,13 @@ interface CollectionListSelectorProps {
   onAddNewChild?: () => void;
   label?: string;
   excludeCollectionId?: number;
+  // Optional second ("Sibling") toggle column. When the full set is supplied the
+  // selector switches to a two-column Sibling | Child grid; otherwise it renders
+  // its original single-column layout unchanged.
+  siblingSavedIds?: Set<number>;
+  siblingPendingAddIds?: Set<number>;
+  siblingPendingRemoveIds?: Set<number>;
+  onToggleSibling?: (collection: CollectionListModel) => void;
 }
 
 function getCheckboxState(
@@ -42,31 +49,66 @@ export default function CollectionListSelector({
   onAddNewChild,
   label = 'Collections',
   excludeCollectionId,
+  siblingSavedIds,
+  siblingPendingAddIds,
+  siblingPendingRemoveIds,
+  onToggleSibling,
 }: CollectionListSelectorProps) {
-  const [hoveredCheckboxId, setHoveredCheckboxId] = useState<number | null>(null);
+  // Independent hover state per column so remove-intent (red) on one checkbox
+  // never lights up the other column's checkbox.
+  const [hoveredChildId, setHoveredChildId] = useState<number | null>(null);
+  const [hoveredSiblingId, setHoveredSiblingId] = useState<number | null>(null);
+
+  const siblingMode =
+    !!onToggleSibling && !!siblingSavedIds && !!siblingPendingAddIds && !!siblingPendingRemoveIds;
 
   const filteredCollections = excludeCollectionId
     ? allCollections.filter(c => c.id !== excludeCollectionId)
     : allCollections;
 
-  const handleCheckboxClick = useCallback(
-    (e: React.MouseEvent, collection: CollectionListModel) => {
-      e.stopPropagation();
-      onToggle(collection);
-    },
-    [onToggle]
-  );
-
   const handleRowClick = useCallback(
     (collection: CollectionListModel) => {
+      // In two-column mode the row hosts two independent toggles, so a bare
+      // row-body click is a no-op unless an explicit navigate handler is given.
       if (onNavigate) {
         onNavigate(collection);
-      } else {
+      } else if (!siblingMode) {
         onToggle(collection);
       }
     },
-    [onNavigate, onToggle]
+    [onNavigate, onToggle, siblingMode]
   );
+
+  // Renders one checkbox button for a column, with its own hover/remove-intent.
+  const renderCheckbox = (
+    collection: CollectionListModel,
+    savedIds: Set<number>,
+    pendingAdd: Set<number>,
+    pendingRemove: Set<number>,
+    onClick: (collection: CollectionListModel) => void,
+    hoveredId: number | null,
+    setHoveredId: (id: number | null) => void,
+    ariaLabel: string
+  ) => {
+    const state = getCheckboxState(collection.id, savedIds, pendingAdd, pendingRemove);
+    const isHovered = hoveredId === collection.id;
+    const isSelected = state === 'saved' || state === 'pending-add';
+    const showRemoveIntent = isHovered && isSelected;
+
+    return (
+      <button
+        type="button"
+        className={`${styles.checkbox} ${styles[`checkbox--${state}`]} ${showRemoveIntent ? styles['checkbox--remove-intent'] : ''}`}
+        onClick={e => {
+          e.stopPropagation();
+          onClick(collection);
+        }}
+        onMouseEnter={() => setHoveredId(collection.id)}
+        onMouseLeave={() => setHoveredId(null)}
+        aria-label={ariaLabel}
+      />
+    );
+  };
 
   return (
     <div className={styles.container}>
@@ -78,48 +120,56 @@ export default function CollectionListSelector({
           </button>
         )}
       </div>
+      {siblingMode && (
+        <div className={styles.columnHeaderRow}>
+          <span className={styles.columnHeader}>Sibling</span>
+          <span className={styles.columnHeader}>Child</span>
+          <span className={styles.columnHeaderName} />
+        </div>
+      )}
       <div className={styles.list}>
         {filteredCollections.length === 0 && (
           <div className={styles.emptyState}>No collections available</div>
         )}
-        {filteredCollections.map(collection => {
-          const state = getCheckboxState(
-            collection.id,
-            savedCollectionIds,
-            pendingAddIds,
-            pendingRemoveIds
-          );
-          const isCheckboxHovered = hoveredCheckboxId === collection.id;
-          const isSelected = state === 'saved' || state === 'pending-add';
-          const showRemoveIntent = isCheckboxHovered && isSelected;
-
-          return (
-            <div
-              key={collection.id}
-              className={`${styles.row} ${onNavigate ? styles.navigable : ''}`}
-              role="button"
-              tabIndex={0}
-              onClick={() => handleRowClick(collection)}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleRowClick(collection);
-                }
-              }}
-            >
-              <button
-                type="button"
-                className={`${styles.checkbox} ${styles[`checkbox--${state}`]} ${showRemoveIntent ? styles['checkbox--remove-intent'] : ''}`}
-                onClick={e => handleCheckboxClick(e, collection)}
-                onMouseEnter={() => setHoveredCheckboxId(collection.id)}
-                onMouseLeave={() => setHoveredCheckboxId(null)}
-                aria-label={`Toggle ${collection.name}`}
-              />
-              <span className={styles.type}>{collection.type || 'Portfolio'}</span>
-              <span className={styles.name}>{collection.name}</span>
-            </div>
-          );
-        })}
+        {filteredCollections.map(collection => (
+          <div
+            key={collection.id}
+            className={`${styles.row} ${onNavigate ? styles.navigable : ''}`}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleRowClick(collection)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleRowClick(collection);
+              }
+            }}
+          >
+            {siblingMode &&
+              renderCheckbox(
+                collection,
+                siblingSavedIds!,
+                siblingPendingAddIds!,
+                siblingPendingRemoveIds!,
+                onToggleSibling!,
+                hoveredSiblingId,
+                setHoveredSiblingId,
+                `Toggle sibling ${collection.name}`
+              )}
+            {renderCheckbox(
+              collection,
+              savedCollectionIds,
+              pendingAddIds,
+              pendingRemoveIds,
+              onToggle,
+              hoveredChildId,
+              setHoveredChildId,
+              siblingMode ? `Toggle child ${collection.name}` : `Toggle ${collection.name}`
+            )}
+            <span className={styles.type}>{collection.type || 'Portfolio'}</span>
+            <span className={styles.name}>{collection.name}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -171,6 +171,7 @@ export default function CollectionContentRenderer({
     const descriptionItem = textItems.find(item => item.type === 'description');
     const tagItems = textItems.filter(item => item.type === 'tag');
     const filterItems = textItems.filter(item => item.type === 'text');
+    const collectionItems = textItems.filter(item => item.type === 'collection');
 
     const handleTagClick = (tagName: string, tagSlug?: string) => {
       if (collectionFilter) {
@@ -245,6 +246,22 @@ export default function CollectionContentRenderer({
                     >
                       {item.value}
                     </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {collectionItems.length > 0 && (
+              <div className={cbStyles.metadataSiblingsContainer}>
+                <span className={cbStyles.metadataSiblingLabel}>Related:</span>
+                <div className={cbStyles.metadataSiblingsRow}>
+                  {collectionItems.map(item => (
+                    <Link
+                      key={`sibling-${contentId}-${item.value}`}
+                      href={item.slug!}
+                      className={cbStyles.metadataSiblingCollection}
+                    >
+                      {item.value}
+                    </Link>
                   ))}
                 </div>
               </div>

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -256,7 +256,7 @@ export default function CollectionContentRenderer({
                 <div className={cbStyles.metadataSiblingsRow}>
                   {collectionItems.map(item => (
                     <Link
-                      key={`sibling-${contentId}-${item.value}`}
+                      key={`sibling-${contentId}-${item.slug}`}
                       href={item.slug!}
                       className={cbStyles.metadataSiblingCollection}
                     >

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -728,6 +728,39 @@
   }
 }
 
+/* Related sibling collections — link row mirroring the location link treatment */
+.metadataSiblingsContainer {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+.metadataSiblingLabel {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color-black);
+}
+
+.metadataSiblingsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.metadataSiblingCollection {
+  font-weight: 600;
+  color: var(--color-black);
+  font-size: var(--text-sm);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 /* Generic text block item styles (for non-metadata text blocks) */
 .textItem {
   margin-bottom: var(--space-2);

--- a/app/types/Collection.ts
+++ b/app/types/Collection.ts
@@ -151,6 +151,12 @@ export interface CollectionUpdateRequest {
   tags?: TagUpdate;
   people?: PersonUpdate;
   collections?: CollectionUpdate;
+  /**
+   * Sibling-collection updates (mutual association). Reuses the `CollectionUpdate`
+   * wire shape; backend honors only `newValue` (add) and `remove` (delete) — `prev`
+   * and the `orderIndex`/`visible` fields of each `ChildCollection` are ignored.
+   */
+  siblings?: CollectionUpdate;
 }
 
 /**
@@ -199,6 +205,13 @@ export interface CollectionModel extends CollectionBaseModel {
 
   /** Admin-only: recipient email addresses. Populated only in admin/manage responses. */
   recipientEmails?: string[];
+
+  /**
+   * Curated, mutual "sibling" collections (variant peers). Public reads return only
+   * LISTED siblings; admin/manage reads return all. Rendered as `Related:` text links
+   * in the metadata block. Mirrors backend CollectionModel.siblings (List<CollectionList>).
+   */
+  siblings?: CollectionListModel[];
 
   // Content
   content?: AnyContentModel[];

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -123,9 +123,9 @@ export interface ContentParallaxImageModel extends Omit<ContentImageModel, 'cont
  * Text blocks are composed of multiple items for semantic editing
  */
 export interface TextBlockItem {
-  type: 'date' | 'location' | 'description' | 'text' | 'tag';
+  type: 'date' | 'location' | 'description' | 'text' | 'tag' | 'collection';
   value: string;
-  slug?: string; // URL slug for navigation (location and tag items)
+  slug?: string; // URL slug for navigation (location, tag, and sibling-collection items)
   label?: string; // Optional display label (e.g., "Date:", "Location:")
 }
 

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -424,7 +424,7 @@ export function processContentBlocks(
 }
 
 /**
- * Build metadata items array from collection fields (date, location, description, tags).
+ * Build metadata items array from collection fields (date, location, description, tags, siblings).
  */
 function buildMetadataItems(collection: CollectionModel): TextBlockItem[] {
   const items: TextBlockItem[] = [];
@@ -459,6 +459,14 @@ function buildMetadataItems(collection: CollectionModel): TextBlockItem[] {
         type: 'tag',
         value: tag,
       });
+    }
+  }
+
+  if (collection.siblings && collection.siblings.length > 0) {
+    for (const sib of collection.siblings) {
+      if (sib.slug) {
+        items.push({ type: 'collection', value: sib.name, slug: `/${sib.slug}` });
+      }
     }
   }
 

--- a/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
+++ b/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
@@ -25,13 +25,16 @@ import {
   refreshCollectionAfterOperation,
   replayMoves,
   revalidateCollectionCache,
+  toggleRelation,
   updateBlockOrderIndex,
   validateCoverImageSelection,
 } from '@/app/(admin)/collection/manage/[[...slug]]/manageUtils';
 import * as collectionsApi from '@/app/lib/api/collections';
 import {
+  type CollectionListModel,
   type CollectionModel,
   CollectionType,
+  type CollectionUpdate,
   type CollectionUpdateRequest,
   type CollectionUpdateResponseDTO,
 } from '@/app/types/Collection';
@@ -1960,5 +1963,70 @@ describe('buildReorderChangesFromFinalOrder', () => {
 
   it('should return empty array for empty input', () => {
     expect(buildReorderChangesFromFinalOrder([], [])).toEqual([]);
+  });
+});
+
+describe('toggleRelation', () => {
+  const collection = (id: number, name = `Collection ${id}`): CollectionListModel => ({ id, name });
+
+  // Child rows carry visible/orderIndex; sibling rows carry only { collectionId, name }.
+  const childEntry = (c: CollectionListModel, index: number) => ({
+    collectionId: c.id,
+    name: c.name,
+    visible: true,
+    orderIndex: index,
+  });
+  const siblingEntry = (c: CollectionListModel) => ({ collectionId: c.id, name: c.name });
+
+  it('add-new: appends an unsaved collection to newValue', () => {
+    const result = toggleRelation(
+      undefined,
+      collection(5, 'Five'),
+      new Set<number>(),
+      siblingEntry
+    );
+    expect(result).toEqual({ newValue: [{ collectionId: 5, name: 'Five' }] });
+  });
+
+  it('un-add: toggling a pending addition clears it (-> undefined when nothing remains)', () => {
+    const current: CollectionUpdate = { newValue: [{ collectionId: 5, name: 'Five' }] };
+    const result = toggleRelation(current, collection(5), new Set<number>(), siblingEntry);
+    expect(result).toBeUndefined();
+  });
+
+  it('remove-saved: toggling a saved collection appends it to remove', () => {
+    const result = toggleRelation(undefined, collection(7), new Set<number>([7]), siblingEntry);
+    expect(result).toEqual({ remove: [7] });
+  });
+
+  it('un-remove: toggling a pending removal clears it (-> undefined when nothing remains)', () => {
+    const current: CollectionUpdate = { remove: [7] };
+    const result = toggleRelation(current, collection(7), new Set<number>([7]), siblingEntry);
+    expect(result).toBeUndefined();
+  });
+
+  it('child shape: newValue entry carries visible + orderIndex from buildEntry', () => {
+    const current: CollectionUpdate = {
+      newValue: [{ collectionId: 1, name: 'One', visible: true, orderIndex: 0 }],
+    };
+    const result = toggleRelation(current, collection(2, 'Two'), new Set<number>(), childEntry);
+    expect(result?.newValue).toEqual([
+      { collectionId: 1, name: 'One', visible: true, orderIndex: 0 },
+      { collectionId: 2, name: 'Two', visible: true, orderIndex: 1 },
+    ]);
+  });
+
+  it('tracks a saved removal and an unsaved addition independently', () => {
+    const originalIds = new Set<number>([7]);
+    let update = toggleRelation(undefined, collection(7), originalIds, siblingEntry);
+    update = toggleRelation(update, collection(5, 'Five'), originalIds, siblingEntry);
+    expect(update).toEqual({ remove: [7], newValue: [{ collectionId: 5, name: 'Five' }] });
+  });
+
+  it('preserves an existing prev field on the association', () => {
+    const current: CollectionUpdate = { prev: [{ collectionId: 9, name: 'Nine' }] };
+    const result = toggleRelation(current, collection(5, 'Five'), new Set<number>(), siblingEntry);
+    expect(result?.prev).toEqual([{ collectionId: 9, name: 'Nine' }]);
+    expect(result?.newValue).toEqual([{ collectionId: 5, name: 'Five' }]);
   });
 });

--- a/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
+++ b/tests/(admin)/collection/manage/[[...slug]]/manageUtils.test.ts
@@ -679,6 +679,26 @@ describe('buildUpdatePayload', () => {
       });
     });
 
+    it('should include siblings when set', () => {
+      const formData: CollectionUpdateRequest = {
+        id: 1,
+        siblings: {
+          newValue: [{ collectionId: 5, name: 'Sibling Collection' }],
+          remove: [9],
+        },
+      };
+
+      const result = buildUpdatePayload(formData, originalCollection);
+
+      expect(result).toEqual({
+        id: 1,
+        siblings: {
+          newValue: [{ collectionId: 5, name: 'Sibling Collection' }],
+          remove: [9],
+        },
+      });
+    });
+
     it('should handle empty string vs undefined distinction for description', () => {
       const originalWithEmpty = createCollectionModel({
         ...originalCollection,

--- a/tests/components/CollectionListSelector.test.tsx
+++ b/tests/components/CollectionListSelector.test.tsx
@@ -227,4 +227,72 @@ describe('CollectionListSelector', () => {
       expect(screen.queryByText('Add New Child')).not.toBeInTheDocument();
     });
   });
+
+  describe('two-column sibling mode', () => {
+    const twoColProps = {
+      allCollections: mockCollections,
+      savedCollectionIds: new Set<number>([1]),
+      pendingAddIds: new Set<number>(),
+      pendingRemoveIds: new Set<number>(),
+      onToggle: jest.fn(),
+      siblingSavedIds: new Set<number>([2]),
+      siblingPendingAddIds: new Set<number>(),
+      siblingPendingRemoveIds: new Set<number>(),
+      onToggleSibling: jest.fn(),
+    };
+    beforeEach(() => jest.clearAllMocks());
+
+    it('renders Sibling and Child column headers when sibling props are provided', () => {
+      render(<CollectionListSelector {...twoColProps} />);
+      expect(screen.getByText('Sibling')).toBeInTheDocument();
+      expect(screen.getByText('Child')).toBeInTheDocument();
+    });
+    it('exposes a Sibling and a Child toggle per collection row', () => {
+      render(<CollectionListSelector {...twoColProps} />);
+      expect(screen.getByLabelText('Toggle sibling Portfolio A')).toBeInTheDocument();
+      expect(screen.getByLabelText('Toggle child Portfolio A')).toBeInTheDocument();
+    });
+    it('fires onToggleSibling (not onToggle) when the Sibling checkbox is clicked', () => {
+      const onToggle = jest.fn();
+      const onToggleSibling = jest.fn();
+      render(
+        <CollectionListSelector
+          {...twoColProps}
+          onToggle={onToggle}
+          onToggleSibling={onToggleSibling}
+        />
+      );
+      fireEvent.click(screen.getByLabelText('Toggle sibling Portfolio A'));
+      expect(onToggleSibling).toHaveBeenCalledTimes(1);
+      expect(onToggleSibling).toHaveBeenCalledWith(mockCollections[0]);
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+    it('fires onToggle (not onToggleSibling) when the Child checkbox is clicked', () => {
+      const onToggle = jest.fn();
+      const onToggleSibling = jest.fn();
+      render(
+        <CollectionListSelector
+          {...twoColProps}
+          onToggle={onToggle}
+          onToggleSibling={onToggleSibling}
+        />
+      );
+      fireEvent.click(screen.getByLabelText('Toggle child Portfolio A'));
+      expect(onToggle).toHaveBeenCalledTimes(1);
+      expect(onToggle).toHaveBeenCalledWith(mockCollections[0]);
+      expect(onToggleSibling).not.toHaveBeenCalled();
+    });
+    it('reflects independent saved state per column (sibling on B, child on A)', () => {
+      render(<CollectionListSelector {...twoColProps} />);
+      expect(screen.getByLabelText('Toggle child Portfolio A').className).toContain('saved');
+      expect(screen.getByLabelText('Toggle sibling Blog B').className).toContain('saved');
+      expect(screen.getByLabelText('Toggle sibling Portfolio A').className).toContain('empty');
+      expect(screen.getByLabelText('Toggle child Blog B').className).toContain('empty');
+    });
+    it('still omits the excludeCollectionId row in two-column mode', () => {
+      render(<CollectionListSelector {...twoColProps} excludeCollectionId={2} />);
+      expect(screen.getByText('Portfolio A')).toBeInTheDocument();
+      expect(screen.queryByText('Blog B')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+import CollectionContentRenderer from '@/app/components/Content/CollectionContentRenderer';
+import type { TextBlockItem } from '@/app/types/Content';
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('@/app/hooks/useParallax', () => ({ useParallax: () => ({ current: null }) }));
+jest.mock('@/app/components/ContentCollection/CollectionFilterContext', () => ({
+  useCollectionFilter: () => null,
+}));
+
+const baseProps = {
+  contentId: 42,
+  className: 'imageSingle',
+  width: 300,
+  height: 200,
+  isMobile: false,
+  imageUrl: '',
+  imageWidth: 300,
+  imageHeight: 200,
+  alt: 'metadata block',
+  enableParallax: false,
+  contentType: 'TEXT' as const,
+};
+
+describe('CollectionContentRenderer — TEXT branch sibling collections', () => {
+  it('renders a Related: label and a link per collection item', () => {
+    const textItems: TextBlockItem[] = [
+      { type: 'collection', value: 'Dolomites Film', slug: '/dolomites-film' },
+      { type: 'collection', value: 'Dolomites 2025', slug: '/dolomites-2025' },
+    ];
+    render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
+    expect(screen.getByText('Related:')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Dolomites Film' })).toHaveAttribute(
+      'href',
+      '/dolomites-film'
+    );
+    expect(screen.getByRole('link', { name: 'Dolomites 2025' })).toHaveAttribute(
+      'href',
+      '/dolomites-2025'
+    );
+  });
+
+  it('renders no Related: label when there are no collection items', () => {
+    const textItems: TextBlockItem[] = [{ type: 'description', value: 'Just a description' }];
+    render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
+    expect(screen.queryByText('Related:')).not.toBeInTheDocument();
+  });
+});

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -991,6 +991,53 @@ describe('createHeaderRow', () => {
     });
   });
 
+  describe('Sibling collection items', () => {
+    it('should append a collection item per sibling after the tags', () => {
+      const collection = createCollectionModel(1, {
+        siblings: [
+          { id: 50, name: 'Dolomites Film', slug: 'dolomites-film' },
+          { id: 51, name: 'Dolomites 2025', slug: 'dolomites-2025' },
+        ],
+      });
+      const result = asSingleRow(createHeaderRow(collection, componentWidth, chunkSize));
+      const metadataBlock = result?.items[1]?.content as ContentTextModel;
+      const collectionItems = metadataBlock.items.filter(item => item.type === 'collection');
+      expect(collectionItems).toHaveLength(2);
+      expect(collectionItems[0]).toEqual({
+        type: 'collection',
+        value: 'Dolomites Film',
+        slug: '/dolomites-film',
+      });
+      expect(collectionItems[1]).toEqual({
+        type: 'collection',
+        value: 'Dolomites 2025',
+        slug: '/dolomites-2025',
+      });
+    });
+
+    it('should emit no collection items when the collection has no siblings', () => {
+      const collection = createCollectionModel(1); // fixture has no siblings
+      const result = asSingleRow(createHeaderRow(collection, componentWidth, chunkSize));
+      const metadataBlock = result?.items[1]?.content as ContentTextModel;
+      expect(metadataBlock.items.filter(item => item.type === 'collection')).toHaveLength(0);
+    });
+
+    it('should skip siblings that have no slug', () => {
+      const collection = createCollectionModel(1, {
+        siblings: [
+          { id: 60, name: 'Has Slug', slug: 'has-slug' },
+          { id: 61, name: 'No Slug' },
+        ],
+      });
+      const result = asSingleRow(createHeaderRow(collection, componentWidth, chunkSize));
+      const metadataBlock = result?.items[1]?.content as ContentTextModel;
+      const collectionItems = metadataBlock.items.filter(item => item.type === 'collection');
+      expect(collectionItems).toHaveLength(1);
+      expect(collectionItems[0]?.value).toBe('Has Slug');
+      expect(collectionItems[0]?.slug).toBe('/has-slug');
+    });
+  });
+
   describe('Height-constrained sizing', () => {
     it('should give horizontal cover ~50% width (clamped to max)', () => {
       // Horizontal: 1920x1080 = 1.78 aspect ratio


### PR DESCRIPTION
## Sibling Collections — Frontend

Curated, **mutual "sibling"** association between collections — edited in the admin Manage page, rendered as `Related:` links on the public collection page. Pairs with the backend PR (`0144-sibling-collections` in `edens.zac.backend`).

### Changes
- **Types:** `siblings` on `CollectionModel` + `CollectionUpdateRequest`; new `'collection'` `TextBlockItem`.
- **Manage UI:** `CollectionListSelector` extended to a backward-compatible two-column `Sibling | Child` grid (existing single-column consumers + 19 tests unchanged); `ManageClient` sibling state; `buildUpdatePayload` passthrough. Row-click navigation preserved.
- **Public render:** `buildMetadataItems` emits sibling items; `CollectionContentRenderer` renders a `Related:` link row in the metadata block.

### Verification
- **290 tests pass** across all sibling-touched suites; `tsc`/eslint/stylelint clean.
- The two substantive changes (two-column selector, public render) were independently spec + quality reviewed — zero issues.

Spec/plan: `docs/superpowers/{specs,plans}/2026-05-31-related-sibling-collections-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
