### PR TITLE
fix(parallax): bound travel to actual overflow so the grey never shows

### DIFF
--- a/app/components/Content/ParallaxImageRenderer.module.scss
+++ b/app/components/Content/ParallaxImageRenderer.module.scss
@@ -8,9 +8,9 @@
   display: block;
   object-fit: cover;
   width: 100%;
-  height: 130%; /* PARALLAX_CONSTANTS.IMAGE_HEIGHT_PERCENTAGE */
+  height: 130%; /* 30% taller than the card: overflow available for parallax travel */
   position: absolute;
-  top: -25%; /* PARALLAX_CONSTANTS.IMAGE_TOP_OFFSET */
+  top: -15%; /* symmetric: 15% overflow above and 15% below (130% - 100% - 15%) */
   left: 0;
   z-index: var(--z-base);
   cursor: inherit;

--- a/app/components/LocationPage/LocationCollections.module.scss
+++ b/app/components/LocationPage/LocationCollections.module.scss
@@ -52,7 +52,7 @@
   width: 100%;
   height: 130%;
   position: absolute;
-  top: -25%;
+  top: -15%; /* symmetric: 15% overflow above and 15% below for parallax travel */
   left: 0;
   will-change: transform;
 }
@@ -61,7 +61,7 @@
   width: 100%;
   height: 130%;
   position: absolute;
-  top: -25%;
+  top: -15%; /* symmetric: 15% overflow above and 15% below for parallax travel */
   left: 0;
   background: var(--surface-secondary, #e0e0e0);
 }

--- a/app/components/LocationPage/LocationCollections.tsx
+++ b/app/components/LocationPage/LocationCollections.tsx
@@ -23,7 +23,8 @@ function CollectionCard({ collection }: CollectionCardProps) {
             <Image
               src={collection.coverImage.imageUrl}
               alt={collection.title}
-              fill
+              width={collection.coverImage.imageWidth ?? collection.coverImage.width ?? 400}
+              height={collection.coverImage.imageHeight ?? collection.coverImage.height ?? 225}
               sizes="(min-width: 768px) 200px, 140px"
               className={`${styles.cardImage} parallax-bg`}
             />

--- a/app/constants/parallax.ts
+++ b/app/constants/parallax.ts
@@ -21,10 +21,11 @@ export const PARALLAX_CONSTANTS = {
   FADE_IN_DELAY: '0.1s',
   FADE_IN_DURATION: '0.4s',
 
-  // Parallax offset range (in pixels)
-  // Asymmetric: -75px upward travel (increased from -50), +100px downward buffer (prevents bottom-of-image showing on entry)
-  OFFSET_MIN: -75,
-  OFFSET_MAX: 100,
+  // Fraction of the available pixel overflow actually used for parallax travel.
+  // Travel is derived per-card from the live overflow (see app/utils/parallaxMath.ts),
+  // so a value < 1 leaves a sub-pixel margin that prevents rounding from ever
+  // revealing the grey container behind the image.
+  TRAVEL_SAFETY: 0.9,
 
   // Viewport height adjustment (accounts for fixed header and mobile chrome UI)
   VIEWPORT_HEIGHT_OFFSET: 200,

--- a/app/hooks/useParallax.ts
+++ b/app/hooks/useParallax.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 
 import { PARALLAX_CONSTANTS } from '@/app/constants/parallax';
+import { computeParallaxOffset, getParallaxBudgets } from '@/app/utils/parallaxMath';
 
 import { useInViewport } from './inViewport';
 
@@ -15,12 +16,14 @@ interface ParallaxOptions {
  * useParallax Hook
  *
  * Viewport-based parallax effect that scrolls images based on their visibility
- * in the viewport. Images are scaled to 130% (15% overflow above and below).
+ * in the viewport. The image is scaled larger than its container (e.g. 130%) so
+ * it overflows on both edges; the parallax travel is bounded by that actual
+ * overflow (read from live layout) so the grey container is never revealed.
  *
  * Behavior:
- * - When element enters bottom of viewport: image positioned at top (-15%)
- * - When element exits top of viewport: image positioned at bottom (+15%)
- * - Scroll position interpolates linearly between these states
+ * - Entering bottom of viewport: image at its highest position (bottom edge aligned)
+ * - Exiting top of viewport: image at its lowest position (top edge aligned)
+ * - Scroll position interpolates linearly between these states, scaled by TRAVEL_SAFETY
  *
  * @dependencies
  * - useInViewport for visibility detection and intersection ratio
@@ -80,9 +83,17 @@ export function useParallax(options: ParallaxOptions = {}) {
 
         const scrollProgress = Math.max(0, Math.min(1, currentPosition / travelDistance));
 
-        // Calculate parallax offset using configured range
-        const offsetRange = PARALLAX_CONSTANTS.OFFSET_MAX - PARALLAX_CONSTANTS.OFFSET_MIN;
-        const newOffset = PARALLAX_CONSTANTS.OFFSET_MIN + scrollProgress * offsetRange;
+        // Derive the travel budget from the image's ACTUAL overflow (read from live
+        // layout), so the offset can never exceed it and reveal the grey container —
+        // at any card height. offsetTop/offsetHeight are transform-independent.
+        const containerHeight =
+          (parallaxBg.offsetParent as HTMLElement | null)?.clientHeight ?? element.offsetHeight;
+        const { upBudgetPx, downBudgetPx } = getParallaxBudgets(
+          parallaxBg.offsetTop,
+          parallaxBg.offsetHeight,
+          containerHeight
+        );
+        const newOffset = computeParallaxOffset(scrollProgress, upBudgetPx, downBudgetPx);
 
         if (
           lastOffsetRef.current === undefined ||

--- a/app/utils/parallaxMath.ts
+++ b/app/utils/parallaxMath.ts
@@ -1,0 +1,57 @@
+import { PARALLAX_CONSTANTS } from '@/app/constants/parallax';
+
+/**
+ * Available vertical parallax travel, in pixels, derived from the rendered
+ * geometry of the parallax background element.
+ *
+ * The background image is absolutely positioned, taller than its clipping
+ * container (e.g. `height: 130%`) and offset upward (e.g. `top: -15%`), so it
+ * overflows the container on both edges. Those overflow amounts are the exact
+ * distances the image may translate before the grey container shows through.
+ *
+ * Reading the values from live layout (rather than hard-coding the CSS
+ * percentages) keeps the hook correct for any card height and self-correcting
+ * if the CSS overflow ever changes.
+ *
+ * @param restTopPx - Untransformed top offset of the element (`offsetTop`); negative when offset upward.
+ * @param imageHeightPx - Rendered height of the element (`offsetHeight`).
+ * @param containerHeightPx - Content height of the clipping container.
+ * @returns `downBudgetPx` (max downward/positive travel before the TOP edge reveals grey) and
+ *          `upBudgetPx` (max upward/negative travel before the BOTTOM edge reveals grey). Both >= 0.
+ */
+export function getParallaxBudgets(
+  restTopPx: number,
+  imageHeightPx: number,
+  containerHeightPx: number
+): { upBudgetPx: number; downBudgetPx: number } {
+  return {
+    downBudgetPx: Math.max(0, -restTopPx),
+    upBudgetPx: Math.max(0, restTopPx + imageHeightPx - containerHeightPx),
+  };
+}
+
+/**
+ * Parallax `translateY` (px) for a given scroll progress, bounded so the image
+ * never travels further than its available overflow. This guarantees the grey
+ * container is never revealed, at any card height or scroll position.
+ *
+ * Maps `scrollProgress` 0 -> full upward travel (`-up`) and 1 -> full downward
+ * travel (`+down`); the neutral (0) position sits where the up/down budgets
+ * balance (the card's center for symmetric overflow).
+ *
+ * @param scrollProgress - 0..1 visibility progress through the viewport (clamped).
+ * @param upBudgetPx - Max upward (negative) travel before bottom grey, in px.
+ * @param downBudgetPx - Max downward (positive) travel before top grey, in px.
+ * @param safety - Fraction of the budget actually used; < 1 leaves a sub-pixel margin so rounding never reveals grey.
+ */
+export function computeParallaxOffset(
+  scrollProgress: number,
+  upBudgetPx: number,
+  downBudgetPx: number,
+  safety: number = PARALLAX_CONSTANTS.TRAVEL_SAFETY
+): number {
+  const progress = Math.max(0, Math.min(1, scrollProgress));
+  const up = Math.max(0, upBudgetPx) * safety;
+  const down = Math.max(0, downBudgetPx) * safety;
+  return -up + progress * (up + down);
+}

--- a/tests/utils/parallaxMath.test.ts
+++ b/tests/utils/parallaxMath.test.ts
@@ -1,0 +1,80 @@
+import { PARALLAX_CONSTANTS } from '@/app/constants/parallax';
+import { computeParallaxOffset, getParallaxBudgets } from '@/app/utils/parallaxMath';
+
+describe('getParallaxBudgets', () => {
+  it('splits overflow evenly for symmetric geometry (height 130%, top -15%)', () => {
+    const H = 400;
+    const { upBudgetPx, downBudgetPx } = getParallaxBudgets(-0.15 * H, 1.3 * H, H);
+    expect(downBudgetPx).toBeCloseTo(0.15 * H); // 60px before top grey
+    expect(upBudgetPx).toBeCloseTo(0.15 * H); // 60px before bottom grey
+  });
+
+  it('reflects the old asymmetric geometry (top -25%) as a starved bottom budget', () => {
+    const H = 400;
+    const { upBudgetPx, downBudgetPx } = getParallaxBudgets(-0.25 * H, 1.3 * H, H);
+    expect(downBudgetPx).toBeCloseTo(0.25 * H); // 100px top budget
+    expect(upBudgetPx).toBeCloseTo(0.05 * H); // only 20px bottom budget — the root of the bug
+  });
+
+  it('never returns negative budgets', () => {
+    const { upBudgetPx, downBudgetPx } = getParallaxBudgets(0, 100, 200);
+    expect(upBudgetPx).toBe(0);
+    expect(downBudgetPx).toBe(0);
+  });
+});
+
+describe('computeParallaxOffset', () => {
+  const up = 60;
+  const down = 60;
+
+  it('is full upward (negative) at scrollProgress 0', () => {
+    expect(computeParallaxOffset(0, up, down, 1)).toBeCloseTo(-60);
+  });
+
+  it('is full downward (positive) at scrollProgress 1', () => {
+    expect(computeParallaxOffset(1, up, down, 1)).toBeCloseTo(60);
+  });
+
+  it('is neutral (0) at scrollProgress 0.5 for symmetric budgets', () => {
+    expect(computeParallaxOffset(0.5, up, down, 1)).toBeCloseTo(0);
+  });
+
+  it('clamps scrollProgress outside [0, 1]', () => {
+    expect(computeParallaxOffset(-1, up, down, 1)).toBeCloseTo(-60);
+    expect(computeParallaxOffset(2, up, down, 1)).toBeCloseTo(60);
+  });
+
+  it('applies the safety factor', () => {
+    expect(computeParallaxOffset(1, up, down, 0.9)).toBeCloseTo(54);
+    expect(computeParallaxOffset(0, up, down, 0.9)).toBeCloseTo(-54);
+  });
+
+  it('uses the configured safety factor by default', () => {
+    expect(computeParallaxOffset(1, up, down)).toBeCloseTo(60 * PARALLAX_CONSTANTS.TRAVEL_SAFETY);
+  });
+
+  // Core invariant: the offset NEVER exceeds the available overflow on either
+  // edge, so the grey container can never be revealed — at any height/progress.
+  it('never exceeds the available budget on either edge (no grey, any height)', () => {
+    for (const H of [120, 311, 500, 1500]) {
+      const { upBudgetPx, downBudgetPx } = getParallaxBudgets(-0.15 * H, 1.3 * H, H);
+      for (let p = 0; p <= 1.0001; p += 0.05) {
+        const offset = computeParallaxOffset(p, upBudgetPx, downBudgetPx);
+        expect(offset).toBeGreaterThanOrEqual(-upBudgetPx - 1e-9);
+        expect(offset).toBeLessThanOrEqual(downBudgetPx + 1e-9);
+      }
+    }
+  });
+
+  it('stays within even the starved bottom budget of the old asymmetric geometry', () => {
+    // The old fixed-px code translated to -75px here, far past the ~15px bottom
+    // budget of a 311px card — exactly what produced the grey strip.
+    const H = 311;
+    const { upBudgetPx, downBudgetPx } = getParallaxBudgets(-0.25 * H, 1.3 * H, H);
+    for (let p = 0; p <= 1.0001; p += 0.05) {
+      const offset = computeParallaxOffset(p, upBudgetPx, downBudgetPx);
+      expect(offset).toBeGreaterThanOrEqual(-upBudgetPx - 1e-9);
+      expect(offset).toBeLessThanOrEqual(downBudgetPx + 1e-9);
+    }
+  });
+});


### PR DESCRIPTION
Parallax cards revealed the grey container below the image whenever they sat low in the viewport (bottom-of-page cards especially, which can't be scrolled past the neutral point). Root cause was a units mismatch: the overflow budget is a percentage of card height (CSS height:130% + top:-25% => 25% top / 5% bottom) while the travel was a fixed pixel range (-75..+100px). The 5% bottom budget can't absorb 75px of upward travel except on cards taller than ~1500px, so the grey showed for normal cards.

- Derive the travel budget per-card from live layout overflow (app/utils/parallaxMath.ts) so the offset can never exceed it, at any height
- Make .parallaxImage and LocationCollections overflow symmetric (top:-15%)
- Replace the fixed OFFSET_MIN/MAX with a TRAVEL_SAFETY factor
- LocationCollections: drop next/image `fill` (its inline height:100%/inset:0 overrode the overflow and disabled parallax); pass explicit width/height
- Add unit tests for the offset math, including the no-grey invariant