### PR TITLE
feat(gif-metadata): enable People + Location editing on GIF/MP4

### DIFF
--- a/app/components/ImageMetadata/ImageMetadataModal.tsx
+++ b/app/components/ImageMetadata/ImageMetadataModal.tsx
@@ -35,6 +35,7 @@ import { hasObjectChanges } from '@/app/utils/objectComparison';
 
 import styles from './ImageMetadataModal.module.scss';
 import {
+  buildContentPeopleLocationsDiff,
   buildImageUpdateDiff,
   buildImageUpdateForSingleEdit,
   buildImageUpdatesForBulkEdit,
@@ -336,6 +337,15 @@ export default function ImageMetadataModal({
             remove: remove.length > 0 ? remove : undefined,
           };
         }
+        // People + locations: reuse the same prev/newValue/remove builders the image path uses, so
+        // a GIF/MP4 can carry general relational metadata. Only attach keys that actually changed.
+        const { people, locations } = buildContentPeopleLocationsDiff(updateState, original);
+        if (people !== undefined) {
+          payload.people = people;
+        }
+        if (locations !== undefined) {
+          payload.locations = locations;
+        }
 
         const updated =
           Object.keys(payload).length > 0 ? await updateGif(original.id, payload) : original;
@@ -603,11 +613,7 @@ export default function ImageMetadataModal({
               />
             </div>
 
-            <div
-              style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
-              aria-disabled={isGif}
-              title={isGif ? 'Locations are not yet supported on GIF/MP4 content.' : undefined}
-            >
+            <div>
               <UnifiedMetadataSelector<LocationModel>
                 label="Locations"
                 multiSelect
@@ -1007,11 +1013,7 @@ export default function ImageMetadataModal({
               emptyText="No tags selected"
             />
 
-            <div
-              style={isGif ? { opacity: 0.4, pointerEvents: 'none' } : undefined}
-              aria-disabled={isGif}
-              title={isGif ? 'People are not yet supported on GIF/MP4 content.' : undefined}
-            >
+            <div>
               <UnifiedMetadataSelector<ContentPersonModel>
                 label="People"
                 multiSelect

--- a/app/components/ImageMetadata/imageMetadataUtils.ts
+++ b/app/components/ImageMetadata/imageMetadataUtils.ts
@@ -470,7 +470,7 @@ function buildLensDiff(
 function buildLocationsDiffField(
   updateLocations: LocationModel[] | undefined,
   currentLocations: LocationModel[] | undefined,
-  diff: ContentImageUpdateRequest
+  diff: Pick<ContentImageUpdateRequest, 'locations'>
 ): void {
   const locationUpdate = buildLocationsDiff(updateLocations ?? [], currentLocations ?? []);
 
@@ -564,7 +564,7 @@ function buildTagsDiff(
 function buildPeopleDiff(
   updatePeople: ContentImageModel['people'],
   currentPeople: ContentImageModel['people'],
-  diff: ContentImageUpdateRequest
+  diff: Pick<ContentImageUpdateRequest, 'people'>
 ): void {
   const updatePeopleArray = updatePeople || [];
   const currentPeopleArray = currentPeople || [];
@@ -716,6 +716,36 @@ export function buildImageUpdateDiff(
   buildTagsDiff(updateState.tags, currentState.tags, diff);
   buildPeopleDiff(updateState.people, currentState.people, diff);
   buildCollectionsDiff(updateState.collections, currentState.collections, diff);
+
+  return diff;
+}
+
+/**
+ * Build ONLY the people + locations diffs (prev/newValue/remove) for any content type.
+ *
+ * Reuses the exact same private builders as the image diff path ({@link buildPeopleDiff} and
+ * {@link buildLocationsDiffField}) so the prev/newValue/remove logic is never duplicated. The
+ * GIF/MP4 save path calls this and copies the resulting keys onto its own update request — people
+ * and locations are general relational metadata that both images and GIFs share.
+ *
+ * @param updateState - The edited people/locations (selected in the modal)
+ * @param currentState - The original people/locations on the content block
+ * @returns An object with `people` and/or `locations` set only when they changed; `{}` if unchanged
+ */
+export function buildContentPeopleLocationsDiff(
+  updateState: {
+    people?: ContentImageModel['people'];
+    locations?: LocationModel[];
+  },
+  currentState: {
+    people?: ContentImageModel['people'];
+    locations?: LocationModel[];
+  }
+): Pick<ContentImageUpdateRequest, 'people' | 'locations'> {
+  const diff: Pick<ContentImageUpdateRequest, 'people' | 'locations'> = {};
+
+  buildPeopleDiff(updateState.people, currentState.people, diff);
+  buildLocationsDiffField(updateState.locations, currentState.locations, diff);
 
   return diff;
 }

--- a/app/lib/api/content.ts
+++ b/app/lib/api/content.ts
@@ -14,7 +14,12 @@ import {
   fetchAdminPostJsonApi,
   fetchReadApi,
 } from '@/app/lib/api/core';
-import { type CollectionUpdate, type TagUpdate } from '@/app/types/Collection';
+import {
+  type CollectionUpdate,
+  type LocationUpdate,
+  type PersonUpdate,
+  type TagUpdate,
+} from '@/app/types/Collection';
 import {
   type ContentGifModel,
   type ContentImageModel,
@@ -197,13 +202,19 @@ export async function createGif(collectionId: number, file: File): Promise<Conte
  * Patch payload for {@link updateGif}. Only non-null fields are applied on the backend.
  *
  * Mirrors the slice of {@link ContentImageUpdateRequest} that makes sense for animated content —
- * no EXIF/equipment fields. `tags` and `collections` use the prev/newValue/remove pattern so a
- * single request can add, remove, and re-order memberships at once.
+ * no EXIF/equipment fields. `tags`, `people`, `locations`, and `collections` use the
+ * prev/newValue/remove pattern so a single request can add, remove, and re-order memberships at
+ * once. People + locations are general relational metadata (not EXIF), so a GIF/MP4 can carry them
+ * just like an image.
  */
 export interface ContentGifUpdateRequest {
   title?: string;
   rating?: number;
   tags?: TagUpdate;
+  /** Person updates using prev/newValue/remove pattern (many-to-many) */
+  people?: PersonUpdate;
+  /** Location updates using prev/newValue/remove pattern (many-to-many) */
+  locations?: LocationUpdate;
   collections?: CollectionUpdate;
 }
 
@@ -219,8 +230,9 @@ export async function deleteGif(id: number): Promise<{ deletedId: number } | nul
 
 /**
  * PATCH /api/admin/content/gifs/{id}
- * Update title/rating on an existing GIF/MP4 content block. The backend mirrors the IMAGE
- * update slice that makes sense for animated content — no EXIF/equipment fields.
+ * Update title/rating/tags/people/locations/collections on an existing GIF/MP4 content block. The
+ * backend mirrors the IMAGE update slice that makes sense for animated content — no EXIF/equipment
+ * fields.
  */
 export async function updateGif(
   id: number,

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -169,6 +169,17 @@ export interface ContentGifModel extends Content {
   rating?: number | null;
   tags?: ContentTagModel[];
   /**
+   * People associated with this GIF/MP4. Many-to-many via the content-level people join, mirroring
+   * {@link ContentImageModel.people}. Used by the metadata modal's People selector so a GIF can be
+   * tagged with the people in it.
+   */
+  people?: ContentPersonModel[];
+  /**
+   * Locations associated with this GIF/MP4. Many-to-many via the content-level location join,
+   * mirroring {@link ContentImageModel.locations}. Used by the metadata modal's Location selector.
+   */
+  locations?: LocationModel[];
+  /**
    * Collections this GIF/MP4 belongs to. Many-to-many via the same `collection_content` join
    * table that images use. Used by the metadata modal's collection selector so the admin can
    * surface a single GIF in multiple galleries.

--- a/tests/components/ImageMetadata/imageMetadataUtils.test.ts
+++ b/tests/components/ImageMetadata/imageMetadataUtils.test.ts
@@ -5,6 +5,7 @@
 
 import {
   applyPartialUpdate,
+  buildContentPeopleLocationsDiff,
   buildImageUpdateDiff,
   buildImageUpdateForSingleEdit,
   buildImageUpdatesForBulkEdit,
@@ -2172,5 +2173,94 @@ describe('computeCameraSelectionUpdate', () => {
   it('null prev.filmFormat and null camera default → filmFormat is null', () => {
     const result = computeCameraSelectionUpdate(filmCameraNoFormat, { filmFormat: null });
     expect(result.filmFormat).toBeNull();
+  });
+});
+
+describe('buildContentPeopleLocationsDiff (shared people/locations builder for GIF/MP4)', () => {
+  it('returns an empty object when nothing changed', () => {
+    const original = {
+      people: [{ id: 1, name: 'Person 1', slug: 'person-1' }],
+      locations: [{ id: 5, name: 'Seattle', slug: 'seattle' }],
+    };
+    const updateState = {
+      people: [{ id: 1, name: 'Person 1', slug: 'person-1' }],
+      locations: [{ id: 5, name: 'Seattle', slug: 'seattle' }],
+    };
+
+    const result = buildContentPeopleLocationsDiff(updateState, original);
+
+    expect(result).toEqual({});
+  });
+
+  it('builds prev for added existing people (same prev/newValue/remove shape as images)', () => {
+    const original = { people: [], locations: [] };
+    const updateState = {
+      people: [
+        { id: 1, name: 'Person 1', slug: 'person-1' },
+        { id: 2, name: 'Person 2', slug: 'person-2' },
+      ],
+      locations: [],
+    };
+
+    const result = buildContentPeopleLocationsDiff(updateState, original);
+
+    expect(result.people).toEqual({ prev: [1, 2] });
+    expect(result.locations).toBeUndefined();
+  });
+
+  it('builds newValue for brand-new people and remove for dropped people', () => {
+    const original = {
+      people: [{ id: 9, name: 'Old Person', slug: 'old-person' }],
+      locations: [],
+    };
+    const updateState = {
+      people: [{ id: 0, name: 'New Person', slug: '' }],
+      locations: [],
+    };
+
+    const result = buildContentPeopleLocationsDiff(updateState, original);
+
+    expect(result.people).toEqual({
+      newValue: ['New Person'],
+      remove: [9],
+    });
+  });
+
+  it('builds a locations diff with prev/newValue/remove for a GIF', () => {
+    const original = {
+      people: [],
+      locations: [{ id: 5, name: 'Seattle', slug: 'seattle' }],
+    };
+    const updateState = {
+      people: [],
+      locations: [
+        { id: 6, name: 'Portland', slug: 'portland' },
+        { id: 0, name: 'Tacoma', slug: '' },
+      ],
+    };
+
+    const result = buildContentPeopleLocationsDiff(updateState, original);
+
+    expect(result.locations).toEqual({
+      prev: [6],
+      newValue: ['Tacoma'],
+      remove: [5],
+    });
+    expect(result.people).toBeUndefined();
+  });
+
+  it('builds both people and locations diffs together', () => {
+    const original = { people: [], locations: [] };
+    const updateState = {
+      people: [{ id: 3, name: 'Person 3', slug: 'person-3' }],
+      locations: [{ id: 7, name: 'Olympia', slug: 'olympia' }],
+    };
+
+    const result = buildContentPeopleLocationsDiff(updateState, original);
+
+    expect(result).toEqual({
+      people: { prev: [3] },
+      locations: { prev: [7] },
+    });
   });
 });


### PR DESCRIPTION
## Summary
Enables the **People** and **Location** selectors when editing a GIF/MP4 in the shared `ImageMetadataModal`, and sends those keys to the backend.

- Adds `people?` + `locations?` to `ContentGifUpdateRequest` and `ContentGifModel`.
- Builds the people/location diffs in the GIF save path by **reusing the existing image builders** (`buildPeopleDiff` / `buildLocationsDiffField`) — no duplicated prev/newValue/remove logic.
- Removes the `isGif` "not yet supported" disable wrappers from the People + Location selectors only (Caption + EXIF/equipment stay image-only).

Cherry-picked clean onto `main` (disjoint from recent parallax/fullscreen changes).

## Depends on
Backend PR (`edens.zac.backend` #97): GIF people/locations support + the content-level join generalization. The modal pre-populates a GIF's existing people/locations from the backend read, so this should land after the backend deploys.

## Test plan
- [x] `jest tests/components/ImageMetadata tests/lib` -> 254 pass (5 new cases for `buildContentPeopleLocationsDiff`); `tsc --noEmit` clean on touched files
- [ ] CI green on this branch (re-run against current main)
- [ ] After backend deploy: edit a GIF's people + location -> persists + pre-populates on reopen

## Follow-up (separate)
Switch the FE off the `caption <-> description` alias now that the backend returns a real `caption` (backend PR #97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)