### PR TITLE
fix(design/001): Phase 0 foundation — canvas color, alias tokens, dead-nav cleanup

### DIFF
--- a/app/(admin)/admin/adminTiles.ts
+++ b/app/(admin)/admin/adminTiles.ts
@@ -10,12 +10,12 @@ export interface AdminTileMerged extends AdminTileConfig {
 
 // tileKey values must match rows seeded by V19__admin_home_tiles.sql in the
 // backend repo. The backend table has 10 keys; this list intentionally only
-// renders 5 (the others - metadata, comments, create, manage, about - live
-// in MenuDropdown instead).
+// renders a subset (the others - metadata, comments, create, manage, about -
+// live in MenuDropdown instead). The 'blogs' tile is omitted until a
+// /all-blogs listing route exists (tracked in the 001 IA+UX sub-plan).
 export const ADMIN_TILES: AdminTileConfig[] = [
-  { tileKey: 'home',             label: 'Home (Preview)',   href: '/homePage' },
-  { tileKey: 'all-collections',  label: 'All Collections',  href: '/all-collections' },
-  { tileKey: 'all-images',       label: 'All Images',       href: '/all-images' },
-  { tileKey: 'blogs',            label: 'Blogs',            href: '/all-blogs' },
+  { tileKey: 'home', label: 'Home (Preview)', href: '/homePage' },
+  { tileKey: 'all-collections', label: 'All Collections', href: '/all-collections' },
+  { tileKey: 'all-images', label: 'All Images', href: '/all-images' },
   { tileKey: 'client-galleries', label: 'Client Galleries', href: '/all-client-galleries' },
 ];

--- a/app/components/About/About.tsx
+++ b/app/components/About/About.tsx
@@ -2,18 +2,12 @@ import Image from 'next/image';
 
 import styles from './About.module.scss';
 
-interface AboutProps {
-  onBack: () => void;
-}
-
 /**
  * About Component
  *
  * Personal introduction displaying profile image and bio text.
- *
- * @param props.onBack - Callback to return to previous view (currently unused)
  */
-export function About({ onBack: _onBack }: AboutProps) {
+export function About() {
   return (
     <div className={styles.aboutContainer}>
       <div className={styles.contentWrapper}>

--- a/app/components/ContactForm/ContactForm.tsx
+++ b/app/components/ContactForm/ContactForm.tsx
@@ -9,11 +9,10 @@ import styles from './ContactForm.module.scss';
 type Status = 'idle' | 'submitting' | 'success' | 'error';
 
 interface ContactFormProps {
-  onBack: () => void;
   onSubmit: () => void;
 }
 
-export function ContactForm({ onBack: _onBack, onSubmit }: ContactFormProps) {
+export function ContactForm({ onSubmit }: ContactFormProps) {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   const [status, setStatus] = useState<Status>('idle');

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -73,14 +73,6 @@ export function MenuDropdown({
       router.push('/comments');
       onClose();
     },
-    manage: () => {
-      router.push('/collection/manage');
-      onClose();
-    },
-    blogs: () => {
-      router.push('/all-blogs');
-      onClose();
-    },
     instagram: () => {
       window.open('https://instagram.com/themancalledzac', '_blank', 'noopener,noreferrer');
       onClose();
@@ -100,11 +92,6 @@ export function MenuDropdown({
       setShowContactForm(prev => !prev);
       setShowAbout(false);
     },
-  };
-
-  const handleBackToMenu = () => {
-    setShowContactForm(false);
-    setShowAbout(false);
   };
 
   const handleContactSubmit = () => {
@@ -184,7 +171,7 @@ export function MenuDropdown({
           </button>
         </div>
 
-        {showAbout && <About onBack={handleBackToMenu} />}
+        {showAbout && <About />}
 
         <div className={styles.dropdownMenuItem}>
           <button
@@ -196,32 +183,19 @@ export function MenuDropdown({
           </button>
         </div>
 
-        {showContactForm && (
-          <ContactForm onBack={handleBackToMenu} onSubmit={handleContactSubmit} />
+        {showContactForm && <ContactForm onSubmit={handleContactSubmit} />}
+
+        {isLocalEnvironment() && (
+          <div className={styles.dropdownMenuItem}>
+            <button
+              type="button"
+              className={styles.dropdownMenuButton}
+              onClick={handleNavigation.create}
+            >
+              <span className={styles.dropdownMenuOptions}>Create</span>
+            </button>
+          </div>
         )}
-
-        <div className={styles.dropdownMenuItem}>
-          <button
-            type="button"
-            className={styles.dropdownMenuButton}
-            onClick={handleNavigation.blogs}
-          >
-            <span className={styles.dropdownMenuOptions}>Blogs</span>
-          </button>
-        </div>
-
-        {isLocalEnvironment() &&
-          (pageType === 'collection' || pageType === 'collectionsCollection') && (
-            <div className={styles.dropdownMenuItem}>
-              <button
-                type="button"
-                className={styles.dropdownMenuButton}
-                onClick={handleNavigation.create}
-              >
-                <span className={styles.dropdownMenuOptions}>Create</span>
-              </button>
-            </div>
-          )}
 
         {isLocalEnvironment() && pageType === 'collection' && (
           <div className={styles.dropdownMenuItem}>
@@ -243,18 +217,6 @@ export function MenuDropdown({
               onClick={handleNavigation.metadata}
             >
               <span className={styles.dropdownMenuOptions}>Metadata</span>
-            </button>
-          </div>
-        )}
-
-        {isLocalEnvironment() && (
-          <div className={styles.dropdownMenuItem}>
-            <button
-              type="button"
-              className={styles.dropdownMenuButton}
-              onClick={handleNavigation.manage}
-            >
-              <span className={styles.dropdownMenuOptions}>Create</span>
             </button>
           </div>
         )}

--- a/app/components/SiteHeader/SiteHeader.module.scss
+++ b/app/components/SiteHeader/SiteHeader.module.scss
@@ -46,7 +46,7 @@
     /* Mobile base font-size */
     font-size: var(--header-1);
     font-weight: 600;
-    color: black;
+    color: var(--color-fg);
     transition: color 0.2s ease;
 
     &:hover {
@@ -89,7 +89,7 @@
   width: var(--space-6);
   height: var(--space-6);
   cursor: pointer;
-  color: black;
+  color: var(--color-fg);
   transition: color 0.2s ease;
   stroke-width: 2.5; /* Base stroke width for mobile */
 

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -145,6 +145,23 @@ html,
   --z-modal: 1000; /* Modal backdrops */
   --z-modal-controls: 1002; /* Modal close buttons */
   --z-fullscreen: 9999; /* Fullscreen overlays */
+
+  /* ── Compatibility aliases: map the previously-undeclared "shadow namespace"
+     onto real tokens so silent hex fallbacks stop winning. Non-breaking.
+     These are the migration seam; the Phase 4 token collapse renames usages
+     onto the semantic roles and then deletes this block. ── */
+  --text-primary: var(--color-text-primary); /* was silently #333 */
+  --text-secondary: var(--color-text-secondary); /* was silently #666 */
+  --text-muted: var(--color-text-muted); /* was silently #999 */
+  --text-base: var(--text-md); /* font-size, ManageClient */
+  --border-color: var(--color-border); /* was silently #ddd */
+  --color-bg-subtle: var(--color-bg-light);
+  --color-bg-muted: var(--color-bg-medium);
+  --surface-secondary: var(--color-bg-light);
+  --color-accent: var(--color-blue); /* selection/link accent */
+  --radius-sm: var(--radius-1);
+  --color-warning: #f4b400; /* RatingStars; net-new token */
+  --color-overlay-light-80: rgb(255, 255, 255, 0.8); /* gap in the 05..90 ramp */
 }
 
 /* Desktop heading sizes */
@@ -158,6 +175,7 @@ html,
 
 body {
   background-color: var(--color-bg);
+  color: var(--color-fg);
   padding: 0;
   margin: 0;
   font-family: var(--font-sans), serif;

--- a/tests/components/ContactForm.test.tsx
+++ b/tests/components/ContactForm.test.tsx
@@ -10,7 +10,7 @@ const mockSubmit = contactApi.submitContactMessage as jest.MockedFunction<
 >;
 
 describe('ContactForm', () => {
-  const defaultProps = { onBack: jest.fn(), onSubmit: jest.fn() };
+  const defaultProps = { onSubmit: jest.fn() };
 
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
First section of the **001 Design System Unification** chapter (Phase 0 — foundation).

## Changes
**fix(foundation)** — bind `color: var(--color-fg)` on `body` (the background already shipped in the 0144 fullscreen work); declare a ~12-token compatibility alias layer (`--text-primary`, `--border-color`, `--color-accent`, `--color-warning`, the `--color-overlay-light-80` ramp gap, …) so previously-undeclared tokens stop silently falling back to hex and the admin UI becomes themeable; SiteHeader title/menu use `var(--color-fg)` instead of a hardcoded `black`.

**fix(nav)** — remove the dead `/all-blogs` 404 link (MenuDropdown + adminTiles), collapse the duplicate "Create" menu item to one (kept the better-named handler, broadened its gate so off-collection behavior is unchanged), and drop the never-wired `onBack` prop from About (now no-prop) and ContactForm (onSubmit-only) plus the orphaned `handleBackToMenu`.

## Verification
- `eslint` / `stylelint` clean; `tsc --noEmit` no new errors; **full jest 1363/1363 pass**.
- Browser (:3001): 404 readable (`color rgb(17,17,17)` on white), SiteHeader title token-driven with **no** text-shadow, menu shows a single "Create" and no "Blogs", no console errors.

Note: Task 0.2 (FsDebug) was already on main; the review/doc claim that the nav cleanup had shipped was **stale** — verified via grep and completed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)