### PR TITLE
fix(security): gate /all-collections and /all-images behind admin auth

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -56,7 +56,11 @@ export function proxy(request: NextRequest) {
     pathname === '/comments' ||
     pathname.startsWith('/comments/') ||
     pathname === '/metadata' ||
-    pathname.startsWith('/metadata/');
+    pathname.startsWith('/metadata/') ||
+    pathname === '/all-collections' ||
+    pathname.startsWith('/all-collections/') ||
+    pathname === '/all-images' ||
+    pathname.startsWith('/all-images/');
 
   if (!isAdminRoute) {
     return NextResponse.next();
@@ -102,5 +106,9 @@ export const config = {
     '/comments/:path*',
     '/metadata',
     '/metadata/:path*',
+    '/all-collections',
+    '/all-collections/:path*',
+    '/all-images',
+    '/all-images/:path*',
   ],
 };

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -144,6 +144,52 @@ describe('proxy middleware — existing /comments admin gating (regression)', ()
   });
 });
 
+describe('proxy middleware — /all-collections admin gating', () => {
+  it('passes /all-collections through on localhost', () => {
+    setLocal();
+    const res = proxy(makeRequest('/all-collections'));
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('returns 403 on /all-collections in prod when admin routes disabled', () => {
+    setProd();
+    process.env.ADMIN_ROUTES_ENABLED = 'false';
+    const res = proxy(makeRequest('/all-collections'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 on /all-collections in prod when admin routes enabled but auth missing', () => {
+    setProd();
+    process.env.ADMIN_ROUTES_ENABLED = 'true';
+    process.env.ADMIN_TOKEN = 'secret123';
+    const res = proxy(makeRequest('/all-collections'));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('proxy middleware — /all-images admin gating', () => {
+  it('passes /all-images through on localhost', () => {
+    setLocal();
+    const res = proxy(makeRequest('/all-images'));
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('returns 403 on /all-images in prod when admin routes disabled', () => {
+    setProd();
+    process.env.ADMIN_ROUTES_ENABLED = 'false';
+    const res = proxy(makeRequest('/all-images'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 on /all-images in prod when admin routes enabled but auth missing', () => {
+    setProd();
+    process.env.ADMIN_ROUTES_ENABLED = 'true';
+    process.env.ADMIN_TOKEN = 'secret123';
+    const res = proxy(makeRequest('/all-images'));
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('proxy middleware — non-matching paths', () => {
   it('passes unrelated paths through on localhost', () => {
     setLocal();


### PR DESCRIPTION
Both routes live under app/(admin)/ but were missing from the proxy middleware matcher, so they were publicly reachable in production — /all-images even self-documents "Dev/Admin Only". Add both to the isAdminRoute check and config.matcher, mirroring the existing /comments and /metadata gating. The (admin) route group has no layout.tsx, so the middleware is the sole auth enforcement point.

Adds 6 proxy tests (local passthrough, 403 when admin disabled, 401 when enabled but unauthenticated) for each route. 24/24 proxy tests pass.