### PR TITLE
fix(image-metadata): guard camera optimistic-create swap + surface fa…

### DIFF
--- a/app/components/ImageMetadata/ImageMetadataModal.tsx
+++ b/app/components/ImageMetadata/ImageMetadataModal.tsx
@@ -88,6 +88,7 @@ export default function ImageMetadataModal({
     pendingAddIds,
     pendingRemoveIds,
     handleCollectionToggle,
+    replaceOptimisticCamera,
   } = useImageMetadataState({ selectedImages, selectedImageIds, availableLocations });
 
   const { saving, error, handleSubmit, handleCancel, handleDelete, handleRemoveFromCollection } =
@@ -150,6 +151,7 @@ export default function ImageMetadataModal({
             <CameraSettingsSection
               updateState={updateState}
               updateStateField={updateStateField}
+              replaceOptimisticCamera={replaceOptimisticCamera}
               availableCameras={availableCameras}
               availableLenses={availableLenses}
               availableFilmTypes={availableFilmTypes}

--- a/app/components/ImageMetadata/hooks/useImageMetadataState.ts
+++ b/app/components/ImageMetadata/hooks/useImageMetadataState.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type CollectionListModel, type LocationModel } from '@/app/types/Collection';
 import { type ContentGifModel, type ContentImageModel } from '@/app/types/Content';
+import { type ContentCameraModel } from '@/app/types/ImageMetadata';
 import { convertLocationsToModels } from '@/app/utils/locationUtils';
 import { hasObjectChanges } from '@/app/utils/objectComparison';
 
@@ -35,6 +36,7 @@ export interface UseImageMetadataStateResult {
   pendingAddIds: Set<number>;
   pendingRemoveIds: Set<number>;
   handleCollectionToggle: (collection: CollectionListModel) => void;
+  replaceOptimisticCamera: (optimisticName: string, replacement: ContentCameraModel | null) => void;
 }
 
 interface UseImageMetadataStateParams {
@@ -96,6 +98,26 @@ export function useImageMetadataState({
   const updateStateField = (updates: Partial<ImageUpdateState>) => {
     setUpdateState(prev => ({ ...prev, ...updates }));
   };
+
+  /**
+   * Swap (or revert) the optimistic `{ id: 0 }` camera created by the Camera
+   * "add new" flow — but ONLY if the current selection is still that exact
+   * placeholder. If the user changed or cleared the camera while the create was
+   * in flight, this is a no-op so their newer choice survives (fixes the
+   * stale-write race that a blind `updateStateField` swap would cause). Pass the
+   * server-assigned camera on success, or the prior camera / null to revert on
+   * failure.
+   */
+  const replaceOptimisticCamera = useCallback(
+    (optimisticName: string, replacement: ContentCameraModel | null) => {
+      setUpdateState(prev =>
+        prev.camera?.id === 0 && prev.camera.name === optimisticName
+          ? { ...prev, camera: replacement }
+          : prev
+      );
+    },
+    []
+  );
 
   const hasChanges = useMemo(() => {
     if (isBulkEdit) {
@@ -168,5 +190,6 @@ export function useImageMetadataState({
     pendingAddIds,
     pendingRemoveIds,
     handleCollectionToggle,
+    replaceOptimisticCamera,
   };
 }

--- a/app/components/ImageMetadata/sections/CameraSettingsSection.tsx
+++ b/app/components/ImageMetadata/sections/CameraSettingsSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import Dropdown, { type AddNewField } from '@/app/components/ui/Dropdown/Dropdown';
 import { Checkbox } from '@/app/components/ui/Field/Checkbox';
 import { Input } from '@/app/components/ui/Field/Input';
@@ -84,6 +86,12 @@ const buildCameraAddNewFields = (availableFilmFormats: FilmFormatDTO[]): AddNewF
 export interface CameraSettingsSectionProps {
   updateState: ImageUpdateState;
   updateStateField: (updates: Partial<ImageUpdateState>) => void;
+  /**
+   * Guarded swap/revert for the optimistic add-new camera. Only mutates the
+   * selection when it is still the `{ id: 0 }` placeholder — see
+   * `useImageMetadataState.replaceOptimisticCamera`.
+   */
+  replaceOptimisticCamera: (optimisticName: string, replacement: ContentCameraModel | null) => void;
   availableCameras: ContentCameraModel[];
   availableLenses: ContentLensModel[];
   availableFilmTypes: ContentFilmTypeModel[];
@@ -95,12 +103,17 @@ export interface CameraSettingsSectionProps {
 export default function CameraSettingsSection({
   updateState,
   updateStateField,
+  replaceOptimisticCamera,
   availableCameras,
   availableLenses,
   availableFilmTypes,
   availableFilmFormats,
   isGif,
 }: CameraSettingsSectionProps): React.JSX.Element {
+  // Inline feedback when an eager camera-create fails (the only add-new picker
+  // that persists before save — see onAddNew below).
+  const [createError, setCreateError] = useState<string | null>(null);
+
   return (
     <div
       className={[modalStyles.formSection, isGif ? modalStyles.sectionDisabled : '']
@@ -124,38 +137,48 @@ export default function CameraSettingsSection({
         onAddNew={data => {
           const cameraName = (data.cameraName as string | null) ?? '';
           if (!cameraName.trim()) return;
+          const trimmedName = cameraName.trim();
           const isFilm = data.isFilm === true;
           const defaultFilmFormat = isFilm
             ? ((data.defaultFilmFormat as string | null) ?? null)
             : null;
+          // Snapshot the prior selection so a failed create can revert to it
+          // rather than nuking a camera the user already had chosen.
+          const previousCamera = updateState.camera ?? null;
+          setCreateError(null);
           // Optimistic local update — assume the create succeeds. Reuses the
           // same auto-toggle helper as picking an existing film camera.
           const optimisticCamera: ContentCameraModel = {
             id: 0,
-            name: cameraName.trim(),
+            name: trimmedName,
             isFilm,
             defaultFilmFormat,
           };
           updateStateField(computeCameraSelectionUpdate(optimisticCamera, updateState));
-          // Fire the create async — when it resolves, swap the camera with the real id.
-          void createCamera({
-            cameraName: optimisticCamera.name,
-            isFilm,
-            defaultFilmFormat,
-          })
+          // Camera is the only add-new that eagerly persists: the save-time diff
+          // (buildCameraDiff) emits a name-only `newValue` that would drop
+          // isFilm/defaultFilmFormat, so we POST to /metadata/cameras here.
+          void createCamera({ cameraName: trimmedName, isFilm, defaultFilmFormat })
             .then(created => {
+              // A null body is a 204 success — keep the optimistic { id: 0 }
+              // camera; the save-time newValue path persists it. NOT a failure.
               if (!created) return;
-              updateStateField({
-                camera: {
-                  id: created.id,
-                  name: created.cameraName,
-                  isFilm: created.isFilm,
-                  defaultFilmFormat,
-                },
+              // Guarded: only swaps if the selection is still our placeholder, so
+              // a camera the user picked while this was in flight is preserved.
+              replaceOptimisticCamera(trimmedName, {
+                id: created.id,
+                name: created.cameraName,
+                isFilm: created.isFilm,
+                defaultFilmFormat,
               });
             })
             .catch(error_ => {
+              // Real failure (createCamera throws on non-2xx). Revert the phantom
+              // camera (guarded — preserves a newer selection) and surface it so
+              // the user isn't left with a camera that was never persisted.
               console.error('Failed to create camera', error_);
+              replaceOptimisticCamera(trimmedName, previousCamera);
+              setCreateError(`Couldn't save camera "${trimmedName}". Please try again.`);
             });
         }}
         addNewFields={buildCameraAddNewFields(availableFilmFormats)}
@@ -163,6 +186,12 @@ export default function CameraSettingsSection({
         showNewIndicator
         emptyText="No camera set"
       />
+
+      {createError && (
+        <div className={modalStyles.errorMessage} role="alert">
+          {createError}
+        </div>
+      )}
 
       <Dropdown<ContentLensModel>
         label="Lens"

--- a/tests/components/ImageMetadata/hooks/useImageMetadataState.test.tsx
+++ b/tests/components/ImageMetadata/hooks/useImageMetadataState.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useImageMetadataState } from '@/app/components/ImageMetadata/hooks/useImageMetadataState';
 import type { CollectionListModel } from '@/app/types/Collection';
 import type { ContentImageModel } from '@/app/types/Content';
+import type { ContentCameraModel } from '@/app/types/ImageMetadata';
 
 const coll = (id: number, name: string): CollectionListModel => ({ id, name });
 
@@ -87,5 +88,63 @@ describe('useImageMetadataState', () => {
     act(() => result.current.handleCollectionToggle(coll(10, 'A')));
     expect([...result.current.pendingAddIds]).toEqual([20]);
     expect([...result.current.pendingRemoveIds]).toEqual([10]);
+  });
+
+  describe('replaceOptimisticCamera (guarded swap)', () => {
+    const optimistic = (name: string): ContentCameraModel => ({
+      id: 0,
+      name,
+      isFilm: false,
+      defaultFilmFormat: null,
+    });
+    const real: ContentCameraModel = {
+      id: 99,
+      name: 'Hasselblad 500cm',
+      isFilm: true,
+      defaultFilmFormat: 'MM_120',
+    };
+
+    it('swaps the optimistic {id:0} camera for the real one when the selection is unchanged', () => {
+      const selectedImages = [img(1)];
+      const { result } = renderHook(() =>
+        useImageMetadataState({ selectedImages, selectedImageIds: [1], availableLocations: [] })
+      );
+      act(() => result.current.updateStateField({ camera: optimistic('Hasselblad 500cm') }));
+      act(() => result.current.replaceOptimisticCamera('Hasselblad 500cm', real));
+      expect(result.current.updateState.camera).toEqual(real);
+    });
+
+    it('does NOT swap when the user picked a different camera mid-flight', () => {
+      const selectedImages = [img(1)];
+      const { result } = renderHook(() =>
+        useImageMetadataState({ selectedImages, selectedImageIds: [1], availableLocations: [] })
+      );
+      const userPick: ContentCameraModel = { id: 7, name: 'Sony A7R IV', isFilm: false };
+      act(() => result.current.updateStateField({ camera: optimistic('Hasselblad 500cm') }));
+      act(() => result.current.updateStateField({ camera: userPick }));
+      act(() => result.current.replaceOptimisticCamera('Hasselblad 500cm', real));
+      expect(result.current.updateState.camera).toEqual(userPick);
+    });
+
+    it('does NOT swap when the camera was cleared mid-flight', () => {
+      const selectedImages = [img(1)];
+      const { result } = renderHook(() =>
+        useImageMetadataState({ selectedImages, selectedImageIds: [1], availableLocations: [] })
+      );
+      act(() => result.current.updateStateField({ camera: optimistic('Hasselblad 500cm') }));
+      act(() => result.current.updateStateField({ camera: null }));
+      act(() => result.current.replaceOptimisticCamera('Hasselblad 500cm', real));
+      expect(result.current.updateState.camera).toBeNull();
+    });
+
+    it('reverts the optimistic camera to null when still unchanged (failure path)', () => {
+      const selectedImages = [img(1)];
+      const { result } = renderHook(() =>
+        useImageMetadataState({ selectedImages, selectedImageIds: [1], availableLocations: [] })
+      );
+      act(() => result.current.updateStateField({ camera: optimistic('Hasselblad 500cm') }));
+      act(() => result.current.replaceOptimisticCamera('Hasselblad 500cm', null));
+      expect(result.current.updateState.camera).toBeNull();
+    });
   });
 });

--- a/tests/components/ImageMetadata/sections/CameraSettingsSection.test.tsx
+++ b/tests/components/ImageMetadata/sections/CameraSettingsSection.test.tsx
@@ -1,13 +1,20 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { ImageUpdateState } from '@/app/components/ImageMetadata/hooks/useImageMetadataState';
 import CameraSettingsSection from '@/app/components/ImageMetadata/sections/CameraSettingsSection';
+import { createCamera } from '@/app/lib/api/content';
 import type {
   ContentCameraModel,
   ContentFilmTypeModel,
   ContentLensModel,
   FilmFormatDTO,
 } from '@/app/types/ImageMetadata';
+
+jest.mock('@/app/lib/api/content', () => ({
+  createCamera: jest.fn(),
+}));
+
+const mockCreateCamera = createCamera as jest.MockedFunction<typeof createCamera>;
 
 const baseUpdateState: ImageUpdateState = {
   id: 101,
@@ -54,6 +61,7 @@ function makeProps(
   return {
     updateState: baseUpdateState,
     updateStateField: jest.fn(),
+    replaceOptimisticCamera: jest.fn(),
     availableCameras: baseCameras,
     availableLenses: baseLenses,
     availableFilmTypes: baseFilmTypes,
@@ -152,5 +160,138 @@ describe('CameraSettingsSection', () => {
   it('Film Photography checkbox is rendered', () => {
     render(<CameraSettingsSection {...makeProps()} />);
     expect(screen.getByText(/film photography/i)).toBeInTheDocument();
+  });
+
+  describe('Camera add-new (optimistic create)', () => {
+    /** Open the Camera dropdown and reveal its inline "add new" form. */
+    function openCameraAddNew(): void {
+      fireEvent.click(screen.getByRole('button', { name: /camera:.*click to change/i }));
+      fireEvent.click(screen.getByRole('button', { name: /add new camera/i }));
+    }
+
+    function typeCameraName(name: string): void {
+      fireEvent.change(screen.getByPlaceholderText(/e\.g\., hasselblad 500cm/i), {
+        target: { value: name },
+      });
+    }
+
+    function submitCamera(): void {
+      fireEvent.click(screen.getByRole('button', { name: /^set camera$/i }));
+    }
+
+    it('writes an optimistic {id:0} camera and POSTs createCamera with the entered fields', () => {
+      const updateStateField = jest.fn();
+      mockCreateCamera.mockResolvedValue({ id: 55, cameraName: 'Leica M6', isFilm: false });
+      render(<CameraSettingsSection {...makeProps({ updateStateField })} />);
+
+      openCameraAddNew();
+      typeCameraName('Leica M6');
+      submitCamera();
+
+      expect(updateStateField).toHaveBeenCalledWith({
+        camera: { id: 0, name: 'Leica M6', isFilm: false, defaultFilmFormat: null },
+      });
+      expect(mockCreateCamera).toHaveBeenCalledWith({
+        cameraName: 'Leica M6',
+        isFilm: false,
+        defaultFilmFormat: null,
+      });
+    });
+
+    it('swaps the optimistic camera for the server-assigned id on success', async () => {
+      const replaceOptimisticCamera = jest.fn();
+      mockCreateCamera.mockResolvedValue({ id: 55, cameraName: 'Leica M6', isFilm: false });
+      render(<CameraSettingsSection {...makeProps({ replaceOptimisticCamera })} />);
+
+      openCameraAddNew();
+      typeCameraName('Leica M6');
+      submitCamera();
+
+      await waitFor(() =>
+        expect(replaceOptimisticCamera).toHaveBeenCalledWith('Leica M6', {
+          id: 55,
+          name: 'Leica M6',
+          isFilm: false,
+          defaultFilmFormat: null,
+        })
+      );
+    });
+
+    it('reverts the optimistic camera and surfaces an inline error when the create fails', async () => {
+      const replaceOptimisticCamera = jest.fn();
+      mockCreateCamera.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      render(<CameraSettingsSection {...makeProps({ replaceOptimisticCamera })} />);
+
+      openCameraAddNew();
+      typeCameraName('Leica M6');
+      submitCamera();
+
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(/leica m6/i);
+      expect(replaceOptimisticCamera).toHaveBeenCalledWith('Leica M6', null);
+      errSpy.mockRestore();
+    });
+
+    it('reverts to the previously-selected camera (not null) on failure', async () => {
+      const replaceOptimisticCamera = jest.fn();
+      const previous = baseCameras[1]!; // Sony A7R IV
+      mockCreateCamera.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      render(
+        <CameraSettingsSection
+          {...makeProps({
+            replaceOptimisticCamera,
+            updateState: { ...baseUpdateState, camera: previous },
+          })}
+        />
+      );
+
+      openCameraAddNew();
+      typeCameraName('Leica M6');
+      submitCamera();
+
+      await screen.findByRole('alert');
+      expect(replaceOptimisticCamera).toHaveBeenCalledWith('Leica M6', previous);
+      errSpy.mockRestore();
+    });
+
+    it('keeps the optimistic camera (no swap, no error) when the API returns 204/null', async () => {
+      const replaceOptimisticCamera = jest.fn();
+      mockCreateCamera.mockResolvedValue(null);
+      render(<CameraSettingsSection {...makeProps({ replaceOptimisticCamera })} />);
+
+      openCameraAddNew();
+      typeCameraName('Leica M6');
+      submitCamera();
+
+      await waitFor(() => expect(mockCreateCamera).toHaveBeenCalled());
+      expect(replaceOptimisticCamera).not.toHaveBeenCalled();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('passes film fields through and auto-toggles film when adding a film camera', () => {
+      const updateStateField = jest.fn();
+      mockCreateCamera.mockResolvedValue({ id: 60, cameraName: 'Hasselblad 500cm', isFilm: true });
+      render(<CameraSettingsSection {...makeProps({ updateStateField })} />);
+
+      openCameraAddNew();
+      typeCameraName('Hasselblad 500cm');
+      // Tick "Film Camera" so the Film Format select appears, then pick a format.
+      fireEvent.click(screen.getByRole('checkbox', { name: /film camera/i }));
+      fireEvent.change(screen.getByLabelText(/film format/i), { target: { value: 'MM_120' } });
+      submitCamera();
+
+      expect(updateStateField).toHaveBeenCalledWith({
+        camera: { id: 0, name: 'Hasselblad 500cm', isFilm: true, defaultFilmFormat: 'MM_120' },
+        isFilm: true,
+        filmFormat: 'MM_120',
+      });
+      expect(mockCreateCamera).toHaveBeenCalledWith({
+        cameraName: 'Hasselblad 500cm',
+        isFilm: true,
+        defaultFilmFormat: 'MM_120',
+      });
+    });
   });
 });


### PR DESCRIPTION
…ilures

The Camera "add new" flow set an optimistic {id:0} camera, fired createCamera fire-and-forget, then unconditionally swapped in the real id on resolve. Two latent bugs:

1. Stale-write race: if the user changed or cleared the camera while the create was in flight, the .then clobbered their newer selection (blind updateStateField merge with no placeholder check).
2. Silent failure: the .catch only console.error'd, leaving a phantom {id:0} camera that looked selected but was never persisted, with no feedback.

Add a guarded updater replaceOptimisticCamera() to useImageMetadataState that only swaps/reverts when the selection is still the {id:0,name} placeholder, so a newer user selection is preserved. On create failure, revert to the previous camera (guarded) and surface an inline role="alert" message. A null response is a 204 success, not a failure: the optimistic camera persists at save via buildCameraDiff's name-only newValue path. The eager /metadata/cameras create stays because it is the only path that persists isFilm/defaultFilmFormat.

Pre-existing bug (verbatim in the monolith at b7ed03a; 0159 only relocated it into CameraSettingsSection). Frontend-only.

Tests: 4 hook guard tests (swap / no-swap-on-change / no-swap-on-clear / revert) plus 6 section add-new tests driving the real Dropdown UI (success swap, failure revert + inline error, 204-not-failure, film-field passthrough).