### PR TITLE
test(api): replace non-asserting fail() in core.test.ts

### DIFF
--- a/tests/lib/api/core.test.ts
+++ b/tests/lib/api/core.test.ts
@@ -86,13 +86,8 @@ describe('handleApiError (tested via public API functions)', () => {
       };
       (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
 
-      try {
-        await fetchPostJsonApi('/test', {});
-        fail('Should have thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ApiError);
-        expect((error as ApiError).status).toBe(403);
-      }
+      await expect(fetchPostJsonApi('/test', {})).rejects.toBeInstanceOf(ApiError);
+      await expect(fetchPostJsonApi('/test', {})).rejects.toHaveProperty('status', 403);
     });
   });
 
@@ -102,14 +97,7 @@ describe('handleApiError (tested via public API functions)', () => {
 
       await expect(fetchPostJsonApi('/test', {})).rejects.toThrow(ApiError);
       await expect(fetchPostJsonApi('/test', {})).rejects.toThrow('Network error');
-
-      try {
-        await fetchPostJsonApi('/test', {});
-        fail('Should have thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ApiError);
-        expect((error as ApiError).status).toBe(500);
-      }
+      await expect(fetchPostJsonApi('/test', {})).rejects.toHaveProperty('status', 500);
     });
 
     it('should re-throw ApiError without modification', async () => {
@@ -125,14 +113,7 @@ describe('handleApiError (tested via public API functions)', () => {
 
       await expect(fetchPostJsonApi('/test', {})).rejects.toThrow(ApiError);
       await expect(fetchPostJsonApi('/test', {})).rejects.toThrow('Unknown error occurred');
-
-      try {
-        await fetchPostJsonApi('/test', {});
-        fail('Should have thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ApiError);
-        expect((error as ApiError).status).toBe(500);
-      }
+      await expect(fetchPostJsonApi('/test', {})).rejects.toHaveProperty('status', 500);
     });
   });
 });


### PR DESCRIPTION
`fail()` is not a Jest 29 global — the three calls only threw a ReferenceError swallowed by the surrounding `catch`, so the throw was never asserted. Replaced with `.rejects.toBeInstanceOf` / `.rejects.toHaveProperty('status', n)`.

**Stack (1/4):** base of the post-0165 refactor wave.
Verify: tsc clean · full jest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)