### PR TITLE
refactor(collections): entity-edit DRY wins — buildAssociationDiff, shared toggleRelation, useToggleTriple

### DIFF
--- a/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
+++ b/app/(admin)/collection/manage/[[...slug]]/ManageClient.tsx
@@ -27,6 +27,7 @@ import { SegmentedControl } from '@/app/components/ui/SegmentedControl/Segmented
 import TagsSelector from '@/app/components/ui/TagsSelector/TagsSelector';
 import { useCollectionData } from '@/app/hooks/useCollectionData';
 import { useMetadataEditor } from '@/app/hooks/useMetadataEditor';
+import { useToggleTriple } from '@/app/hooks/useToggleTriple';
 import {
   createChildCollection,
   createCollection,
@@ -791,7 +792,10 @@ export default function ManageClient({ slug }: ManageClientProps) {
   const handleDeleteSuccess = useCallback(
     async (_deletedIds: number[]) => {
       if (!currentState?.collection.slug) {
-        logger.warn('ManageClient', 'handleDeleteSuccess: currentState or slug unavailable, cannot refresh collection');
+        logger.warn(
+          'ManageClient',
+          'handleDeleteSuccess: currentState or slug unavailable, cannot refresh collection'
+        );
         setError('Unable to refresh collection after deletion — please reload the page.');
         return;
       }
@@ -817,29 +821,25 @@ export default function ManageClient({ slug }: ManageClientProps) {
     [currentState]
   );
 
-  const originalCollectionIds = useMemo(() => {
-    const ids = new Set<number>();
-    if (collection?.content) {
-      for (const block of collection.content) {
-        if (isContentCollection(block)) {
-          ids.add(block.referencedCollectionId);
-        }
-      }
-    }
-    return ids;
-  }, [collection?.content]);
-
-  const pendingAddIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const child of updateData.collections?.newValue || []) {
-      ids.add(child.collectionId);
-    }
-    return ids;
-  }, [updateData.collections?.newValue]);
-
-  const pendingRemoveIds = useMemo(() => {
-    return new Set<number>(updateData.collections?.remove || []);
-  }, [updateData.collections?.remove]);
+  // Child-collection picker triple. Saved children come from the content blocks (containment);
+  // pending add/remove come from the discrete `collections` update.
+  const originalChildIds = useMemo(
+    () =>
+      (collection?.content ?? [])
+        .filter(isContentCollection)
+        .map(block => block.referencedCollectionId),
+    [collection?.content]
+  );
+  const {
+    savedIds: originalCollectionIds,
+    pendingAddIds,
+    pendingRemoveIds,
+  } = useToggleTriple(
+    originalChildIds,
+    updateData.collections?.newValue,
+    updateData.collections?.remove,
+    child => child.collectionId
+  );
 
   /**
    * Derive current locations from `collection.locations` and `updateData.locations`.
@@ -968,28 +968,23 @@ export default function ManageClient({ slug }: ManageClientProps) {
 
   /**
    * Sibling-collection selection state — mirrors the child-collection state above,
-   * but `originalSiblingIds` derives from `collection.siblings` (mutual association)
-   * rather than from `collection.content` (containment).
+   * but the saved IDs derive from `collection.siblings` (mutual association) rather
+   * than from `collection.content` (containment).
    */
-  const originalSiblingIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const sib of collection?.siblings ?? []) {
-      ids.add(sib.id);
-    }
-    return ids;
-  }, [collection?.siblings]);
-
-  const pendingAddSiblingIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const sib of updateData.siblings?.newValue ?? []) {
-      ids.add(sib.collectionId);
-    }
-    return ids;
-  }, [updateData.siblings?.newValue]);
-
-  const pendingRemoveSiblingIds = useMemo(() => {
-    return new Set<number>(updateData.siblings?.remove ?? []);
-  }, [updateData.siblings?.remove]);
+  const originalSiblingIdsArray = useMemo(
+    () => (collection?.siblings ?? []).map(sib => sib.id),
+    [collection?.siblings]
+  );
+  const {
+    savedIds: originalSiblingIds,
+    pendingAddIds: pendingAddSiblingIds,
+    pendingRemoveIds: pendingRemoveSiblingIds,
+  } = useToggleTriple(
+    originalSiblingIdsArray,
+    updateData.siblings?.newValue,
+    updateData.siblings?.remove,
+    sib => sib.collectionId
+  );
 
   /**
    * Toggle a sibling link. Same engine as handleCollectionToggle, but sibling rows carry
@@ -1015,28 +1010,23 @@ export default function ManageClient({ slug }: ManageClientProps) {
 
   /**
    * Parent-collection selection state — mirrors the sibling-collection state above,
-   * but `originalParentIds` derives from `collection.parents` (the inverse of the
-   * child containment relation, surfaced by admin/manage reads).
+   * but the saved IDs derive from `collection.parents` (the inverse of the child
+   * containment relation, surfaced by admin/manage reads).
    */
-  const originalParentIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const parent of collection?.parents ?? []) {
-      ids.add(parent.id);
-    }
-    return ids;
-  }, [collection?.parents]);
-
-  const pendingAddParentIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const parent of updateData.parents?.newValue ?? []) {
-      ids.add(parent.collectionId);
-    }
-    return ids;
-  }, [updateData.parents?.newValue]);
-
-  const pendingRemoveParentIds = useMemo(() => {
-    return new Set<number>(updateData.parents?.remove ?? []);
-  }, [updateData.parents?.remove]);
+  const originalParentIdsArray = useMemo(
+    () => (collection?.parents ?? []).map(parent => parent.id),
+    [collection?.parents]
+  );
+  const {
+    savedIds: originalParentIds,
+    pendingAddIds: pendingAddParentIds,
+    pendingRemoveIds: pendingRemoveParentIds,
+  } = useToggleTriple(
+    originalParentIdsArray,
+    updateData.parents?.newValue,
+    updateData.parents?.remove,
+    parent => parent.collectionId
+  );
 
   /**
    * Toggle a parent link. Same engine as handleSiblingToggle; parent rows carry
@@ -1703,7 +1693,11 @@ export default function ManageClient({ slug }: ManageClientProps) {
                             if (col.slug) {
                               router.push(`/collection/manage/${col.slug}`);
                             } else {
-                              logger.error('ManageClient', 'Cannot navigate to collection: missing slug', col);
+                              logger.error(
+                                'ManageClient',
+                                'Cannot navigate to collection: missing slug',
+                                col
+                              );
                               setError(`Cannot navigate to collection "${col.name}": missing slug`);
                             }
                           }}

--- a/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
+++ b/app/(admin)/collection/manage/[[...slug]]/manageUtils.ts
@@ -5,10 +5,7 @@
 
 import { reorderCollectionContent } from '@/app/lib/api/collections';
 import {
-  type ChildCollection,
-  type CollectionListModel,
   type CollectionModel,
-  type CollectionUpdate,
   type CollectionUpdateRequest,
   type CollectionUpdateResponseDTO,
 } from '@/app/types/Collection';
@@ -19,6 +16,7 @@ import {
   type ContentImageModel,
   type ContentImageUpdateResponse,
 } from '@/app/types/Content';
+import { toggleRelation } from '@/app/utils/collectionToggle';
 import { isContentCollection, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
 import { isLocalEnvironment } from '@/app/utils/environment';
 import { toggleImageSelection } from '@/app/utils/imageSelection';
@@ -28,57 +26,12 @@ export const COVER_IMAGE_FLASH_DURATION = 500; // milliseconds
 export const DEFAULT_PAGE_SIZE = 50;
 
 /**
- * Toggle one collection within a `prev`/`newValue`/`remove` association — the shared
- * engine behind both the child-collection and sibling-collection pickers in ManageClient.
- *
- * Pure and exhaustive over the four transitions:
- * - add a not-yet-saved collection  → appended to `newValue`
- * - un-add a pending addition        → removed from `newValue`
- * - remove a saved collection        → appended to `remove`
- * - un-remove a pending removal       → removed from `remove`
- *
- * `buildEntry` lets each caller shape its `newValue` rows: child rows carry
- * `visible`/`orderIndex`; sibling rows carry only `{ collectionId, name }`. Returns
- * `undefined` when no pending changes remain, so the key drops out of the payload.
+ * Re-export the shared, pure collection-toggle engine so existing collection-side callers
+ * (ManageClient children/siblings/parents pickers) and tests keep importing it from here
+ * unchanged. The implementation now lives in `@/app/utils/collectionToggle` so the image
+ * side can adapt the same engine.
  */
-export function toggleRelation(
-  current: CollectionUpdate | undefined,
-  toggled: CollectionListModel,
-  originalIds: Set<number>,
-  buildEntry: (collection: CollectionListModel, index: number) => ChildCollection
-): CollectionUpdate | undefined {
-  const currentRemove = new Set(current?.remove ?? []);
-  const currentNewValue = current?.newValue ?? [];
-  const isSaved = originalIds.has(toggled.id);
-
-  let newRemove: number[];
-  if (!isSaved) {
-    newRemove = [...currentRemove];
-  } else if (currentRemove.has(toggled.id)) {
-    newRemove = [...currentRemove].filter(id => id !== toggled.id);
-  } else {
-    newRemove = [...currentRemove, toggled.id];
-  }
-
-  let newNewValue: ChildCollection[];
-  if (isSaved) {
-    newNewValue = [...currentNewValue];
-  } else if (currentNewValue.some(c => c.collectionId === toggled.id)) {
-    newNewValue = currentNewValue.filter(c => c.collectionId !== toggled.id);
-  } else {
-    newNewValue = [...currentNewValue, buildEntry(toggled, currentNewValue.length)];
-  }
-
-  const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
-  if (!hasChanges) {
-    return undefined;
-  }
-  return {
-    ...current,
-    remove: newRemove.length > 0 ? newRemove : undefined,
-    newValue: newNewValue.length > 0 ? newNewValue : undefined,
-  };
-}
+export { toggleRelation };
 
 /**
  * Build an update payload containing only changed fields.
@@ -539,7 +492,10 @@ export function replayMoves(originalOrder: number[], moves: ReorderMove[]): numb
   for (const move of moves) {
     const fromIndex = order.indexOf(move.imageId);
     if (fromIndex === -1) {
-      logger.warn('replayMoves', `imageId ${move.imageId} not found in current order — move skipped`);
+      logger.warn(
+        'replayMoves',
+        `imageId ${move.imageId} not found in current order — move skipped`
+      );
       continue;
     }
     // Remove from current position

--- a/app/components/Metadata/hooks/useMetadataState.ts
+++ b/app/components/Metadata/hooks/useMetadataState.ts
@@ -2,9 +2,16 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { type CollectionListModel, type LocationModel } from '@/app/types/Collection';
+import { useToggleTriple } from '@/app/hooks/useToggleTriple';
+import {
+  type ChildCollection,
+  type CollectionListModel,
+  type CollectionUpdate,
+  type LocationModel,
+} from '@/app/types/Collection';
 import { type ContentGifModel, type ContentImageModel } from '@/app/types/Content';
 import { type ContentCameraModel } from '@/app/types/Metadata';
+import { toggleRelation } from '@/app/utils/collectionToggle';
 import { convertLocationsToModels } from '@/app/utils/locationUtils';
 import { hasObjectChanges } from '@/app/utils/objectComparison';
 
@@ -27,6 +34,67 @@ export type ImageUpdateState = Partial<ContentImageModel> &
  * re-render → new `[]` → infinite loop.)
  */
 const EMPTY_LOCATIONS: LocationModel[] = [];
+
+/**
+ * Toggle one collection on the image-side FLAT array (`ChildCollection[]`) representation.
+ *
+ * The image editor stores collection membership as a single flat array of `ChildCollection`
+ * (saved-and-kept items + pending additions; a removed saved item is simply absent). The shared
+ * pure {@link toggleRelation} engine speaks the discrete `prev`/`newValue`/`remove`
+ * `CollectionUpdate` shape that the collection editor uses, so this adapter:
+ *
+ * 1. Projects the current flat array into a `CollectionUpdate` (`newValue` = pending adds not in
+ *    `originalIds`; `remove` = saved IDs absent from the flat array).
+ * 2. Runs the shared engine.
+ * 3. Re-flattens: every saved ID still kept (not in the engine's `remove`) plus every pending add
+ *    in `newValue`. Existing flat objects are reused so saved-item metadata (name/slug/cover) is
+ *    preserved; an un-removed saved item is rebuilt from the toggled `CollectionListModel`.
+ *
+ * Engine stays pure; this flat-array adaptation is the only image-specific glue.
+ */
+export function toggleCollectionFlat(
+  currentCollections: ChildCollection[],
+  toggled: CollectionListModel,
+  originalIds: Set<number>
+): ChildCollection[] {
+  const buildEntry = (collection: CollectionListModel, index: number): ChildCollection => ({
+    collectionId: collection.id,
+    name: collection.name,
+    visible: true,
+    orderIndex: index,
+  });
+
+  // 1. Flat array → CollectionUpdate (discrete prev/newValue/remove the engine understands).
+  const pendingAdds = currentCollections.filter(c => !originalIds.has(c.collectionId));
+  const currentIds = new Set(currentCollections.map(c => c.collectionId));
+  const pendingRemoves: number[] = [];
+  for (const id of originalIds) {
+    if (!currentIds.has(id)) pendingRemoves.push(id);
+  }
+  const current: CollectionUpdate = {
+    newValue: pendingAdds.length > 0 ? pendingAdds : undefined,
+    remove: pendingRemoves.length > 0 ? pendingRemoves : undefined,
+  };
+
+  // 2. Run the shared pure engine.
+  const next = toggleRelation(current, toggled, originalIds, buildEntry);
+
+  // 3. CollectionUpdate → flat array. Reuse existing objects to preserve saved-item metadata.
+  const nextRemove = new Set(next?.remove ?? []);
+  const existingById = new Map(currentCollections.map(c => [c.collectionId, c]));
+  const kept: ChildCollection[] = [];
+  for (const id of originalIds) {
+    if (nextRemove.has(id)) continue;
+    const existing = existingById.get(id);
+    if (existing) {
+      kept.push(existing);
+    } else if (id === toggled.id) {
+      // Saved item just un-removed: rebuild from the toggled CollectionListModel.
+      kept.push(buildEntry(toggled, kept.length));
+    }
+  }
+  return [...kept, ...(next?.newValue ?? [])];
+}
 
 export interface UseMetadataStateResult {
   updateState: ImageUpdateState;
@@ -130,57 +198,38 @@ export function useMetadataState({
     // imageSubset is derived from selectedImages each render; reflect that in deps.
   }, [updateState, selectedImages, isBulkEdit]);
 
-  const originalCollectionIds = useMemo(() => {
-    const ids = new Set<number>();
-    if (!isBulkEdit && selectedImages[0]?.collections) {
-      for (const c of selectedImages[0].collections) {
-        ids.add(c.collectionId);
-      }
-    }
-    return ids;
-  }, [selectedImages, isBulkEdit]);
+  // Saved collection membership (single-edit only — bulk edit has no per-collection picker).
+  const originalIds = useMemo(
+    () => (isBulkEdit ? [] : (selectedImages[0]?.collections ?? []).map(c => c.collectionId)),
+    [selectedImages, isBulkEdit]
+  );
 
-  const pendingAddIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const c of updateState.collections || []) {
-      if (!originalCollectionIds.has(c.collectionId)) {
-        ids.add(c.collectionId);
-      }
-    }
-    return ids;
-  }, [updateState.collections, originalCollectionIds]);
+  // Image-side removes are implicit: a saved ID absent from the flat membership array is "removed".
+  // Convert that to the discrete `remove` list the shared triple hook expects.
+  const pendingRemoves = useMemo(() => {
+    const currentIds = new Set((updateState.collections ?? []).map(c => c.collectionId));
+    return originalIds.filter(id => !currentIds.has(id));
+  }, [updateState.collections, originalIds]);
 
-  const pendingRemoveIds = useMemo(() => {
-    const ids = new Set<number>();
-    const currentIds = new Set((updateState.collections || []).map(c => c.collectionId));
-    for (const id of originalCollectionIds) {
-      if (!currentIds.has(id)) {
-        ids.add(id);
-      }
-    }
-    return ids;
-  }, [updateState.collections, originalCollectionIds]);
+  const {
+    savedIds: originalCollectionIds,
+    pendingAddIds,
+    pendingRemoveIds,
+  } = useToggleTriple(originalIds, updateState.collections, pendingRemoves, c => c.collectionId);
 
-  const handleCollectionToggle = useCallback((collection: CollectionListModel) => {
-    setUpdateState(prev => {
-      const currentCollections = prev.collections || [];
-      const exists = currentCollections.some(c => c.collectionId === collection.id);
-
-      const updatedCollections = exists
-        ? currentCollections.filter(c => c.collectionId !== collection.id)
-        : [
-            ...currentCollections,
-            {
-              collectionId: collection.id,
-              name: collection.name,
-              visible: true,
-              orderIndex: currentCollections.length,
-            },
-          ];
-
-      return { ...prev, collections: updatedCollections };
-    });
-  }, []);
+  const handleCollectionToggle = useCallback(
+    (collection: CollectionListModel) => {
+      setUpdateState(prev => ({
+        ...prev,
+        collections: toggleCollectionFlat(
+          prev.collections || [],
+          collection,
+          originalCollectionIds
+        ),
+      }));
+    },
+    [originalCollectionIds]
+  );
 
   return {
     updateState,

--- a/app/components/Metadata/metadataUtils.ts
+++ b/app/components/Metadata/metadataUtils.ts
@@ -529,66 +529,47 @@ function buildFilmTypeDiff(
 }
 
 /**
- * Build diff for tags field using prev/newValue/remove pattern
+ * Build diff for a many-to-many association field (tags or people) using the
+ * prev/newValue/remove pattern.
+ *
+ * Both fields share the exact same mechanic: existing items (`id > 0`) become `prev`,
+ * brand-new items (`id` 0/undefined) contribute their names to `newValue`, and items
+ * present in `currentItems` but dropped from `updateItems` become `remove`. The field is
+ * only written onto `diff` when at least one of add/remove/new-name actually changed.
+ *
+ * @param field - Which association to write (`'tags'` or `'people'`)
+ * @param updateItems - The edited selection (existing + new items)
+ * @param currentItems - The original selection on the content block
+ * @param diff - The diff object to mutate in place
  */
-function buildTagsDiff(
-  updateTags: ContentImageModel['tags'],
-  currentTags: ContentImageModel['tags'],
-  diff: ContentImageUpdateRequest
+function buildAssociationDiff<T extends { id?: number; name: string }>(
+  field: 'tags' | 'people',
+  updateItems: T[] | undefined,
+  currentItems: T[] | undefined,
+  diff: Pick<ContentImageUpdateRequest, 'tags' | 'people'>
 ): void {
-  const updateTagsArray = updateTags || [];
-  const currentTagsArray = currentTags || [];
-  const updateTagIds = updateTagsArray.filter(t => t.id && t.id > 0).map(t => t.id!);
-  const currentTagIds = currentTagsArray.filter(t => t.id && t.id > 0).map(t => t.id!);
-  const updateTagNames = updateTagsArray.filter(t => !t.id || t.id === 0).map(t => t.name);
+  const updateArray = updateItems || [];
+  const currentArray = currentItems || [];
+  const updateIds = updateArray.filter(item => item.id && item.id > 0).map(item => item.id!);
+  const currentIds = currentArray.filter(item => item.id && item.id > 0).map(item => item.id!);
+  const updateNames = updateArray.filter(item => !item.id || item.id === 0).map(item => item.name);
 
-  const addedTagIds = updateTagIds.filter(id => !currentTagIds.includes(id));
-  const removedTagIds = currentTagIds.filter(id => !updateTagIds.includes(id));
-  const hasNewTagNames = updateTagNames.length > 0;
+  const addedIds = updateIds.filter(id => !currentIds.includes(id));
+  const removedIds = currentIds.filter(id => !updateIds.includes(id));
+  const hasNewNames = updateNames.length > 0;
 
-  if (addedTagIds.length > 0 || removedTagIds.length > 0 || hasNewTagNames) {
-    diff.tags = {};
-    if (updateTagIds.length > 0) {
-      diff.tags.prev = updateTagIds;
+  if (addedIds.length > 0 || removedIds.length > 0 || hasNewNames) {
+    const update: { prev?: number[]; newValue?: string[]; remove?: number[] } = {};
+    if (updateIds.length > 0) {
+      update.prev = updateIds;
     }
-    if (updateTagNames.length > 0) {
-      diff.tags.newValue = updateTagNames;
+    if (updateNames.length > 0) {
+      update.newValue = updateNames;
     }
-    if (removedTagIds.length > 0) {
-      diff.tags.remove = removedTagIds;
+    if (removedIds.length > 0) {
+      update.remove = removedIds;
     }
-  }
-}
-
-/**
- * Build diff for people field using prev/newValue/remove pattern
- */
-function buildPeopleDiff(
-  updatePeople: ContentImageModel['people'],
-  currentPeople: ContentImageModel['people'],
-  diff: Pick<ContentImageUpdateRequest, 'people'>
-): void {
-  const updatePeopleArray = updatePeople || [];
-  const currentPeopleArray = currentPeople || [];
-  const updatePeopleIds = updatePeopleArray.filter(p => p.id && p.id > 0).map(p => p.id!);
-  const currentPeopleIds = currentPeopleArray.filter(p => p.id && p.id > 0).map(p => p.id!);
-  const updatePeopleNames = updatePeopleArray.filter(p => !p.id || p.id === 0).map(p => p.name);
-
-  const addedPeopleIds = updatePeopleIds.filter(id => !currentPeopleIds.includes(id));
-  const removedPeopleIds = currentPeopleIds.filter(id => !updatePeopleIds.includes(id));
-  const hasNewPeopleNames = updatePeopleNames.length > 0;
-
-  if (addedPeopleIds.length > 0 || removedPeopleIds.length > 0 || hasNewPeopleNames) {
-    diff.people = {};
-    if (updatePeopleIds.length > 0) {
-      diff.people.prev = updatePeopleIds;
-    }
-    if (updatePeopleNames.length > 0) {
-      diff.people.newValue = updatePeopleNames;
-    }
-    if (removedPeopleIds.length > 0) {
-      diff.people.remove = removedPeopleIds;
-    }
+    diff[field] = update;
   }
 }
 
@@ -715,8 +696,8 @@ export function buildImageUpdateDiff(
     availableFilmTypes,
     diff
   );
-  buildTagsDiff(updateState.tags, currentState.tags, diff);
-  buildPeopleDiff(updateState.people, currentState.people, diff);
+  buildAssociationDiff('tags', updateState.tags, currentState.tags, diff);
+  buildAssociationDiff('people', updateState.people, currentState.people, diff);
   buildCollectionsDiff(updateState.collections, currentState.collections, diff);
 
   return diff;
@@ -725,7 +706,7 @@ export function buildImageUpdateDiff(
 /**
  * Build ONLY the people + locations diffs (prev/newValue/remove) for any content type.
  *
- * Reuses the exact same private builders as the image diff path ({@link buildPeopleDiff} and
+ * Reuses the exact same private builders as the image diff path ({@link buildAssociationDiff} and
  * {@link buildLocationsDiffField}) so the prev/newValue/remove logic is never duplicated. The
  * GIF/MP4 save path calls this and copies the resulting keys onto its own update request — people
  * and locations are general relational metadata that both images and GIFs share.
@@ -746,7 +727,7 @@ export function buildContentPeopleLocationsDiff(
 ): Pick<ContentImageUpdateRequest, 'people' | 'locations'> {
   const diff: Pick<ContentImageUpdateRequest, 'people' | 'locations'> = {};
 
-  buildPeopleDiff(updateState.people, currentState.people, diff);
+  buildAssociationDiff('people', updateState.people, currentState.people, diff);
   buildLocationsDiffField(updateState.locations, currentState.locations, diff);
 
   return diff;

--- a/app/hooks/useToggleTriple.ts
+++ b/app/hooks/useToggleTriple.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+
+/**
+ * Derive the `(savedIds, pendingAddIds, pendingRemoveIds)` triple that
+ * `CollectionListSelector` consumes to paint each row's checkbox state.
+ *
+ * This is the single source for the feeder pattern that previously appeared, byte-for-byte, in
+ * three places: the image-collection picker (`useMetadataState`) and the child + sibling + parent
+ * pickers in `ManageClient`. Centralizing it locks the contract the picker depends on.
+ *
+ * Inputs are the discrete `prev`/`newValue`/`remove` shape the collection editor already stores:
+ * - `originalIds` — the saved (already-persisted) membership IDs.
+ * - `pendingAdds` — items staged to be added (typically a `newValue` array). Any whose id is
+ *   already saved is ignored, so callers can pass a raw membership array without pre-filtering.
+ * - `pendingRemoves` — saved IDs staged for removal (a `remove` array).
+ *
+ * @returns Three `Set<number>`s: `savedIds`, `pendingAddIds`, `pendingRemoveIds`.
+ */
+export function useToggleTriple<T>(
+  originalIds: number[],
+  pendingAdds: T[] | undefined,
+  pendingRemoves: number[] | undefined,
+  getId: (item: T) => number
+): { savedIds: Set<number>; pendingAddIds: Set<number>; pendingRemoveIds: Set<number> } {
+  const savedIds = useMemo(() => new Set(originalIds), [originalIds]);
+
+  // `getId` is a pure projection (callers pass an inline arrow like `c => c.collectionId`); its
+  // result depends only on `pendingAdds`, so it is intentionally not a dependency here.
+  const pendingAddIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const item of pendingAdds ?? []) {
+      const id = getId(item);
+      if (!savedIds.has(id)) ids.add(id);
+    }
+    return ids;
+  }, [pendingAdds, savedIds]);
+
+  const pendingRemoveIds = useMemo(() => new Set(pendingRemoves ?? []), [pendingRemoves]);
+
+  return { savedIds, pendingAddIds, pendingRemoveIds };
+}

--- a/app/utils/collectionToggle.ts
+++ b/app/utils/collectionToggle.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared, pure collection-toggle engine.
+ *
+ * Extracted from the admin/manage page so both the collection side (children +
+ * siblings + parents in ManageClient) and the image side (collection membership in
+ * the metadata editor) can drive the exact same `prev`/`newValue`/`remove` toggle
+ * logic. Keep this file engine-only — no React, no component imports — so it stays
+ * trivially unit-testable.
+ */
+
+import {
+  type ChildCollection,
+  type CollectionListModel,
+  type CollectionUpdate,
+} from '@/app/types/Collection';
+
+/**
+ * Toggle one collection within a `prev`/`newValue`/`remove` association — the shared
+ * engine behind both the collection-side pickers (children / siblings / parents in
+ * ManageClient) and the image-side collection picker (via a thin adapter).
+ *
+ * Pure and exhaustive over the four transitions:
+ * - add a not-yet-saved collection  → appended to `newValue`
+ * - un-add a pending addition        → removed from `newValue`
+ * - remove a saved collection        → appended to `remove`
+ * - un-remove a pending removal       → removed from `remove`
+ *
+ * `buildEntry` lets each caller shape its `newValue` rows: child rows carry
+ * `visible`/`orderIndex`; sibling/parent rows carry only `{ collectionId, name }`.
+ * Returns `undefined` when no pending changes remain, so the key drops out of the
+ * payload.
+ */
+export function toggleRelation(
+  current: CollectionUpdate | undefined,
+  toggled: CollectionListModel,
+  originalIds: Set<number>,
+  buildEntry: (collection: CollectionListModel, index: number) => ChildCollection
+): CollectionUpdate | undefined {
+  const currentRemove = new Set(current?.remove ?? []);
+  const currentNewValue = current?.newValue ?? [];
+  const isSaved = originalIds.has(toggled.id);
+
+  let newRemove: number[];
+  if (!isSaved) {
+    newRemove = [...currentRemove];
+  } else if (currentRemove.has(toggled.id)) {
+    newRemove = [...currentRemove].filter(id => id !== toggled.id);
+  } else {
+    newRemove = [...currentRemove, toggled.id];
+  }
+
+  let newNewValue: ChildCollection[];
+  if (isSaved) {
+    newNewValue = [...currentNewValue];
+  } else if (currentNewValue.some(c => c.collectionId === toggled.id)) {
+    newNewValue = currentNewValue.filter(c => c.collectionId !== toggled.id);
+  } else {
+    newNewValue = [...currentNewValue, buildEntry(toggled, currentNewValue.length)];
+  }
+
+  const hasChanges = newRemove.length > 0 || newNewValue.length > 0;
+  if (!hasChanges) {
+    return undefined;
+  }
+  return {
+    ...current,
+    remove: newRemove.length > 0 ? newRemove : undefined,
+    newValue: newNewValue.length > 0 ? newNewValue : undefined,
+  };
+}

--- a/tests/components/Metadata/hooks/useMetadataState.test.tsx
+++ b/tests/components/Metadata/hooks/useMetadataState.test.tsx
@@ -1,7 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useMetadataState } from '@/app/components/Metadata/hooks/useMetadataState';
-import type { CollectionListModel } from '@/app/types/Collection';
+import {
+  toggleCollectionFlat,
+  useMetadataState,
+} from '@/app/components/Metadata/hooks/useMetadataState';
+import type { ChildCollection, CollectionListModel } from '@/app/types/Collection';
 import type { ContentImageModel } from '@/app/types/Content';
 import type { ContentCameraModel } from '@/app/types/Metadata';
 
@@ -146,5 +149,44 @@ describe('useMetadataState', () => {
       act(() => result.current.replaceOptimisticCamera('Hasselblad 500cm', null));
       expect(result.current.updateState.camera).toBeNull();
     });
+  });
+});
+
+describe('toggleCollectionFlat (image-side flat-array adapter)', () => {
+  const saved = (id: number, name: string): ChildCollection => ({
+    collectionId: id,
+    name,
+    visible: true,
+    orderIndex: 0,
+  });
+
+  it('add: appends a not-yet-saved collection with image-row shape', () => {
+    const result = toggleCollectionFlat([], coll(5, 'Iceland'), new Set<number>());
+    expect(result).toEqual([{ collectionId: 5, name: 'Iceland', visible: true, orderIndex: 0 }]);
+  });
+
+  it('un-add: toggling a pending addition removes it from the flat array', () => {
+    const current: ChildCollection[] = [saved(5, 'Iceland')];
+    const result = toggleCollectionFlat(current, coll(5, 'Iceland'), new Set<number>());
+    expect(result).toEqual([]);
+  });
+
+  it('remove: toggling a saved collection drops it from the flat array', () => {
+    const current: ChildCollection[] = [saved(10, 'A')];
+    const result = toggleCollectionFlat(current, coll(10, 'A'), new Set<number>([10]));
+    expect(result).toEqual([]);
+  });
+
+  it('re-add after remove: toggling a removed saved collection restores it', () => {
+    // Start with the saved item removed (absent from the flat array), then toggle it back.
+    const result = toggleCollectionFlat([], coll(10, 'A'), new Set<number>([10]));
+    expect(result).toEqual([{ collectionId: 10, name: 'A', visible: true, orderIndex: 0 }]);
+  });
+
+  it('preserves saved-item metadata for kept collections while adding a new one', () => {
+    const kept = saved(10, 'A');
+    const result = toggleCollectionFlat([kept], coll(20, 'B'), new Set<number>([10]));
+    // The kept saved object is reused verbatim; the new one is appended in image-row shape.
+    expect(result).toEqual([kept, { collectionId: 20, name: 'B', visible: true, orderIndex: 0 }]);
   });
 });

--- a/tests/hooks/useToggleTriple.test.tsx
+++ b/tests/hooks/useToggleTriple.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for useToggleTriple — the single source for the
+ * (savedIds, pendingAddIds, pendingRemoveIds) feeder pattern consumed by
+ * CollectionListSelector across the image + collection editors.
+ *
+ * Covers the four state transitions:
+ * - initial (only saved, no pending)
+ * - add (a pending addition not already saved)
+ * - remove (a saved id staged for removal)
+ * - re-add-after-remove (the same id appears in both adds and removes)
+ *
+ * Plus the guard that already-saved ids passed in `pendingAdds` are ignored.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useToggleTriple } from '@/app/hooks/useToggleTriple';
+
+interface Row {
+  collectionId: number;
+  name: string;
+}
+
+const row = (id: number): Row => ({ collectionId: id, name: `C${id}` });
+const getId = (r: Row) => r.collectionId;
+
+describe('useToggleTriple', () => {
+  it('initial: only saved ids, no pending', () => {
+    const { result } = renderHook(() => useToggleTriple([1, 2], undefined, undefined, getId));
+    expect([...result.current.savedIds]).toEqual([1, 2]);
+    expect([...result.current.pendingAddIds]).toEqual([]);
+    expect([...result.current.pendingRemoveIds]).toEqual([]);
+  });
+
+  it('add: a not-yet-saved pending addition surfaces in pendingAddIds', () => {
+    const { result } = renderHook(() => useToggleTriple([1], [row(5)], undefined, getId));
+    expect([...result.current.savedIds]).toEqual([1]);
+    expect([...result.current.pendingAddIds]).toEqual([5]);
+    expect([...result.current.pendingRemoveIds]).toEqual([]);
+  });
+
+  it('remove: a saved id staged for removal surfaces in pendingRemoveIds', () => {
+    const { result } = renderHook(() => useToggleTriple([1, 2], undefined, [2], getId));
+    expect([...result.current.savedIds]).toEqual([1, 2]);
+    expect([...result.current.pendingAddIds]).toEqual([]);
+    expect([...result.current.pendingRemoveIds]).toEqual([2]);
+  });
+
+  it('re-add after remove: an id can appear in both pendingAdd and pendingRemove independently', () => {
+    // id 2 is saved+removed; id 5 is a fresh add. The triple keeps the two channels separate.
+    const { result } = renderHook(() => useToggleTriple([2], [row(5)], [2], getId));
+    expect([...result.current.savedIds]).toEqual([2]);
+    expect([...result.current.pendingAddIds]).toEqual([5]);
+    expect([...result.current.pendingRemoveIds]).toEqual([2]);
+  });
+
+  it('ignores already-saved ids passed in pendingAdds (callers may pass raw membership)', () => {
+    // 1 is already saved, 9 is genuinely new — only 9 counts as a pending add.
+    const { result } = renderHook(() => useToggleTriple([1], [row(1), row(9)], undefined, getId));
+    expect([...result.current.pendingAddIds]).toEqual([9]);
+  });
+
+  it('memoizes each set across re-renders with stable inputs', () => {
+    const originalIds = [1, 2];
+    const adds = [row(5)];
+    const removes = [2];
+    const { result, rerender } = renderHook(() =>
+      useToggleTriple(originalIds, adds, removes, getId)
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current.savedIds).toBe(first.savedIds);
+    expect(result.current.pendingAddIds).toBe(first.pendingAddIds);
+    expect(result.current.pendingRemoveIds).toBe(first.pendingRemoveIds);
+  });
+});


### PR DESCRIPTION
## MR B — Entity-edit DRY wins

Eliminates 3 duplications between the image-edit and collection-edit flows. Plan: `docs/superpowers/plans/006-entity-edit-dry-wins.md`.

- **Win #1** — `buildAssociationDiff<T>` replaces the ~90%-identical private `buildTagsDiff`/`buildPeopleDiff` in `metadataUtils.ts` (adopted at all 3 call sites).
- **Win #2** — promote the pure `toggleRelation` engine to `app/utils/collectionToggle.ts` (re-exported from `manageUtils` so existing callers/tests are unchanged); the image side adopts it via a thin flat-array adapter `toggleCollectionFlat`.
- **Win #3** — new `app/hooks/useToggleTriple.ts` derives `(savedIds, pendingAddIds, pendingRemoveIds)`; replaces byte-identical `useMemo` triples at 4 sites (image collections + child/sibling/parent pickers in `ManageClient`).

### Verification
- `tsc --noEmit`: clean
- jest: **93 suites / 1740 tests** green (baseline 92/1729 → +1 suite, +11 cases)
- eslint clean on all touched files

### Commits
1. `refactor(metadata): extract buildAssociationDiff<T> for tags + people` (Win #1)
2. `refactor(collections): share toggleRelation engine + add useToggleTriple hook` (Wins #2+#3 — both edit `useMetadataState.ts` and are entangled, so a clean 3-way split would yield a non-compiling intermediate commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)