### PR TITLE
refactor(text-block): lift TextBlockCreateModal format + align option ladders to module scope

### DIFF
--- a/app/components/TextBlockCreateModal/TextBlockCreateModal.tsx
+++ b/app/components/TextBlockCreateModal/TextBlockCreateModal.tsx
@@ -5,16 +5,18 @@ import { type SubmitEvent, useState } from 'react';
 import { LoadingSpinner } from '@/app/components/LoadingSpinner/LoadingSpinner';
 import { CloseButton } from '@/app/components/ui/CloseButton/CloseButton';
 import { Modal } from '@/app/components/ui/Modal/Modal';
+import {
+  TEXT_ALIGN_OPTIONS,
+  TEXT_FORMAT_OPTIONS,
+  type TextAlign,
+  type TextFormat,
+} from '@/app/types/Content';
 
 import styles from './TextBlockCreateModal.module.scss';
 
 interface TextBlockCreateModalProps {
   onClose: () => void;
-  onSubmit: (data: {
-    content: string;
-    format: 'plain' | 'markdown' | 'html';
-    align: 'left' | 'center' | 'right';
-  }) => Promise<void>;
+  onSubmit: (data: { content: string; format: TextFormat; align: TextAlign }) => Promise<void>;
 }
 
 /**
@@ -28,8 +30,8 @@ interface TextBlockCreateModalProps {
  */
 export default function TextBlockCreateModal({ onClose, onSubmit }: TextBlockCreateModalProps) {
   const [content, setContent] = useState('');
-  const [format, setFormat] = useState<'plain' | 'markdown' | 'html'>('plain');
-  const [align, setAlign] = useState<'left' | 'center' | 'right'>('left');
+  const [format, setFormat] = useState<TextFormat>('plain');
+  const [align, setAlign] = useState<TextAlign>('left');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -93,12 +95,14 @@ export default function TextBlockCreateModal({ onClose, onSubmit }: TextBlockCre
               <label className={styles.formLabel}>Format</label>
               <select
                 value={format}
-                onChange={e => setFormat(e.target.value as 'plain' | 'markdown' | 'html')}
+                onChange={e => setFormat(e.target.value as TextFormat)}
                 className={styles.formSelect}
               >
-                <option value="plain">Plain Text</option>
-                <option value="markdown">Markdown</option>
-                <option value="html">HTML</option>
+                {TEXT_FORMAT_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </div>
 
@@ -106,12 +110,14 @@ export default function TextBlockCreateModal({ onClose, onSubmit }: TextBlockCre
               <label className={styles.formLabel}>Alignment</label>
               <select
                 value={align}
-                onChange={e => setAlign(e.target.value as 'left' | 'center' | 'right')}
+                onChange={e => setAlign(e.target.value as TextAlign)}
                 className={styles.formSelect}
               >
-                <option value="left">Left</option>
-                <option value="center">Center</option>
-                <option value="right">Right</option>
+                {TEXT_ALIGN_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </div>
           </div>

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -130,15 +130,41 @@ export interface TextBlockItem {
 }
 
 /**
+ * Selectable text-block format options. Single source of truth for both the
+ * `TextFormat` union below and the `<option>` ladder in `TextBlockCreateModal`.
+ */
+export const TEXT_FORMAT_OPTIONS = [
+  { value: 'plain', label: 'Plain Text' },
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'html', label: 'HTML' },
+] as const;
+
+/** Frontend text-block format union, derived from {@link TEXT_FORMAT_OPTIONS}. */
+export type TextFormat = (typeof TEXT_FORMAT_OPTIONS)[number]['value'];
+
+/**
+ * Selectable text-block alignment options. Single source of truth for both the
+ * `TextAlign` union below and the `<option>` ladder in `TextBlockCreateModal`.
+ */
+export const TEXT_ALIGN_OPTIONS = [
+  { value: 'left', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'right', label: 'Right' },
+] as const;
+
+/** Frontend text-block alignment union, derived from {@link TEXT_ALIGN_OPTIONS}. */
+export type TextAlign = (typeof TEXT_ALIGN_OPTIONS)[number]['value'];
+
+/**
  * Text content model - displays structured text content as items
  * Each text block contains an array of items that can be individually styled/edited
  */
 export interface ContentTextModel extends Content {
   contentType: 'TEXT';
   items: TextBlockItem[]; // Array of text items (required)
-  format: 'plain' | 'markdown' | 'html'; // Frontend format type
+  format: TextFormat; // Frontend format type
   formatType?: 'plain' | 'markdown' | 'html' | 'js' | 'css' | 'json'; // Backend field (maps to format)
-  align: 'left' | 'center' | 'right';
+  align: TextAlign;
 }
 
 /**


### PR DESCRIPTION
## MR C — Inline-JSX Win #3 (TextBlock config lift)

Lifts the two inline `<select>`/`<option>` ladders in `TextBlockCreateModal` to module-scope `const` arrays. Plan: `docs/superpowers/plans/006-inline-jsx-config-cross-file.md` (Win #3; Wins #1/#2 shipped in #172).

- `TEXT_FORMAT_OPTIONS` / `TEXT_ALIGN_OPTIONS` (`as const`) added to `app/types/Content.ts`, rendered via `.map()` with labels preserved verbatim.
- `TextFormat` / `TextAlign` unions **derived** from the consts; `ContentTextModel.format`/`.align` repointed to them. The wider backend `formatType` field is untouched.

### Verification
- `tsc --noEmit`: clean (project-wide — derived unions are structurally identical, all consumers compile)
- jest: **92 suites / 1729 tests** green (baseline)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)