### PR TITLE
chore(deps): upgrade React 18 → 19 runtime (+ lucide-react 1.x)

### DIFF
--- a/ai_guidelines/ai_typescript.md
+++ b/ai_guidelines/ai_typescript.md
@@ -236,30 +236,32 @@ const model: CollectionModel = { type: 'PORTFOLIO', ... };
 
 ## Known Type Issues
 
-### React 18 Runtime / @types/react 19 Mismatch
+### React 18 → 19 Runtime Upgrade (RESOLVED 2026-06-06)
 
-**Status**: Documented, intentionally not fixed.
+**Status**: ✅ Resolved. The runtime is now React 19; runtime and types are aligned.
 
-The project uses `react: ^18.3.1` (runtime) with `@types/react: ^19.2.10` (type definitions).
-This mismatch exists because:
+The project uses `react`/`react-dom: ^19.2.7` (runtime) with `@types/react: ^19.2.10` and
+`@types/react-dom: ^19.2.3` (types). The prior 18-runtime / 19-types mismatch is gone.
 
-- Next.js 15+ ships React 19 types and recommends the newer type definitions
-- The actual React runtime remains at 18.x for stability
-- Upgrading React to 19 would require testing all components and hooks for breaking changes
-  (e.g., `ref` as prop, removal of implicit `children`, new `use()` hook semantics)
+The upgrade was transparent: `tsc` clean and the full jest suite green with **no source changes**.
+`types-react-codemod preset-19` was run and produced no _necessary_ changes — the codebase was
+already authored against the React 19 types, so its only proposals were spurious (`RefObject<T>`
+null-widening that reduced precision) or rule-violating (`ReactElement<any>`, which trips
+`@typescript-eslint/no-explicit-any`); all were reverted. The migration surface was tiny: one
+`forwardRef` (`Tile.tsx`, still valid in 19), two `createContext` (`.Provider` still valid), no
+string refs, no bare `useRef()`, no `propTypes`/`defaultProps`, no legacy `ReactDOM` APIs.
 
-**Impact**: Mostly transparent. Some React 19 type features (like `SubmitEvent<HTMLFormElement>`)
-are available in types but not in the runtime. Use `FormEvent<HTMLFormElement>` if the React 19
-`SubmitEvent` causes runtime issues.
+`SubmitEvent<HTMLFormElement>` (imported from `react`) works under the React 19 runtime and is
+kept as-is — see the **React 19 Event Types** section above.
 
-**Resolution plan**: Upgrade React to 19 when Next.js 15 is fully stable and all dependencies
-(MUI, react-zoom-pan-pinch, @react-spring/parallax) confirm React 19 compatibility.
+### Dependency Notes (as of 2026-06)
 
-### Dependency Notes (as of 2026-03)
-
-- `lucide-react: ^0.399.0` - Current. Check for major version bumps periodically.
-- `@react-spring/parallax: ^9.6.1` - Does not yet support React 19 runtime. Keep React 18.
-- `react-zoom-pan-pinch: ^3.4.4` - Check React 19 compat before upgrading React.
+- `react` / `react-dom: ^19.2.7` - upgraded from `^18.3.1` (2026-06-06).
+- `lucide-react: ^1.17.0` - upgraded from `^0.399.0` (a `0.x` → `1.x` major bump; named-icon
+  import API is stable, verified via `tsc` + `next build`).
+- The former React-19 blockers (`@react-spring/parallax`, `react-zoom-pan-pinch`, MUI) are no
+  longer dependencies — they were removed in the chapter-006 dead-dep cleanup, which is what
+  unblocked this upgrade.
 
 ## Type Safety Checklist
 

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -199,6 +199,11 @@ export function useFullScreenImage(): {
     const timeoutId = setTimeout(checkImageLoaded, 100);
 
     return () => clearTimeout(timeoutId);
+    // Intentionally keyed to currentIndex only. This effect re-checks whether the
+    // newly-shown image has finished loading; it should re-run when the viewer moves
+    // to a different image, not on every fullScreenState mutation (e.g. scrollPosition
+    // changes). It reads the current image via fullScreenState and calls the stable
+    // setLoadedImageIds dispatcher — listing either would only cause redundant re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullScreenState?.currentIndex]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "lucide-react": "^0.399.0",
+        "lucide-react": "^1.17.0",
         "next": "^16.2.6",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "sass": "^1.77.8"
       },
       "devDependencies": {
@@ -8590,6 +8590,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8820,6 +8821,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8839,9 +8841,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.399.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.399.0.tgz",
-      "integrity": "sha512-UyTNa3djBISdzL2UktgCrESXexQXaDQWi/WsDkbw6fBFfHlapajR58WoR+gxQ4laxfEyiHmoFrEIM3V+5XOVQg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10364,28 +10366,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/read-pkg": {
@@ -10848,13 +10846,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "test:ci": "jest --ci --coverage"
   },
   "dependencies": {
-    "lucide-react": "^0.399.0",
+    "lucide-react": "^1.17.0",
     "next": "^16.2.6",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "sass": "^1.77.8"
   },
   "overrides": {


### PR DESCRIPTION
## MR A — React 18 → 19 runtime upgrade

Plan: `docs/superpowers/plans/006-dependency-upgrade.md`. Lands the runtime upgrade (the P0 item) now that the former blockers (`@react-spring/parallax`, `react-zoom-pan-pinch`, MUI) are gone and `@types/react` was already on `^19`.

### Changes
- `react` / `react-dom`: `^18.3.1` → `^19.2.7` (runtime now aligned with the already-installed React 19 types)
- `lucide-react`: `^0.399.0` → `^1.17.0` (0.x → 1.x major; named-icon import API stable)
- `package-lock.json` regenerated via fresh `npm install`
- `useFullScreenImage.tsx`: replaced a bare `eslint-disable` with a justified comment (the image-loaded-check effect is intentionally keyed to `currentIndex` only)
- `ai_guidelines/ai_typescript.md`: marked the React-18-runtime / types-19 mismatch **resolved**; refreshed dependency notes

### Codemods
`types-react-codemod preset-19` was run and produced **no necessary changes** — the codebase was already authored against the React 19 types. Its only proposals were spurious (`RefObject<T>` null-widening that reduced precision on a non-null `useRef(false)`) or rule-violating (`ReactElement<any>`, which trips `@typescript-eslint/no-explicit-any`), so all 6 were reverted. Migration surface was tiny: one `forwardRef` (`Tile.tsx`, still valid in 19), two `createContext` (`.Provider` still valid), no string refs, no bare `useRef()`, no `propTypes`/`defaultProps`, no legacy `ReactDOM`.

### Verification
- `tsc --noEmit`: clean
- jest: **92 suites / 1729 tests** green
- `next build`: succeeds (all 17 routes, TypeScript clean)
- **Smoke (dev server on React 19):** home grid + parallax hero render; `/event` collection renders 54 images via BoxTree; fullscreen modal opens (ref-driven `modalRef`/`isSwiping`) and ArrowRight navigation advances images; **zero console errors / no hydration mismatches**; `SubmitEvent` forms compile + build fine (runtime is type-agnostic)

Disjoint from #174 / #175 — no shared files, merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)