### PR TITLE
refactor(react19): adopt ref-as-prop + <Context> provider idioms

### DIFF
--- a/app/components/ContentCollection/ClientGalleryDownloadContext.tsx
+++ b/app/components/ContentCollection/ClientGalleryDownloadContext.tsx
@@ -31,11 +31,7 @@ export function ClientGalleryDownloadProvider({
   children: React.ReactNode;
   value: ClientGalleryDownloadContextValue;
 }) {
-  return (
-    <ClientGalleryDownloadContext.Provider value={value}>
-      {children}
-    </ClientGalleryDownloadContext.Provider>
-  );
+  return <ClientGalleryDownloadContext value={value}>{children}</ClientGalleryDownloadContext>;
 }
 
 /** Returns the download/select state, or null when rendered outside a client gallery. */

--- a/app/components/ContentCollection/CollectionFilterContext.tsx
+++ b/app/components/ContentCollection/CollectionFilterContext.tsx
@@ -55,9 +55,7 @@ export function CollectionFilterProvider({
   children: React.ReactNode;
   value: CollectionFilterContextValue;
 }) {
-  return (
-    <CollectionFilterContext.Provider value={value}>{children}</CollectionFilterContext.Provider>
-  );
+  return <CollectionFilterContext value={value}>{children}</CollectionFilterContext>;
 }
 
 export function useCollectionFilter(): CollectionFilterContextValue | null {

--- a/app/components/ui/Tile/Tile.tsx
+++ b/app/components/ui/Tile/Tile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link, { type LinkProps } from 'next/link';
-import { type AnchorHTMLAttributes, forwardRef, type ReactNode } from 'react';
+import { type AnchorHTMLAttributes, type ReactNode, type Ref } from 'react';
 
 import styles from './Tile.module.scss';
 
@@ -11,6 +11,8 @@ export interface TileProps
   'aria-label': string;
   children: ReactNode;
   className?: string;
+  /** Forwarded to the underlying next/link `<a>` (React 19 ref-as-prop). */
+  ref?: Ref<HTMLAnchorElement>;
 }
 
 /**
@@ -20,14 +22,11 @@ export interface TileProps
  * is reserved for genuine non-nav actions (fullscreen-open); navigation is the
  * <a href>, so middle-click / cmd-click keep working.
  */
-export const Tile = forwardRef<HTMLAnchorElement, TileProps>(function Tile(
-  { children, className, ...rest },
-  ref
-) {
+export function Tile({ children, className, ref, ...rest }: TileProps) {
   const classes = [styles.tile, className].filter(Boolean).join(' ');
   return (
     <Link ref={ref} className={classes} {...rest}>
       {children}
     </Link>
   );
-});
+}


### PR DESCRIPTION
## React 19 idiom modernizations

Optional follow-ups after the React 19 runtime upgrade (#176). These were the only items the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide) flagged that the codebase hadn't already adopted — everything else (removed ReactDOM/test-utils/propTypes/string-refs/etc.) was already absent or already correct (`act` from `@testing-library/react`, scoped `React.JSX.Element`, new JSX transform).

### Changes
- **`Tile.tsx`** — `forwardRef` → **ref-as-prop**. React 19 passes `ref` as a normal prop, so the `forwardRef` wrapper is dropped; `ref?: Ref<HTMLAnchorElement>` is declared on `TileProps` and forwarded to the `next/link` `<a>`. No caller passes a ref today, so behavior is unchanged.
- **`ClientGalleryDownloadContext.tsx` / `CollectionFilterContext.tsx`** — `<Context.Provider value>` → **`<Context value>`** (React 19 renders a context object directly as its provider).

Both are idiom updates — `forwardRef` and `.Provider` still work in 19; this just adopts the current form.

### ⚠️ Stacks on #176
This branch is based on `0171-react-19-upgrade` because ref-as-prop **requires the React 19 runtime**. **Merge #176 first** — afterward this PR's diff reduces to just the two modernization commits and merges cleanly onto `main`.

### Verification
- `tsc --noEmit`: clean · jest: **92 suites / 1729 tests** green · eslint clean
- **Smoke (React 19 dev server):** home grid renders; clicking a `Tile` navigates to `/film` (ref-as-prop nav intact); collection page renders through `CollectionFilterContext`; **zero console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)