### PR TITLE
fix(layout): adopt measured width on mobile so tiles fill the viewport

### DIFF
--- a/app/components/Content/componentUtils.ts
+++ b/app/components/Content/componentUtils.ts
@@ -39,10 +39,16 @@ export function resolveEffectiveViewport(
   server: ServerViewport,
   tolerance: number
 ): EffectiveViewport {
+  // The tolerance keeps the SSR width across hydration to avoid a reflow. On desktop the SSR
+  // width is capped at pageMaxWidth, so it matches most real viewports exactly and keeping it is
+  // free. Mobile has no width cap, so a real device wider than the SSR fallback (e.g. a 430px
+  // phone vs the 390px default) would stay short of full-bleed. On mobile we therefore drop the
+  // tolerance and always adopt the measured width.
+  const effectiveTolerance = measured.isMobile ? 0 : tolerance;
   const useMeasured = shouldUseMeasuredWidth(
     measured.contentWidth,
     server.serverContentWidth,
-    tolerance
+    effectiveTolerance
   );
   return {
     contentWidth: useMeasured

--- a/tests/components/Content/componentUtils.test.ts
+++ b/tests/components/Content/componentUtils.test.ts
@@ -75,6 +75,38 @@ describe('resolveEffectiveViewport', () => {
     const result = resolveEffectiveViewport(measured({ contentWidth: 1100 }), {}, TOL);
     expect(result.contentWidth).toBe(1100);
   });
+
+  it('recomputes to the measured width on mobile even within tolerance (full-bleed)', () => {
+    // iPhone 14 Pro Max: SSR assumes 390px, the device measures 430px. The 40px gap is
+    // within the 64px desktop tolerance, but mobile has no width cap and must fill the
+    // viewport edge-to-edge, so it adopts the measured width instead of keeping 390.
+    const mobileServer = {
+      serverContentWidth: 390,
+      serverViewportHeight: 844,
+      serverIsMobile: true,
+    };
+    const result = resolveEffectiveViewport(
+      measured({ contentWidth: 430, width: 430, viewportHeight: 932, isMobile: true }),
+      mobileServer,
+      TOL
+    );
+    expect(result).toEqual<EffectiveViewport>({
+      contentWidth: 430,
+      viewportHeight: 932,
+      isMobile: true,
+    });
+  });
+
+  it('keeps the SSR width on desktop when the measured width is wider within tolerance', () => {
+    // Desktop guard: the anti-flash tolerance still applies off mobile, so a 26px-wider
+    // measurement keeps the SSR width (no hydration reflow).
+    const result = resolveEffectiveViewport(
+      measured({ contentWidth: 1300, viewportHeight: 700, isMobile: false }),
+      server,
+      TOL
+    );
+    expect(result.contentWidth).toBe(1274);
+  });
 });
 
 describe('computeTargetAspectRatio', () => {


### PR DESCRIPTION
The SSR-recompute tolerance (64px) kept the SSR-assumed mobile width (390px) on real devices up to 64px wider, leaving phones in the 391-454px band (e.g. iPhone 14/15 Pro Max @430) short of full-bleed. Mobile has no width cap, so the tolerance - which exists to avoid a hydration reflow on desktop, where the SSR width is capped and matches real viewports - never applies cleanly on mobile.

Drop the tolerance to 0 on mobile in resolveEffectiveViewport so it always adopts the measured width; desktop behavior (and its anti-flash tolerance) is unchanged.