### PR TITLE
refactor(006): thin-component extraction sweep — 8 components → co-located *Utils.ts

### DIFF
--- a/app/components/Content/BoxRenderer.tsx
+++ b/app/components/Content/BoxRenderer.tsx
@@ -8,6 +8,7 @@ import { logger } from '@/app/utils/logger';
 import { type BoxTree } from '@/app/utils/rowCombination';
 
 import styles from './BoxRenderer.module.scss';
+import { computeReorderFlags } from './boxRendererUtils';
 import CollectionContentRenderer from './CollectionContentRenderer';
 import cbStyles from './ContentComponent.module.scss';
 
@@ -89,11 +90,12 @@ export function BoxRenderer({
     );
 
     const contentId = tree.content.id;
-    const isPickedUp = isReorderMode && pickedUpImageId === contentId;
-    const hasMoved = isReorderMode && (reorderMoves?.some(m => m.imageId === contentId) ?? false);
-    const orderIndex = reorderDisplayOrder?.indexOf(contentId) ?? -1;
-    const isFirstInOrder = orderIndex === 0;
-    const isLastInOrder = orderIndex === (reorderDisplayOrder?.length ?? 0) - 1;
+    const { isPickedUp, hasMoved, isFirstInOrder, isLastInOrder } = computeReorderFlags(contentId, {
+      isReorderMode,
+      pickedUpImageId,
+      reorderMoves,
+      reorderDisplayOrder,
+    });
 
     const fullProps: CollectionContentRendererProps = {
       ...rendererProps,

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -8,10 +8,7 @@ import { type Ref, useCallback, useState } from 'react';
 import ClientGalleryDownload from '@/app/components/ClientGalleryDownload/ClientGalleryDownload';
 import { useCollectionFilter } from '@/app/components/ContentCollection/CollectionFilterContext';
 import { Badge } from '@/app/components/ui/Badge/Badge';
-import {
-  FilterToolbar,
-  type ToolbarDimension,
-} from '@/app/components/ui/FilterToolbar/FilterToolbar';
+import { FilterToolbar } from '@/app/components/ui/FilterToolbar/FilterToolbar';
 import { Tile } from '@/app/components/ui/Tile/Tile';
 import { useParallax } from '@/app/hooks/useParallax';
 import {
@@ -20,7 +17,7 @@ import {
   type ViewableContent,
 } from '@/app/types/Content';
 import { type CollectionContentRendererProps } from '@/app/types/ContentRenderer';
-import { type ArrayFilterKey, toggleArrayFilter } from '@/app/types/GalleryFilter';
+import { toggleArrayFilter } from '@/app/types/GalleryFilter';
 import {
   checkImageVisibility,
   createContentClickHandler,
@@ -32,52 +29,15 @@ import {
 import { slugify } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
 
+import {
+  getClickEligibility,
+  resolveValidDimensions,
+  toCollectionDimensions,
+} from './collectionContentRendererUtils';
 import cbStyles from './ContentComponent.module.scss';
 import { ImageOverlays } from './ImageOverlays';
 import variantStyles from './ParallaxImageRenderer.module.scss';
 import ReorderOverlay from './ReorderOverlay';
-
-/**
- * Maps the collection page's CollectionInfoOptions (per-dimension `filterable`
- * + values) into the toolbar's `dimensions` config. Only filterable dimensions
- * with at least one value become dropdowns; lens names and lens-type chips are
- * surfaced as separate dropdowns (types carry display labels).
- */
-function toCollectionDimensions(
-  options: NonNullable<ReturnType<typeof useCollectionFilter>>['filterOptions']
-): Partial<Record<ArrayFilterKey, ToolbarDimension>> {
-  const dims: Partial<Record<ArrayFilterKey, ToolbarDimension>> = {};
-  if (options.people.filterable && options.people.values.length > 0) {
-    dims.selectedPeople = { label: 'People', options: options.people.values };
-  }
-  if (options.tags.filterable && options.tags.values.length > 0) {
-    dims.selectedTags = { label: 'Tags', options: options.tags.values };
-  }
-  if (options.cameras.filterable && options.cameras.values.length > 0) {
-    dims.selectedCameras = { label: 'Camera', options: options.cameras.values };
-  }
-  if (options.locations.filterable && options.locations.values.length > 0) {
-    dims.selectedLocations = { label: 'Location', options: options.locations.values };
-  }
-  if (
-    (options.lenses.filterable && options.lenses.values.length > 0) ||
-    (options.lensTypes.filterable && options.lensTypes.values.length > 0)
-  ) {
-    // Lens is surfaced as two dropdowns: NAMES and TYPES.
-    dims.selectedLenses = {
-      label: 'Lens',
-      options: options.lenses.values,
-    };
-    if (options.lensTypes.values.length > 0) {
-      dims.selectedLensTypes = {
-        label: 'Lens type',
-        options: options.lensTypes.values,
-        optionLabels: { wide: 'Wide', normal: 'Normal', telephoto: 'Telephoto' },
-      };
-    }
-  }
-  return dims;
-}
 
 /**
  * Renders a single content item: IMAGE, GIF, COLLECTION, or TEXT metadata block.
@@ -134,19 +94,16 @@ export default function CollectionContentRenderer({
   // Parallax hook (always called, but disabled if enableParallax = false)
   const parallaxRef = useParallax({ enableParallax });
 
-  // COLLECTION tiles navigate via href; IMAGE/GIF fullscreen stays on onClick.
-  const isSlugNav = !!_hasSlug && !onImageClick && !isReorderMode && contentType !== 'TEXT';
-
-  // Whether a meaningful click action exists for this item (used for cursor/style checks).
-  // Mirrors the guard logic in handleClick: TEXT and reorder mode produce no action,
-  // slug-only navigation fires when _hasSlug is set and no onImageClick is present,
-  // otherwise a handler exists when onImageClick or fullscreen is configured.
-  const hasClickHandler =
-    contentType !== 'TEXT' &&
-    !isReorderMode &&
-    ((_hasSlug !== undefined && !onImageClick) ||
-      !!onImageClick ||
-      !!(enableFullScreenView && onFullScreenImageClick));
+  // COLLECTION tiles navigate via href; IMAGE/GIF fullscreen stays on onClick. `hasClickHandler`
+  // mirrors the guard logic in handleClick (TEXT/reorder produce no action).
+  const { hasClickHandler, isSlugNav } = getClickEligibility({
+    contentType,
+    isReorderMode,
+    hasSlug: _hasSlug,
+    onImageClick,
+    enableFullScreenView,
+    onFullScreenImageClick,
+  });
 
   const handleClick = useCallback(() => {
     if (contentType === 'TEXT') return;
@@ -529,32 +486,12 @@ export default function CollectionContentRenderer({
     });
   }
 
-  let validWidth = width;
-  let validHeight = height;
-
-  if (!Number.isFinite(width) || !Number.isFinite(height)) {
-    if (imageWidth && imageHeight && imageWidth > 0 && imageHeight > 0) {
-      if (!Number.isFinite(width) && Number.isFinite(height)) {
-        validWidth = (height * imageWidth) / imageHeight;
-      } else if (!Number.isFinite(height) && Number.isFinite(width)) {
-        validHeight = (width * imageHeight) / imageWidth;
-      } else {
-        validWidth = 300;
-        validHeight = 200;
-      }
-    } else {
-      if (!Number.isFinite(width)) {
-        validWidth = Number.isFinite(height) ? height * 1.5 : 300;
-      }
-      if (!Number.isFinite(height)) {
-        validHeight = Number.isFinite(width) ? width / 1.5 : 200;
-      }
-      if (!Number.isFinite(validWidth) && !Number.isFinite(validHeight)) {
-        validWidth = 300;
-        validHeight = 200;
-      }
-    }
-  }
+  const { width: validWidth, height: validHeight } = resolveValidDimensions({
+    width,
+    height,
+    imageWidth,
+    imageHeight,
+  });
 
   const wrapperProps = {
     className: enableParallax

--- a/app/components/Content/boxRendererUtils.ts
+++ b/app/components/Content/boxRendererUtils.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helpers for {@link BoxRenderer} — kept out of the component so the recursive JSX stays a thin
+ * prop-plumbing pass and the reorder-flag derivation is unit-testable in isolation.
+ */
+
+import { type ReorderMove } from '@/app/(admin)/collection/manage/[[...slug]]/manageUtils';
+
+/** The reorder-mode state available to a single rendered content item. */
+export interface ReorderState {
+  isReorderMode?: boolean;
+  pickedUpImageId?: number | null;
+  reorderMoves?: ReorderMove[];
+  reorderDisplayOrder?: number[];
+}
+
+/** Per-item reorder flags consumed by the content renderer's reorder overlay. */
+export interface ReorderFlags {
+  isPickedUp: boolean;
+  hasMoved: boolean;
+  isFirstInOrder: boolean;
+  isLastInOrder: boolean;
+}
+
+/**
+ * Derive the reorder flags for one content item from the current reorder state. Outside reorder mode
+ * an item is never picked up or moved. Position flags fall back to "last" when the id is absent from
+ * `reorderDisplayOrder` or the order is empty (orderIndex -1 === length 0 - 1).
+ */
+export function computeReorderFlags(contentId: number, state: ReorderState): ReorderFlags {
+  const { isReorderMode, pickedUpImageId, reorderMoves, reorderDisplayOrder } = state;
+  const orderIndex = reorderDisplayOrder?.indexOf(contentId) ?? -1;
+  return {
+    isPickedUp: !!isReorderMode && pickedUpImageId === contentId,
+    hasMoved: !!isReorderMode && (reorderMoves?.some(m => m.imageId === contentId) ?? false),
+    isFirstInOrder: orderIndex === 0,
+    isLastInOrder: orderIndex === (reorderDisplayOrder?.length ?? 0) - 1,
+  };
+}

--- a/app/components/Content/collectionContentRendererUtils.ts
+++ b/app/components/Content/collectionContentRendererUtils.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure helpers for {@link CollectionContentRenderer} — filter-dimension mapping, click-eligibility
+ * derivation, and NaN-dimension recovery. Kept out of the component so the JSX stays thin and the
+ * logic is unit-testable in isolation. No hooks, no JSX, no side effects (the NaN `logger.error`
+ * stays in the component).
+ */
+
+import { type CollectionInfoOptions } from '@/app/components/ContentCollection/CollectionFilterContext';
+import { type ToolbarDimension } from '@/app/components/ui/FilterToolbar/FilterToolbar';
+import { type ContentType, type ViewableContent } from '@/app/types/Content';
+import { type ArrayFilterKey } from '@/app/types/GalleryFilter';
+
+/**
+ * Maps the collection page's CollectionInfoOptions (per-dimension `filterable`
+ * + values) into the toolbar's `dimensions` config. Only filterable dimensions
+ * with at least one value become dropdowns; lens names and lens-type chips are
+ * surfaced as separate dropdowns (types carry display labels).
+ */
+export function toCollectionDimensions(
+  options: CollectionInfoOptions
+): Partial<Record<ArrayFilterKey, ToolbarDimension>> {
+  const dims: Partial<Record<ArrayFilterKey, ToolbarDimension>> = {};
+  if (options.people.filterable && options.people.values.length > 0) {
+    dims.selectedPeople = { label: 'People', options: options.people.values };
+  }
+  if (options.tags.filterable && options.tags.values.length > 0) {
+    dims.selectedTags = { label: 'Tags', options: options.tags.values };
+  }
+  if (options.cameras.filterable && options.cameras.values.length > 0) {
+    dims.selectedCameras = { label: 'Camera', options: options.cameras.values };
+  }
+  if (options.locations.filterable && options.locations.values.length > 0) {
+    dims.selectedLocations = { label: 'Location', options: options.locations.values };
+  }
+  if (
+    (options.lenses.filterable && options.lenses.values.length > 0) ||
+    (options.lensTypes.filterable && options.lensTypes.values.length > 0)
+  ) {
+    // Lens is surfaced as two dropdowns: NAMES and TYPES.
+    dims.selectedLenses = {
+      label: 'Lens',
+      options: options.lenses.values,
+    };
+    if (options.lensTypes.values.length > 0) {
+      dims.selectedLensTypes = {
+        label: 'Lens type',
+        options: options.lensTypes.values,
+        optionLabels: { wide: 'Wide', normal: 'Normal', telephoto: 'Telephoto' },
+      };
+    }
+  }
+  return dims;
+}
+
+/** Inputs that decide whether/how a content item responds to a click. */
+export interface ClickEligibilityInput {
+  contentType: ContentType;
+  isReorderMode: boolean;
+  /** The item's slug (route segment), or undefined when it does not navigate. */
+  hasSlug: string | undefined;
+  onImageClick?: (imageId: number) => void;
+  enableFullScreenView?: boolean;
+  onFullScreenImageClick?: (image: ViewableContent) => void;
+}
+
+/** Whether an item navigates via href (`isSlugNav`) and/or has a meaningful click action. */
+export interface ClickEligibility {
+  hasClickHandler: boolean;
+  isSlugNav: boolean;
+}
+
+/**
+ * Derive click eligibility for a content item. COLLECTION tiles navigate via href; IMAGE/GIF
+ * fullscreen stays on `onClick`. TEXT and reorder mode produce no action; slug-only navigation
+ * fires when `hasSlug` is set and no `onImageClick` is present; otherwise a handler exists when
+ * `onImageClick` or fullscreen is configured.
+ */
+export function getClickEligibility(input: ClickEligibilityInput): ClickEligibility {
+  const {
+    contentType,
+    isReorderMode,
+    hasSlug,
+    onImageClick,
+    enableFullScreenView,
+    onFullScreenImageClick,
+  } = input;
+
+  const isSlugNav = !!hasSlug && !onImageClick && !isReorderMode && contentType !== 'TEXT';
+
+  const hasClickHandler =
+    contentType !== 'TEXT' &&
+    !isReorderMode &&
+    ((hasSlug !== undefined && !onImageClick) ||
+      !!onImageClick ||
+      !!(enableFullScreenView && onFullScreenImageClick));
+
+  return { hasClickHandler, isSlugNav };
+}
+
+/** The four dimension inputs subject to NaN recovery. */
+export interface DimensionInput {
+  width: number;
+  height: number;
+  imageWidth?: number;
+  imageHeight?: number;
+}
+
+/** A width/height pair guaranteed finite after recovery. */
+export interface ResolvedDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Recover finite render dimensions when `width`/`height` arrive as NaN. Prefers the image's
+ * intrinsic aspect ratio; falls back to a 1.5 aspect ratio against the finite dimension, then to a
+ * 300×200 default. When both width and height are already finite this is a no-op passthrough.
+ *
+ * Pure — the diagnostic `logger.error` for the NaN case stays in the component.
+ */
+export function resolveValidDimensions({
+  width,
+  height,
+  imageWidth,
+  imageHeight,
+}: DimensionInput): ResolvedDimensions {
+  let validWidth = width;
+  let validHeight = height;
+
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    if (imageWidth && imageHeight && imageWidth > 0 && imageHeight > 0) {
+      if (!Number.isFinite(width) && Number.isFinite(height)) {
+        validWidth = (height * imageWidth) / imageHeight;
+      } else if (!Number.isFinite(height) && Number.isFinite(width)) {
+        validHeight = (width * imageHeight) / imageWidth;
+      } else {
+        validWidth = 300;
+        validHeight = 200;
+      }
+    } else {
+      if (!Number.isFinite(width)) {
+        validWidth = Number.isFinite(height) ? height * 1.5 : 300;
+      }
+      if (!Number.isFinite(height)) {
+        validHeight = Number.isFinite(width) ? width / 1.5 : 200;
+      }
+      if (!Number.isFinite(validWidth) && !Number.isFinite(validHeight)) {
+        validWidth = 300;
+        validHeight = 200;
+      }
+    }
+  }
+
+  return { width: validWidth, height: validHeight };
+}

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -7,12 +7,19 @@ import { fromMobileDensity, LAYOUT, toMobileDensity } from '@/app/constants';
 import { useFilterUrlState } from '@/app/hooks/useFilterUrlState';
 import { useViewport } from '@/app/hooks/useViewport';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
-import { type ContentCollectionModel, type ContentImageModel } from '@/app/types/Content';
 import { type FilterState, INITIAL_FILTER_STATE, type LensType } from '@/app/types/GalleryFilter';
-import { extractFilterOptions, filterContent, isImageContent } from '@/app/utils/contentFilter';
+import {
+  applyCollectionFilters,
+  buildCollectionCriteria,
+  extractCollectionFilterOptions,
+  hasAnyActiveFilter,
+  hasFilterableOptions,
+  hasValueVariance,
+  isImageContent,
+  mergeDateSortedImages,
+} from '@/app/utils/contentFilter';
 import { processContentBlocks } from '@/app/utils/contentLayout';
 import { isContentCollection } from '@/app/utils/contentTypeGuards';
-import { getLensType } from '@/app/utils/focalLength';
 import { toggleImageSelection } from '@/app/utils/imageSelection';
 import { sortByDate } from '@/app/utils/sortByDate';
 
@@ -32,46 +39,6 @@ interface CollectionPageClientProps {
   serverContentWidth?: number;
   serverViewportHeight?: number;
   serverIsMobile?: boolean;
-}
-
-/**
- * Extracts filter options specific to collection pages.
- *
- * Returns per-dimension data with a `filterable` flag. When a dimension has
- * exactly one value and the dimension's policy allows info-mode (cameras /
- * lenses / locations), filterable is set to false so the bar renders it as
- * an inline info chip instead of a dropdown.
- */
-function extractCollectionFilterOptions(
-  images: ContentImageModel[],
-  collectionRefs: ContentCollectionModel[] = []
-): CollectionDimensions {
-  // Pass images + refs together so extractFilterOptions can aggregate filter
-  // dimensions from collection refs too. This is what populates the filter bar
-  // on synthetic PARENT pages whose `content` is 100% collection refs and 0
-  // images (e.g. /all-collections, /all-blog).
-  const baseOptions = extractFilterOptions([...images, ...collectionRefs], 0.9);
-
-  // Lens types: only show if 2+ distinct categories present (image-only signal)
-  const lensTypeSet = new Set<LensType>();
-  for (const img of images) {
-    const lt = getLensType(img.focalLength);
-    if (lt !== null) lensTypeSet.add(lt);
-  }
-  const typeOrder: LensType[] = ['wide', 'normal', 'telephoto'];
-  const lensTypes =
-    lensTypeSet.size >= 2 && baseOptions.lenses.length >= 2
-      ? typeOrder.filter(t => lensTypeSet.has(t))
-      : [];
-
-  return {
-    tags: { values: baseOptions.tags, filterable: true },
-    people: { values: baseOptions.people, filterable: true },
-    cameras: { values: baseOptions.cameras, filterable: baseOptions.cameras.length >= 2 },
-    lenses: { values: baseOptions.lenses, filterable: baseOptions.lenses.length >= 2 },
-    locations: { values: baseOptions.locations, filterable: baseOptions.locations.length >= 2 },
-    lensTypes: { values: lensTypes, filterable: true },
-  };
 }
 
 const EMPTY_STRING_DIM = { values: [] as readonly string[], filterable: true };
@@ -167,68 +134,26 @@ export default function CollectionPageClient({
   }, [allImages, allCollections, isCollectionDominant]);
 
   // Build criteria from filter state — all AND mode for collection page
-  const criteria = useMemo(
-    () => ({
-      ...(filterState.highlyRatedOnly ? { minRating: 4 } : {}),
-      ...(filterState.selectedTags.length > 0
-        ? { tags: filterState.selectedTags, tagMatchMode: 'AND' as const }
-        : {}),
-      ...(filterState.selectedPeople.length > 0
-        ? { people: filterState.selectedPeople, peopleMatchMode: 'AND' as const }
-        : {}),
-      ...(filterState.selectedCameras.length > 0
-        ? { cameras: filterState.selectedCameras, cameraMatchMode: 'AND' as const }
-        : {}),
-      ...(filterState.selectedLenses.length > 0
-        ? { lenses: filterState.selectedLenses, lensMatchMode: 'AND' as const }
-        : {}),
-      ...(filterState.selectedLocations.length > 0
-        ? { locations: filterState.selectedLocations }
-        : {}),
-    }),
-    [filterState]
-  );
+  const criteria = useMemo(() => buildCollectionCriteria(filterState), [filterState]);
 
-  const hasActiveFilters = useMemo(
-    () =>
-      filterState.highlyRatedOnly ||
-      filterState.selectedTags.length > 0 ||
-      filterState.selectedPeople.length > 0 ||
-      filterState.selectedCameras.length > 0 ||
-      filterState.selectedLenses.length > 0 ||
-      filterState.selectedLensTypes.length > 0 ||
-      filterState.selectedLocations.length > 0,
-    [filterState]
-  );
+  const hasActiveFilters = useMemo(() => hasAnyActiveFilter(filterState), [filterState]);
 
   // Filter only images (for filter UI); non-image content (COLLECTION, TEXT, etc.) passes through
   const filteredContent = useMemo(() => {
     if (!hasActiveFilters) return allContent;
-    let filtered = filterContent(allImages, criteria).filter(isImageContent);
-
-    // Apply lens type filter — images without parseable focalLength are
-    // included intentionally so they aren't silently hidden by a lens-type chip.
-    if (filterState.selectedLensTypes.length > 0) {
-      filtered = filtered.filter(img => {
-        const lt = getLensType(img.focalLength);
-        return lt === null || filterState.selectedLensTypes.includes(lt);
-      });
-    }
-
-    const filteredImageIds = new Set(filtered.map(img => img.id));
-    // Keep non-image content as-is, only filter images
-    return allContent.filter(item => !isImageContent(item) || filteredImageIds.has(item.id));
+    return applyCollectionFilters(allContent, allImages, criteria, filterState.selectedLensTypes);
   }, [allContent, allImages, criteria, hasActiveFilters, filterState.selectedLensTypes]);
 
   const filteredImages = useMemo(() => filteredContent.filter(isImageContent), [filteredContent]);
 
   // Date sort is applied after processContentBlocks (which has its own orderIndex sort)
 
-  const hasRatingVariance = useMemo(() => {
-    if (allImages.length === 0) return false;
-    const ratings = new Set(allImages.map(img => img.rating ?? 0));
-    return ratings.size > 1;
-  }, [allImages]);
+  // Stringify so a rating of 0 (falsy) still counts as a distinct value — the
+  // helper drops falsy selector outputs (intended for date variance below).
+  const hasRatingVariance = useMemo(
+    () => hasValueVariance(allImages, img => String(img.rating ?? 0)),
+    [allImages]
+  );
 
   const showHighlyRated = hasRatingVariance && !isCollectionDominant;
 
@@ -266,36 +191,19 @@ export default function CollectionPageClient({
     );
     if (filterState.dateSortDirection === 'off') return processed;
     // Apply date sort after layout processing to override orderIndex sort
-    const images = processed.filter(isImageContent);
-    const sorted = sortByDate(images, filterState.dateSortDirection);
-    let imageIdx = 0;
-    return processed.map(item => {
-      if (!isImageContent(item)) return item;
-      return sorted[imageIdx++] ?? item;
-    });
+    const sorted = sortByDate(processed.filter(isImageContent), filterState.dateSortDirection);
+    return mergeDateSortedImages(processed, sorted);
   }, [filteredContent, collection.id, collection.displayMode, filterState.dateSortDirection]);
 
   const handleFilterChange = useCallback(
     (update: Partial<FilterState>) => {
       setFilterState(prev => {
         const next = { ...prev, ...update };
-        // Mirror the `criteria` mapping above so the URL faithfully serializes
-        // the live filter. selectedLenses / selectedLensTypes have no URL key in
-        // serializeFilterToParams (it has no `lens` key; lens-type is derived),
-        // and dateSortDirection is a sort, not a filter — all stay local by design.
-        syncToUrl({
-          ...(next.highlyRatedOnly ? { minRating: 4 } : {}),
-          ...(next.selectedTags.length > 0
-            ? { tags: [...next.selectedTags], tagMatchMode: 'AND' }
-            : {}),
-          ...(next.selectedPeople.length > 0
-            ? { people: [...next.selectedPeople], peopleMatchMode: 'AND' }
-            : {}),
-          ...(next.selectedCameras.length > 0
-            ? { cameras: [...next.selectedCameras], cameraMatchMode: 'AND' }
-            : {}),
-          ...(next.selectedLocations.length > 0 ? { locations: [...next.selectedLocations] } : {}),
-        });
+        // Single source of truth with the `criteria` memo. selectedLenses /
+        // selectedLensTypes have no URL key in serializeFilterToParams (lens-type
+        // is derived) so they're silently dropped, and dateSortDirection is a
+        // sort, not a filter — all stay local by design.
+        syncToUrl(buildCollectionCriteria(next));
         return next;
       });
     },
@@ -325,23 +233,12 @@ export default function CollectionPageClient({
 
   const pageSize = collection.contentPerPage ?? 30;
 
-  const hasDateVariance = useMemo(() => {
-    const dates = new Set(allImages.map(img => img.captureDate).filter(Boolean));
-    return dates.size > 1;
-  }, [allImages]);
+  const hasDateVariance = useMemo(
+    () => hasValueVariance(allImages, img => img.captureDate),
+    [allImages]
+  );
 
-  const hasOptions =
-    showHighlyRated ||
-    hasDateVariance ||
-    baseCollectionOptions.tags.values.length > 0 ||
-    baseCollectionOptions.people.values.length > 0 ||
-    baseCollectionOptions.cameras.values.length > 0 ||
-    baseCollectionOptions.lenses.values.length > 0 ||
-    baseCollectionOptions.lensTypes.values.length > 0 ||
-    // Locations contributes only when multi-value (filterable) — single-value
-    // locations are intentionally not surfaced (extractCollectionFilterOptions
-    // marks them non-filterable) and so should not trigger the toolbar alone.
-    baseCollectionOptions.locations.filterable;
+  const hasOptions = hasFilterableOptions(baseCollectionOptions, showHighlyRated, hasDateVariance);
 
   const content = (
     <>

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -15,7 +15,9 @@ import { Modal } from '@/app/components/ui/Modal/Modal';
 import { IMAGE } from '@/app/constants';
 import styles from '@/app/styles/fullscreen-image.module.scss';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
-import type { ContentGifModel, ViewableContent } from '@/app/types/Content';
+import type { ViewableContent } from '@/app/types/Content';
+
+import { isGifBlock, resolveDisplayDate, resolveDisplayLocations } from './fullScreenModalUtils';
 
 type ImageBlock = ViewableContent;
 
@@ -23,10 +25,6 @@ type FullScreenState = {
   images: ImageBlock[];
   currentIndex: number;
 };
-
-function isGifBlock(block: ImageBlock): block is ContentGifModel {
-  return block.contentType === 'GIF';
-}
 
 interface FullScreenModalProps {
   fullScreenState: FullScreenState | null;
@@ -95,18 +93,10 @@ export function FullScreenModal({
 
   const isGif = isGifBlock(currentImage);
 
-  // Resolve locations: image locations take priority, fall back to collection locations.
-  // GIF blocks don't carry locations today — fall straight through to the collection.
-  const imageLocations = !isGif ? currentImage.locations : undefined;
-  const displayLocations = imageLocations?.length
-    ? imageLocations
-    : (collectionData?.locations ?? []);
-
-  // Resolve date: image captureDate takes priority, fall back to collection collectionDate.
-  // GIFs don't have captureDate — fall back immediately.
-  const displayDate = !isGif
-    ? (currentImage.captureDate ?? collectionData?.collectionDate ?? null)
-    : (collectionData?.collectionDate ?? null);
+  // Resolve locations/date: image fields take priority, falling back to the collection. GIF blocks
+  // carry neither, so they fall straight through to the collection.
+  const displayLocations = resolveDisplayLocations(currentImage, collectionData, isGif);
+  const displayDate = resolveDisplayDate(currentImage, collectionData, isGif);
 
   const currentImageLoaded = loadedImageIds.has(currentImage.id);
   const hasPrevious = fullScreenState.currentIndex > 0;

--- a/app/components/FullScreenModal/fullScreenModalUtils.ts
+++ b/app/components/FullScreenModal/fullScreenModalUtils.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure helpers for {@link FullScreenModal} — image-vs-collection fallback for the metadata overlay's
+ * date and location lines. Kept out of the component so the fallback rules are unit-testable in
+ * isolation and the JSX stays thin.
+ */
+
+import type { CollectionModel, LocationModel } from '@/app/types/Collection';
+import type { ContentGifModel, ViewableContent } from '@/app/types/Content';
+
+/**
+ * Type guard for GIF content blocks. GIFs lack `captureDate` and may lack `locations`, so the
+ * resolvers below fall straight through to the collection for them.
+ */
+export function isGifBlock(block: ViewableContent): block is ContentGifModel {
+  return block.contentType === 'GIF';
+}
+
+/**
+ * Resolve the locations to display: the image's own locations take priority; fall back to the
+ * collection's locations when the image has none (or is a GIF, which doesn't carry locations today).
+ *
+ * `isGif` mirrors `isGifBlock(currentImage)` at the call site; narrowing uses the type guard so the
+ * GIF (location-less) member is excluded before reading `.locations`.
+ */
+export function resolveDisplayLocations(
+  currentImage: ViewableContent,
+  collectionData: CollectionModel | undefined,
+  isGif: boolean
+): LocationModel[] {
+  const imageLocations = !isGif && !isGifBlock(currentImage) ? currentImage.locations : undefined;
+  return imageLocations?.length ? imageLocations : (collectionData?.locations ?? []);
+}
+
+/**
+ * Resolve the date to display: the image's `captureDate` takes priority; fall back to the
+ * collection's `collectionDate` (GIFs have no `captureDate`, so they fall back immediately).
+ *
+ * `isGif` mirrors `isGifBlock(currentImage)` at the call site; narrowing uses the type guard so the
+ * GIF member (which has no `captureDate`) is excluded before reading it.
+ */
+export function resolveDisplayDate(
+  currentImage: ViewableContent,
+  collectionData: CollectionModel | undefined,
+  isGif: boolean
+): string | null {
+  return !isGif && !isGifBlock(currentImage)
+    ? (currentImage.captureDate ?? collectionData?.collectionDate ?? null)
+    : (collectionData?.collectionDate ?? null);
+}

--- a/app/components/LocationPage/LocationPageClient.tsx
+++ b/app/components/LocationPage/LocationPageClient.tsx
@@ -9,8 +9,10 @@ import { type CollectionModel } from '@/app/types/Collection';
 import { type ContentImageModel } from '@/app/types/Content';
 import { type FilterState, INITIAL_FILTER_STATE } from '@/app/types/GalleryFilter';
 import {
+  buildLocationCriteria,
   computeFilterCounts,
   extractFilterOptions,
+  filmFilterFromIsFilm,
   filterContent,
   type FilterCounts,
 } from '@/app/utils/contentFilter';
@@ -26,13 +28,6 @@ interface LocationPageClientProps {
   collections: CollectionModel[];
 }
 
-/** Map the URL's isFilm tristate onto the FilterState film toggle. */
-function filmFilterFromIsFilm(isFilm: boolean | undefined): FilterState['filmFilter'] {
-  if (isFilm === true) return 'film';
-  if (isFilm === false) return 'digital';
-  return 'off';
-}
-
 export default function LocationPageClient({ images, collections }: LocationPageClientProps) {
   const { initialCriteria, syncToUrl } = useFilterUrlState();
 
@@ -46,16 +41,7 @@ export default function LocationPageClient({ images, collections }: LocationPage
 
   const availableOptions = useMemo(() => extractFilterOptions(images), [images]);
 
-  const criteria = useMemo(
-    () => ({
-      ...(filterState.highlyRatedOnly ? { minRating: 4 } : {}),
-      ...(filterState.filmFilter === 'film' ? { isFilm: true as const } : {}),
-      ...(filterState.filmFilter === 'digital' ? { isFilm: false as const } : {}),
-      ...(filterState.selectedTags.length > 0 ? { tags: filterState.selectedTags } : {}),
-      ...(filterState.selectedPeople.length > 0 ? { people: filterState.selectedPeople } : {}),
-    }),
-    [filterState]
-  );
+  const criteria = useMemo(() => buildLocationCriteria(filterState), [filterState]);
 
   const filteredImages = useMemo(() => {
     const filtered = filterContent(images, criteria).filter(
@@ -92,16 +78,10 @@ export default function LocationPageClient({ images, collections }: LocationPage
     (update: Partial<FilterState>) => {
       setFilterState(prev => {
         const next = { ...prev, ...update };
-        // Mirror the `criteria` mapping above so the URL is a faithful
-        // serialization of the live filter. dateSortDirection / lens dimensions
-        // have no URL key in serializeFilterToParams and stay local by design.
-        syncToUrl({
-          ...(next.highlyRatedOnly ? { minRating: 4 } : {}),
-          ...(next.filmFilter === 'film' ? { isFilm: true } : {}),
-          ...(next.filmFilter === 'digital' ? { isFilm: false } : {}),
-          ...(next.selectedTags.length > 0 ? { tags: [...next.selectedTags] } : {}),
-          ...(next.selectedPeople.length > 0 ? { people: [...next.selectedPeople] } : {}),
-        });
+        // Single source of truth with the `criteria` memo. dateSortDirection /
+        // lens dimensions have no URL key in serializeFilterToParams and stay
+        // local by design.
+        syncToUrl(buildLocationCriteria(next));
         return next;
       });
     },

--- a/app/components/Metadata/sections/EssentialInfoSection.tsx
+++ b/app/components/Metadata/sections/EssentialInfoSection.tsx
@@ -10,6 +10,7 @@ import type { CollectionListModel, LocationModel } from '@/app/types/Collection'
 
 import type { ImageUpdateState } from '../hooks/useMetadataState';
 import modalStyles from '../MetadataModal.module.scss';
+import { isCurrentCollectionVisible, toggleCollectionVisibility } from './essentialInfoUtils';
 
 // ---------------------------------------------------------------------------
 // Static option list for the Rating <Select>. Hoisted out of the render path
@@ -46,44 +47,23 @@ export default function EssentialInfoSection({
 }: EssentialInfoSectionProps): React.JSX.Element {
   // Visibility of the current collection's junction. Absent/undefined means "visible" (only an
   // explicit `false` hides it), matching the backend default.
-  const currentCollectionVisible =
-    updateState.collections?.find(c => c.collectionId === currentCollectionId)?.visible !== false;
+  const currentCollectionVisible = isCurrentCollectionVisible(
+    updateState.collections,
+    currentCollectionId
+  );
 
   // Toggle the current collection's `visible` flag in updateState — updating the existing junction
   // in place, or appending one when the image isn't in this collection's list yet.
   const handleCollectionVisibilityToggle = (checked: boolean) => {
     if (currentCollectionId == null) return;
-
-    const currentCollections = updateState.collections || [];
-    const collectionIndex = currentCollections.findIndex(
-      c => c.collectionId === currentCollectionId
-    );
-
-    let updatedCollections: Array<{
-      collectionId: number;
-      name?: string;
-      visible?: boolean;
-      orderIndex?: number;
-    }>;
-
-    if (collectionIndex >= 0) {
-      updatedCollections = currentCollections.map((c, idx) =>
-        idx === collectionIndex ? { ...c, visible: checked } : c
-      );
-    } else {
-      const collectionName = availableCollections.find(c => c.id === currentCollectionId)?.name;
-      updatedCollections = [
-        ...currentCollections,
-        {
-          collectionId: currentCollectionId,
-          name: collectionName,
-          visible: checked,
-          orderIndex: currentCollections.length,
-        },
-      ];
-    }
-
-    updateStateField({ collections: updatedCollections });
+    updateStateField({
+      collections: toggleCollectionVisibility(
+        updateState.collections,
+        currentCollectionId,
+        checked,
+        availableCollections
+      ),
+    });
   };
 
   return (

--- a/app/components/Metadata/sections/essentialInfoUtils.ts
+++ b/app/components/Metadata/sections/essentialInfoUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for {@link EssentialInfoSection} — the collection-visibility toggle on the image
+ * metadata editor. Kept out of the component so the junction append-vs-update branching is
+ * unit-testable in isolation and the JSX stays thin.
+ */
+
+import type { ChildCollection, CollectionListModel } from '@/app/types/Collection';
+
+/**
+ * Is the current collection's junction visible? Absent/undefined means "visible" — only an explicit
+ * `false` hides it, matching the backend default. Returns `true` when there is no junction yet.
+ */
+export function isCurrentCollectionVisible(
+  collections: ChildCollection[] | undefined,
+  currentCollectionId: number | undefined
+): boolean {
+  return collections?.find(c => c.collectionId === currentCollectionId)?.visible !== false;
+}
+
+/**
+ * Toggle the current collection's `visible` flag, returning the next junction array. Updates the
+ * existing junction in place when the image is already in this collection's list, or appends a new
+ * one (with the collection name looked up from `availableCollections` and a trailing `orderIndex`)
+ * when it isn't.
+ *
+ * Returns the unchanged input array when `currentCollectionId` is null/undefined.
+ */
+export function toggleCollectionVisibility(
+  collections: ChildCollection[] | undefined,
+  currentCollectionId: number | undefined,
+  checked: boolean,
+  availableCollections: CollectionListModel[]
+): ChildCollection[] {
+  const currentCollections = collections || [];
+
+  if (currentCollectionId == null) return currentCollections;
+
+  const collectionIndex = currentCollections.findIndex(c => c.collectionId === currentCollectionId);
+
+  if (collectionIndex >= 0) {
+    return currentCollections.map((c, idx) =>
+      idx === collectionIndex ? { ...c, visible: checked } : c
+    );
+  }
+
+  const collectionName = availableCollections.find(c => c.id === currentCollectionId)?.name;
+  return [
+    ...currentCollections,
+    {
+      collectionId: currentCollectionId,
+      name: collectionName,
+      visible: checked,
+      orderIndex: currentCollections.length,
+    },
+  ];
+}

--- a/app/components/ui/Dropdown/Dropdown.tsx
+++ b/app/components/ui/Dropdown/Dropdown.tsx
@@ -6,6 +6,18 @@ import { useCallback, useRef, useState } from 'react';
 import { useClickOutsideMultiple } from '@/app/hooks/useClickOutside';
 
 import styles from './Dropdown.module.scss';
+import {
+  findMissingRequiredFields,
+  getItemDisplayName as resolveItemDisplayName,
+  getKey as resolveKey,
+  isAddNewFormValid as checkAddNewFormValid,
+  isFieldVisible as checkFieldVisible,
+  isItemSelected as checkItemSelected,
+  itemExistsInDatabase as checkItemExistsInDatabase,
+  processAddNewFormData,
+  removeFromSelection,
+  toggleMultiSelection,
+} from './dropdownUtils';
 
 /**
  * Generic metadata item interface.
@@ -113,43 +125,16 @@ export default function Dropdown<T extends MetadataItem>({
 
   useClickOutsideMultiple(containerRef, [isSelectingFromDropdown, isAddingNew], handleCloseAll);
 
-  /**
-   * Uses custom getter if provided, otherwise falls back to displayName or name.
-   * Always returns a string, never an object.
-   */
-  const getItemDisplayName = (item: T | null | undefined): string => {
-    if (!item) return '';
-    if (getDisplayName) {
-      const result = getDisplayName(item);
-      if (typeof result === 'string') return result;
-      return '';
-    }
-    return item.displayName || item.name || '';
-  };
+  const getItemDisplayName = (item: T | null | undefined): string =>
+    resolveItemDisplayName(item, getDisplayName);
 
-  /** Uses custom getter if provided, otherwise uses id or name. */
-  const getKey = (item: T): string | number => {
-    if (getItemKey) return getItemKey(item);
-    return item.id ?? item.name ?? '';
-  };
+  const getKey = (item: T): string | number => resolveKey(item, getItemKey);
 
-  /** Check if an item exists in the database (has a valid id > 0). */
-  const itemExistsInDatabase = (item: T | null | undefined): boolean => {
-    if (!item) return true;
-    return Boolean(item.id && item.id > 0);
-  };
+  const itemExistsInDatabase = (item: T | null | undefined): boolean =>
+    checkItemExistsInDatabase(item);
 
-  const isItemSelected = (item: T): boolean => {
-    if (multiSelect) {
-      return selectedValues.some(selected => {
-        if (selected.id && item.id) return selected.id === item.id;
-        return getItemDisplayName(selected) === getItemDisplayName(item);
-      });
-    }
-    if (!selectedValue) return false;
-    if (selectedValue.id && item.id) return selectedValue.id === item.id;
-    return getItemDisplayName(selectedValue) === getItemDisplayName(item);
-  };
+  const isItemSelected = (item: T): boolean =>
+    checkItemSelected(item, selectedValue, selectedValues, multiSelect, getDisplayName);
 
   const handleToggleDropdown = () => {
     setIsSelectingFromDropdown(prev => !prev);
@@ -174,16 +159,7 @@ export default function Dropdown<T extends MetadataItem>({
 
   const handleSelectItem = (item: T) => {
     if (multiSelect) {
-      const isCurrentlySelected = isItemSelected(item);
-      if (isCurrentlySelected) {
-        const newSelection = selectedValues.filter(selected => {
-          if (selected.id && item.id) return selected.id !== item.id;
-          return getItemDisplayName(selected) !== getItemDisplayName(item);
-        });
-        onChange(newSelection);
-      } else {
-        onChange([...selectedValues, item]);
-      }
+      onChange(toggleMultiSelection(selectedValues, item, getDisplayName));
     } else {
       onChange(item);
     }
@@ -195,45 +171,16 @@ export default function Dropdown<T extends MetadataItem>({
   const handleRemoveItem = (e: React.MouseEvent | React.KeyboardEvent, item: T) => {
     e.stopPropagation();
     if (!multiSelect) return;
-
-    const newSelection = selectedValues.filter(selected => {
-      if (selected.id && item.id) return selected.id !== item.id;
-      return getItemDisplayName(selected) !== getItemDisplayName(item);
-    });
-    onChange(newSelection);
+    onChange(removeFromSelection(selectedValues, item, getDisplayName));
   };
 
-  const isFieldVisible = (field: AddNewField): boolean =>
-    field.showWhen ? field.showWhen(formData) : true;
+  const isFieldVisible = (field: AddNewField): boolean => checkFieldVisible(field, formData);
 
   const handleAddNew = () => {
     // Validate visible, required fields. Hidden fields (showWhen → false) are skipped.
-    const missing = addNewFields.filter(isFieldVisible).filter(field => {
-      if (!field.required) return false;
-      const value = formData[field.name];
-      if (field.type === 'checkbox') return false; // checkboxes never "missing"
-      if (value === undefined || value === null) return true;
-      return value.toString().trim() === '';
-    });
-    if (missing.length > 0) return;
+    if (findMissingRequiredFields(addNewFields, formData).length > 0) return;
 
-    const processedData: Record<string, string | number | boolean | null> = {};
-    for (const field of addNewFields) {
-      // Drop fields that are hidden so the parent doesn't get stale values from
-      // a sibling toggle (e.g. defaultFilmFormat when isFilm flips off).
-      if (!isFieldVisible(field)) continue;
-      const value = formData[field.name];
-      if (field.type === 'checkbox') {
-        processedData[field.name] = value === true;
-      } else if (field.type === 'number') {
-        processedData[field.name] =
-          typeof value === 'string' && value !== '' ? Number.parseInt(value, 10) : null;
-      } else if (typeof value === 'string') {
-        processedData[field.name] = value.trim() || null;
-      } else {
-        processedData[field.name] = value ? String(value) : null;
-      }
-    }
+    const processedData = processAddNewFormData(addNewFields, formData);
 
     if (onAddNew) {
       onAddNew(processedData);
@@ -243,21 +190,7 @@ export default function Dropdown<T extends MetadataItem>({
     setIsAddingNew(false);
   };
 
-  const isAddNewFormValid = (): boolean => {
-    return addNewFields
-      .filter(isFieldVisible)
-      .filter(field => field.required)
-      .every(field => {
-        const value = formData[field.name];
-        if (field.type === 'checkbox') return true;
-        if (value === undefined || value === null) return false;
-        if (field.type === 'number') {
-          const numValue = typeof value === 'string' ? Number.parseInt(value, 10) : Number.NaN;
-          return !Number.isNaN(numValue) && numValue > 0;
-        }
-        return value.toString().trim().length > 0;
-      });
-  };
+  const isAddNewFormValid = (): boolean => checkAddNewFormValid(addNewFields, formData);
 
   const handleFieldChange = (fieldName: string, value: string | boolean) => {
     setFormData(prev => ({ ...prev, [fieldName]: value }));

--- a/app/components/ui/Dropdown/dropdownUtils.ts
+++ b/app/components/ui/Dropdown/dropdownUtils.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure helpers for {@link Dropdown} — item display/key resolution, selection matching, and the
+ * "add new" form's visibility/validation/processing logic. Kept out of the component so the JSX
+ * stays thin and each derivation is individually unit-testable.
+ *
+ * All item helpers are generic over `T extends MetadataItem`; callers thread their optional
+ * `getDisplayName` / `getItemKey` getters in as arguments rather than closing over component props.
+ */
+
+import { type AddNewField, type AddNewFieldFormData, type MetadataItem } from './Dropdown';
+
+/**
+ * Resolve an item's display text. Uses the custom `getDisplayName` getter when provided, otherwise
+ * falls back to `displayName` or `name`. Always returns a string, never an object — a non-string
+ * getter result is defensively coerced to `''`.
+ */
+export function getItemDisplayName<T extends MetadataItem>(
+  item: T | null | undefined,
+  getDisplayName?: (item: T) => string
+): string {
+  if (!item) return '';
+  if (getDisplayName) {
+    const result = getDisplayName(item);
+    if (typeof result === 'string') return result;
+    return '';
+  }
+  return item.displayName || item.name || '';
+}
+
+/** Resolve an item's list key. Uses the custom `getItemKey` getter if provided, otherwise id or name. */
+export function getKey<T extends MetadataItem>(
+  item: T,
+  getItemKey?: (item: T) => string | number
+): string | number {
+  if (getItemKey) return getItemKey(item);
+  return item.id ?? item.name ?? '';
+}
+
+/** Check if an item exists in the database (has a valid id > 0). A null/undefined item is treated as existing. */
+export function itemExistsInDatabase<T extends MetadataItem>(item: T | null | undefined): boolean {
+  if (!item) return true;
+  return Boolean(item.id && item.id > 0);
+}
+
+/**
+ * Whether `item` is currently selected. Matches by id when both sides have one, otherwise by
+ * resolved display name. In single-select mode `selectedValues` is ignored (and vice versa).
+ */
+export function isItemSelected<T extends MetadataItem>(
+  item: T,
+  selectedValue: T | null | undefined,
+  selectedValues: T[],
+  multiSelect: boolean,
+  getDisplayName?: (item: T) => string
+): boolean {
+  if (multiSelect) {
+    return selectedValues.some(selected => {
+      if (selected.id && item.id) return selected.id === item.id;
+      return (
+        getItemDisplayName(selected, getDisplayName) === getItemDisplayName(item, getDisplayName)
+      );
+    });
+  }
+  if (!selectedValue) return false;
+  if (selectedValue.id && item.id) return selectedValue.id === item.id;
+  return (
+    getItemDisplayName(selectedValue, getDisplayName) === getItemDisplayName(item, getDisplayName)
+  );
+}
+
+/**
+ * Remove `item` from `selectedValues`. Matches by id when both sides have one, otherwise by resolved
+ * display name. Shared by the chip-remove and multi-select-toggle paths.
+ */
+export function removeFromSelection<T extends MetadataItem>(
+  selectedValues: T[],
+  item: T,
+  getDisplayName?: (item: T) => string
+): T[] {
+  return selectedValues.filter(selected => {
+    if (selected.id && item.id) return selected.id !== item.id;
+    return (
+      getItemDisplayName(selected, getDisplayName) !== getItemDisplayName(item, getDisplayName)
+    );
+  });
+}
+
+/**
+ * Toggle `item` in a multi-select array: remove it if already selected, otherwise append it.
+ */
+export function toggleMultiSelection<T extends MetadataItem>(
+  selectedValues: T[],
+  item: T,
+  getDisplayName?: (item: T) => string
+): T[] {
+  if (isItemSelected(item, null, selectedValues, true, getDisplayName)) {
+    return removeFromSelection(selectedValues, item, getDisplayName);
+  }
+  return [...selectedValues, item];
+}
+
+/** Whether an add-new field should render: true unless its `showWhen` predicate returns false. */
+export function isFieldVisible(field: AddNewField, formData: AddNewFieldFormData): boolean {
+  return field.showWhen ? field.showWhen(formData) : true;
+}
+
+/**
+ * The visible, required fields that are still empty. Hidden fields (`showWhen` → false) are skipped,
+ * and checkboxes are never considered missing.
+ */
+export function findMissingRequiredFields(
+  fields: AddNewField[],
+  formData: AddNewFieldFormData
+): AddNewField[] {
+  return fields
+    .filter(field => isFieldVisible(field, formData))
+    .filter(field => {
+      if (!field.required) return false;
+      const value = formData[field.name];
+      if (field.type === 'checkbox') return false; // checkboxes never "missing"
+      if (value === undefined || value === null) return true;
+      return value.toString().trim() === '';
+    });
+}
+
+/**
+ * Coerce the raw form data into the typed payload `onAddNew` expects. Hidden fields are dropped so
+ * the parent doesn't get stale values from a sibling toggle (e.g. defaultFilmFormat when isFilm
+ * flips off). Checkboxes → boolean, numbers → parsed int or null, strings → trimmed or null.
+ */
+export function processAddNewFormData(
+  fields: AddNewField[],
+  formData: AddNewFieldFormData
+): Record<string, string | number | boolean | null> {
+  const processedData: Record<string, string | number | boolean | null> = {};
+  for (const field of fields) {
+    // Drop fields that are hidden so the parent doesn't get stale values from
+    // a sibling toggle (e.g. defaultFilmFormat when isFilm flips off).
+    if (!isFieldVisible(field, formData)) continue;
+    const value = formData[field.name];
+    if (field.type === 'checkbox') {
+      processedData[field.name] = value === true;
+    } else if (field.type === 'number') {
+      processedData[field.name] =
+        typeof value === 'string' && value !== '' ? Number.parseInt(value, 10) : null;
+    } else if (typeof value === 'string') {
+      processedData[field.name] = value.trim() || null;
+    } else {
+      processedData[field.name] = value ? String(value) : null;
+    }
+  }
+  return processedData;
+}
+
+/**
+ * Whether every visible, required field holds a valid value. Checkboxes are always valid; numbers
+ * must parse to a positive (> 0) value; other fields must have non-whitespace content.
+ */
+export function isAddNewFormValid(fields: AddNewField[], formData: AddNewFieldFormData): boolean {
+  return fields
+    .filter(field => isFieldVisible(field, formData))
+    .filter(field => field.required)
+    .every(field => {
+      const value = formData[field.name];
+      if (field.type === 'checkbox') return true;
+      if (value === undefined || value === null) return false;
+      if (field.type === 'number') {
+        const numValue = typeof value === 'string' ? Number.parseInt(value, 10) : Number.NaN;
+        return !Number.isNaN(numValue) && numValue > 0;
+      }
+      return value.toString().trim().length > 0;
+    });
+}

--- a/app/components/ui/FilterToolbar/FilterToolbar.tsx
+++ b/app/components/ui/FilterToolbar/FilterToolbar.tsx
@@ -5,15 +5,17 @@ import { useCallback, useRef, useState } from 'react';
 import { FilterChip } from '@/app/components/ui/FilterChip/FilterChip';
 import { useClickOutside } from '@/app/hooks/useClickOutside';
 import {
+  ARRAY_FILTER_KEYS,
   type ArrayFilterKey,
   cycleDateSort,
-  type FilmFilter,
+  cycleFilmFilter,
   type FilterState,
   INITIAL_FILTER_STATE,
   toggleArrayFilter,
 } from '@/app/types/GalleryFilter';
 
 import styles from './FilterToolbar.module.scss';
+import { computeHasActiveFilters, isOptionAvailable } from './filterToolbarUtils';
 
 /** One filterable dimension: which state key it writes, its dropdown label, its options, and optional value->label/count maps. */
 export interface ToolbarDimension {
@@ -51,15 +53,6 @@ export interface FilterToolbarProps {
   onDensityChange?: (value: number) => void;
 }
 
-const ARRAY_KEYS: readonly ArrayFilterKey[] = [
-  'selectedTags',
-  'selectedPeople',
-  'selectedCameras',
-  'selectedLenses',
-  'selectedLocations',
-  'selectedLensTypes',
-];
-
 const DATE_LABELS: Record<FilterState['dateSortDirection'], string> = {
   asc: 'Date ↑',
   desc: 'Date ↓',
@@ -90,24 +83,11 @@ export function FilterToolbar({
 
   const toggleOpen = (key: ArrayFilterKey) => setOpenDropdown(prev => (prev === key ? null : key));
 
-  const isAvailable = (key: ArrayFilterKey, value: string): boolean => {
-    const avail = filteredAvailable?.[key];
-    if (!avail) return true;
-    return avail.includes(value);
-  };
-
-  const cycleFilm = () => {
-    const next: Record<FilmFilter, FilmFilter> = { off: 'film', film: 'digital', digital: 'off' };
-    onFilterChange({ filmFilter: next[filterState.filmFilter] });
-  };
+  const cycleFilm = () => onFilterChange({ filmFilter: cycleFilmFilter(filterState.filmFilter) });
 
   const filmCount = filterState.filmFilter === 'off' ? undefined : counts?.[filterState.filmFilter];
 
-  const hasActiveFilters =
-    filterState.dateSortDirection !== 'off' ||
-    filterState.highlyRatedOnly ||
-    filterState.filmFilter !== 'off' ||
-    ARRAY_KEYS.some(k => (filterState[k] as readonly string[]).length > 0);
+  const hasActiveFilters = computeHasActiveFilters(filterState, ARRAY_FILTER_KEYS);
 
   const resetAll = () => {
     onFilterChange({ ...INITIAL_FILTER_STATE });
@@ -145,7 +125,7 @@ export function FilterToolbar({
         />
       )}
 
-      {ARRAY_KEYS.map(key => {
+      {ARRAY_FILTER_KEYS.map(key => {
         const dim = dimensions[key];
         if (!dim || dim.options.length === 0) return null;
         const selected = filterState[key] as readonly string[];
@@ -168,7 +148,7 @@ export function FilterToolbar({
               <div className={styles.panel}>
                 {dim.options.map(option => {
                   const isSelected = selected.includes(option);
-                  const available = isSelected || isAvailable(key, option);
+                  const available = isSelected || isOptionAvailable(filteredAvailable, key, option);
                   return (
                     <FilterChip
                       key={`${key}-${option}`}

--- a/app/components/ui/FilterToolbar/filterToolbarUtils.ts
+++ b/app/components/ui/FilterToolbar/filterToolbarUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for the {@link FilterToolbar} — availability lookup and the active-filter check.
+ * Kept out of the component so the JSX stays thin and the logic is unit-testable. The film-filter
+ * cycle and the canonical array-key list live in {@link app/types/GalleryFilter} next to the other
+ * filter-state derivations (the project's home for filter-state logic).
+ */
+
+import { type ArrayFilterKey, type FilterState } from '@/app/types/GalleryFilter';
+
+/**
+ * Whether a dropdown option is still reachable under the current filters. With no
+ * `filteredAvailable` map (null/undefined), every option is available; otherwise an option is
+ * available only when it appears in that dimension's reachable subset.
+ */
+export function isOptionAvailable(
+  filteredAvailable: Partial<Record<ArrayFilterKey, readonly string[]>> | null | undefined,
+  key: ArrayFilterKey,
+  value: string
+): boolean {
+  const avail = filteredAvailable?.[key];
+  if (!avail) return true;
+  return avail.includes(value);
+}
+
+/**
+ * Whether any filter is active: a date sort, the highly-rated toggle, the film/digital filter, or
+ * any non-empty array dimension. Drives the reset (×) button's visibility.
+ */
+export function computeHasActiveFilters(
+  filterState: FilterState,
+  arrayKeys: readonly ArrayFilterKey[]
+): boolean {
+  return (
+    filterState.dateSortDirection !== 'off' ||
+    filterState.highlyRatedOnly ||
+    filterState.filmFilter !== 'off' ||
+    arrayKeys.some(k => (filterState[k] as readonly string[]).length > 0)
+  );
+}

--- a/app/types/GalleryFilter.ts
+++ b/app/types/GalleryFilter.ts
@@ -46,6 +46,20 @@ export type ArrayFilterKey =
   | 'selectedLensTypes';
 
 /**
+ * The canonical list of array dimensions in {@link FilterState} — the single source of truth for
+ * "which keys are arrays" (mirrors the array fields in {@link INITIAL_FILTER_STATE}). Consumers
+ * iterate this to surface dropdowns and detect active array filters.
+ */
+export const ARRAY_FILTER_KEYS: readonly ArrayFilterKey[] = [
+  'selectedTags',
+  'selectedPeople',
+  'selectedCameras',
+  'selectedLenses',
+  'selectedLocations',
+  'selectedLensTypes',
+];
+
+/**
  * The single canonical date-sort cycle: off -> asc -> desc -> off.
  */
 export function cycleDateSort(current: DateSortDirection): DateSortDirection {
@@ -53,6 +67,18 @@ export function cycleDateSort(current: DateSortDirection): DateSortDirection {
     off: 'asc',
     asc: 'desc',
     desc: 'off',
+  };
+  return next[current];
+}
+
+/**
+ * The single canonical film-filter cycle: off -> film -> digital -> off.
+ */
+export function cycleFilmFilter(current: FilmFilter): FilmFilter {
+  const next: Record<FilmFilter, FilmFilter> = {
+    off: 'film',
+    film: 'digital',
+    digital: 'off',
   };
   return next[current];
 }

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -13,6 +13,8 @@ import {
   type ContentCollectionModel,
   type ContentImageModel,
 } from '@/app/types/Content';
+import { type FilmFilter, type FilterState, type LensType } from '@/app/types/GalleryFilter';
+import { getLensType } from '@/app/utils/focalLength';
 
 /**
  * Filter criteria for content arrays.
@@ -585,4 +587,253 @@ export function serializeFilterToParams(criteria: ContentFilterCriteria): URLSea
   for (const id of criteria.collectionIds ?? []) params.append('collection', String(id));
 
   return params;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Collection-page filter derivations
+//
+// Pure helpers consolidated here (rather than forked into a co-located
+// *Utils.ts) because they belong to the same filter domain as the functions
+// above and share its fixtures/tests. Used by CollectionPageClient (and the
+// location/taxonomy pages) so those components read as hooks → helpers → JSX.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Per-dimension data for the collection filter bar: values + whether it renders as a dropdown. */
+export interface FilterDimension<T = string> {
+  values: readonly T[];
+  filterable: boolean;
+}
+
+/**
+ * Filter dimensions specific to collection pages — structurally compatible with
+ * `CollectionInfoOptions` minus `showHighlyRated`.
+ */
+export interface CollectionFilterDimensions {
+  tags: FilterDimension;
+  people: FilterDimension;
+  cameras: FilterDimension;
+  lenses: FilterDimension;
+  locations: FilterDimension;
+  lensTypes: FilterDimension<LensType>;
+}
+
+/**
+ * Extract filter options specific to collection pages.
+ *
+ * Returns per-dimension data with a `filterable` flag. When a dimension has a
+ * single value and the dimension's policy allows info-mode (cameras / lenses /
+ * locations need 2+ values), `filterable` is false so the bar renders it as an
+ * inline info chip instead of a dropdown. Lens types only surface when 2+
+ * distinct categories AND 2+ distinct lenses are present (an image-only signal).
+ *
+ * @param images - Image content to aggregate dimensions from
+ * @param collectionRefs - Collection refs (synthetic PARENT pages aggregate from these too)
+ */
+export function extractCollectionFilterOptions(
+  images: ContentImageModel[],
+  collectionRefs: ContentCollectionModel[] = []
+): CollectionFilterDimensions {
+  // Pass images + refs together so extractFilterOptions can aggregate filter
+  // dimensions from collection refs too. This is what populates the filter bar
+  // on synthetic PARENT pages whose `content` is 100% collection refs and 0
+  // images (e.g. /all-collections, /all-blog).
+  const baseOptions = extractFilterOptions([...images, ...collectionRefs], 0.9);
+
+  // Lens types: only show if 2+ distinct categories present (image-only signal)
+  const lensTypeSet = new Set<LensType>();
+  for (const img of images) {
+    const lt = getLensType(img.focalLength);
+    if (lt !== null) lensTypeSet.add(lt);
+  }
+  const typeOrder: LensType[] = ['wide', 'normal', 'telephoto'];
+  const lensTypes =
+    lensTypeSet.size >= 2 && baseOptions.lenses.length >= 2
+      ? typeOrder.filter(t => lensTypeSet.has(t))
+      : [];
+
+  return {
+    tags: { values: baseOptions.tags, filterable: true },
+    people: { values: baseOptions.people, filterable: true },
+    cameras: { values: baseOptions.cameras, filterable: baseOptions.cameras.length >= 2 },
+    lenses: { values: baseOptions.lenses, filterable: baseOptions.lenses.length >= 2 },
+    locations: { values: baseOptions.locations, filterable: baseOptions.locations.length >= 2 },
+    lensTypes: { values: lensTypes, filterable: true },
+  };
+}
+
+/**
+ * Build filter criteria from a collection page's filter state — all-AND match
+ * mode. Single source of truth for both the live filter and the URL sync (the
+ * `lenses` key has no URL param, so it is silently dropped by
+ * {@link serializeFilterToParams}). `selectedLensTypes` is applied separately as
+ * a post-filter (see {@link applyCollectionFilters}) since it derives from focal
+ * length rather than a stored field.
+ */
+export function buildCollectionCriteria(filterState: FilterState): ContentFilterCriteria {
+  return {
+    ...(filterState.highlyRatedOnly ? { minRating: 4 } : {}),
+    ...(filterState.selectedTags.length > 0
+      ? { tags: filterState.selectedTags, tagMatchMode: 'AND' as const }
+      : {}),
+    ...(filterState.selectedPeople.length > 0
+      ? { people: filterState.selectedPeople, peopleMatchMode: 'AND' as const }
+      : {}),
+    ...(filterState.selectedCameras.length > 0
+      ? { cameras: filterState.selectedCameras, cameraMatchMode: 'AND' as const }
+      : {}),
+    ...(filterState.selectedLenses.length > 0
+      ? { lenses: filterState.selectedLenses, lensMatchMode: 'AND' as const }
+      : {}),
+    ...(filterState.selectedLocations.length > 0
+      ? { locations: filterState.selectedLocations }
+      : {}),
+  };
+}
+
+/**
+ * Whether any collection-page filter is active. Includes `selectedLensTypes`
+ * (a post-filter not represented in {@link ContentFilterCriteria}).
+ */
+export function hasAnyActiveFilter(filterState: FilterState): boolean {
+  return (
+    filterState.highlyRatedOnly ||
+    filterState.selectedTags.length > 0 ||
+    filterState.selectedPeople.length > 0 ||
+    filterState.selectedCameras.length > 0 ||
+    filterState.selectedLenses.length > 0 ||
+    filterState.selectedLensTypes.length > 0 ||
+    filterState.selectedLocations.length > 0
+  );
+}
+
+/**
+ * Apply the collection page's filters to its content.
+ *
+ * Filters only images by `criteria`, applies the lens-type post-filter (images
+ * with an unparseable focalLength are kept so a lens-type chip never silently
+ * hides them), then reattaches: non-image content passes through unchanged and
+ * images survive only if their id is in the filtered set.
+ *
+ * @param allContent - The full content array (images + non-image blocks)
+ * @param allImages - The image subset of `allContent`
+ * @param criteria - Filter criteria (from {@link buildCollectionCriteria})
+ * @param selectedLensTypes - Active lens-type chips (post-filter)
+ */
+export function applyCollectionFilters(
+  allContent: AnyContentModel[],
+  allImages: ContentImageModel[],
+  criteria: ContentFilterCriteria,
+  selectedLensTypes: readonly LensType[]
+): AnyContentModel[] {
+  let filtered = filterContent(allImages, criteria).filter(isImageContent);
+
+  // Apply lens type filter — images without parseable focalLength are
+  // included intentionally so they aren't silently hidden by a lens-type chip.
+  if (selectedLensTypes.length > 0) {
+    filtered = filtered.filter(img => {
+      const lt = getLensType(img.focalLength);
+      return lt === null || selectedLensTypes.includes(lt);
+    });
+  }
+
+  const filteredImageIds = new Set(filtered.map(img => img.id));
+  // Keep non-image content as-is, only filter images
+  return allContent.filter(item => !isImageContent(item) || filteredImageIds.has(item.id));
+}
+
+/**
+ * Whether a per-image selector yields more than one distinct value across the
+ * images (drives "show this control only when it varies"). Covers both rating
+ * variance and capture-date variance. Returns false for an empty array.
+ *
+ * @param images - Images to inspect
+ * @param selector - Maps an image to the value whose variance is checked
+ */
+export function hasValueVariance<T>(
+  images: ContentImageModel[],
+  selector: (image: ContentImageModel) => T
+): boolean {
+  if (images.length === 0) return false;
+  const values = new Set(images.map(selector).filter(Boolean));
+  return values.size > 1;
+}
+
+/**
+ * Re-interleave date-sorted images back into a processed content array.
+ *
+ * Date sort runs after `processContentBlocks` (which sorts by orderIndex), so
+ * this walks the processed array and replaces each image slot, in order, with
+ * the next date-sorted image — leaving non-image blocks in place.
+ *
+ * @param processed - Content already processed for layout
+ * @param sortedImages - The processed images re-sorted by date
+ */
+export function mergeDateSortedImages(
+  processed: AnyContentModel[],
+  sortedImages: ContentImageModel[]
+): AnyContentModel[] {
+  let imageIdx = 0;
+  return processed.map(item => {
+    if (!isImageContent(item)) return item;
+    return sortedImages[imageIdx++] ?? item;
+  });
+}
+
+/**
+ * Whether the collection filter bar has anything to show (controls the
+ * decision to wrap the page in the filter provider at all). Locations
+ * contribute only when multi-value (`filterable`) — single-value locations are
+ * intentionally surfaced elsewhere and must not trigger the bar alone.
+ *
+ * @param baseOptions - The page's base dimensions
+ * @param showHighlyRated - Whether the Highly Rated control is shown
+ * @param hasDateVariance - Whether capture dates vary (date-sort control)
+ */
+export function hasFilterableOptions(
+  baseOptions: CollectionFilterDimensions,
+  showHighlyRated: boolean,
+  hasDateVariance: boolean
+): boolean {
+  return (
+    showHighlyRated ||
+    hasDateVariance ||
+    baseOptions.tags.values.length > 0 ||
+    baseOptions.people.values.length > 0 ||
+    baseOptions.cameras.values.length > 0 ||
+    baseOptions.lenses.values.length > 0 ||
+    baseOptions.lensTypes.values.length > 0 ||
+    baseOptions.locations.filterable
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Location/taxonomy-page filter derivations
+//
+// The location page shares the filter domain but its criteria differ from the
+// collection page: it surfaces a film/digital toggle (mapped to `isFilm`) and
+// uses default (OR) match mode on tags/people with no location/camera/lens
+// dimensions — so it gets its own criteria builder rather than parameterizing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Map the URL's isFilm tristate onto the FilterState film toggle. */
+export function filmFilterFromIsFilm(isFilm: boolean | undefined): FilmFilter {
+  if (isFilm === true) return 'film';
+  if (isFilm === false) return 'digital';
+  return 'off';
+}
+
+/**
+ * Build filter criteria from a location page's filter state. Single source of
+ * truth for both the live filter and the URL sync. Differs from
+ * {@link buildCollectionCriteria}: includes the film/digital toggle and uses
+ * default (OR) match mode on tags/people with no location/camera/lens keys.
+ */
+export function buildLocationCriteria(filterState: FilterState): ContentFilterCriteria {
+  return {
+    ...(filterState.highlyRatedOnly ? { minRating: 4 } : {}),
+    ...(filterState.filmFilter === 'film' ? { isFilm: true as const } : {}),
+    ...(filterState.filmFilter === 'digital' ? { isFilm: false as const } : {}),
+    ...(filterState.selectedTags.length > 0 ? { tags: filterState.selectedTags } : {}),
+    ...(filterState.selectedPeople.length > 0 ? { people: filterState.selectedPeople } : {}),
+  };
 }

--- a/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Characterization tests for {@link CollectionContentRenderer}'s click branches (GIF, placeholder,
+ * image, and slug-navigation). These pin the observable behavior driven by the inline
+ * `hasClickHandler`/`isSlugNav` derivation BEFORE that logic is extracted into
+ * `collectionContentRendererUtils.getClickEligibility`, so the extraction is provably
+ * behavior-preserving. They must pass against the un-refactored component unchanged.
+ */
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import CollectionContentRenderer from '@/app/components/Content/CollectionContentRenderer';
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('@/app/hooks/useParallax', () => ({ useParallax: () => ({ current: null }) }));
+jest.mock('@/app/components/ContentCollection/CollectionFilterContext', () => ({
+  useCollectionFilter: () => null,
+}));
+
+const imageProps = {
+  contentId: 7,
+  className: 'imageSingle',
+  width: 300,
+  height: 200,
+  isMobile: false,
+  imageUrl: 'https://cdn.example/img.jpg',
+  imageWidth: 300,
+  imageHeight: 200,
+  alt: 'a photo',
+  enableParallax: false,
+  contentType: 'IMAGE' as const,
+};
+
+describe('CollectionContentRenderer — image click branch', () => {
+  it('fires onImageClick when the image wrapper is clicked', () => {
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer {...imageProps} onImageClick={onImageClick} />
+    );
+    const wrapper = container.querySelector('[data-image-wrapper]');
+    expect(wrapper).not.toBeNull();
+    fireEvent.click(wrapper!.querySelector('div')!);
+    expect(onImageClick).toHaveBeenCalledWith(7);
+  });
+
+  it('shows a pointer cursor when a click handler exists', () => {
+    const { container } = render(
+      <CollectionContentRenderer {...imageProps} onImageClick={jest.fn()} />
+    );
+    const wrapper = container.querySelector('[data-image-wrapper]') as HTMLElement;
+    expect(wrapper.style.cursor).toBe('pointer');
+  });
+
+  it('shows a default cursor when no click handler exists', () => {
+    const { container } = render(<CollectionContentRenderer {...imageProps} />);
+    const wrapper = container.querySelector('[data-image-wrapper]') as HTMLElement;
+    expect(wrapper.style.cursor).toBe('default');
+  });
+
+  it('fires onFullScreenImageClick when fullscreen is enabled and no onImageClick', () => {
+    const onFullScreenImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer
+        {...imageProps}
+        enableFullScreenView
+        onFullScreenImageClick={onFullScreenImageClick}
+      />
+    );
+    const wrapper = container.querySelector('[data-image-wrapper]')!;
+    fireEvent.click(wrapper.querySelector('div')!);
+    expect(onFullScreenImageClick).toHaveBeenCalledTimes(1);
+    expect(onFullScreenImageClick.mock.calls[0][0]).toMatchObject({ id: 7, contentType: 'IMAGE' });
+  });
+});
+
+describe('CollectionContentRenderer — slug navigation branch', () => {
+  it('renders a navigation link (no onImageClick) and does not fire a click handler', () => {
+    render(
+      <CollectionContentRenderer
+        {...imageProps}
+        contentType="COLLECTION"
+        isCollection
+        hasSlug="dolomites-2025"
+        overlayText="Dolomites"
+      />
+    );
+    const link = screen.getByRole('link', { name: 'Dolomites' });
+    expect(link).toHaveAttribute('href', '/dolomites-2025');
+  });
+
+  it('does NOT navigate via href when onImageClick is supplied (handler wins)', () => {
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer
+        {...imageProps}
+        contentType="COLLECTION"
+        isCollection
+        hasSlug="dolomites-2025"
+        onImageClick={onImageClick}
+      />
+    );
+    // With onImageClick present, isSlugNav is false → wrapper div, not a Tile/link.
+    expect(container.querySelector('a[href="/dolomites-2025"]')).toBeNull();
+    const wrapper = container.querySelector('[data-image-wrapper]')!;
+    fireEvent.click(wrapper.querySelector('div')!);
+    expect(onImageClick).toHaveBeenCalledWith(7);
+  });
+});
+
+describe('CollectionContentRenderer — GIF branch', () => {
+  const gifProps = {
+    ...imageProps,
+    contentId: 11,
+    contentType: 'GIF' as const,
+    imageUrl: 'https://cdn.example/clip.mp4',
+    isGif: true,
+  };
+
+  it('renders a video source and fires onImageClick on click', () => {
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer {...gifProps} onImageClick={onImageClick} />
+    );
+    const source = container.querySelector('source');
+    expect(source).toHaveAttribute('src', 'https://cdn.example/clip.mp4');
+    fireEvent.click(container.querySelector('video')!.parentElement!);
+    expect(onImageClick).toHaveBeenCalledWith(11);
+  });
+
+  it('uses a pointer cursor on the GIF container when a click handler exists', () => {
+    const { container } = render(
+      <CollectionContentRenderer {...gifProps} onImageClick={jest.fn()} />
+    );
+    const box = container.querySelector('video')!.closest('div')!.parentElement as HTMLElement;
+    expect(box.style.cursor).toBe('pointer');
+  });
+});
+
+describe('CollectionContentRenderer — placeholder branch (no valid image)', () => {
+  const placeholderProps = {
+    ...imageProps,
+    contentId: 21,
+    imageUrl: '',
+    overlayText: 'Untitled',
+  };
+
+  it('renders overlay text and is a button when a click handler exists', () => {
+    const onImageClick = jest.fn();
+    render(<CollectionContentRenderer {...placeholderProps} onImageClick={onImageClick} />);
+    const button = screen.getByRole('button', { name: 'Untitled' });
+    fireEvent.click(button);
+    expect(onImageClick).toHaveBeenCalledWith(21);
+  });
+
+  it('fires the click handler on Enter/Space keydown', () => {
+    const onImageClick = jest.fn();
+    render(<CollectionContentRenderer {...placeholderProps} onImageClick={onImageClick} />);
+    const button = screen.getByRole('button', { name: 'Untitled' });
+    fireEvent.keyDown(button, { key: 'Enter' });
+    expect(onImageClick).toHaveBeenCalledWith(21);
+  });
+
+  it('is not a button when no click handler exists', () => {
+    render(<CollectionContentRenderer {...placeholderProps} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('Untitled')).toBeInTheDocument();
+  });
+});
+
+describe('CollectionContentRenderer — reorder mode disables click handling', () => {
+  it('does not fire onImageClick while in reorder mode', () => {
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer {...imageProps} onImageClick={onImageClick} isReorderMode />
+    );
+    const wrapper = container.querySelector('[data-image-wrapper]')!;
+    fireEvent.click(wrapper.querySelector('div')!);
+    expect(onImageClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/Content/boxRendererUtils.test.ts
+++ b/tests/components/Content/boxRendererUtils.test.ts
@@ -16,6 +16,18 @@ describe('computeReorderFlags', () => {
       expect(flags.isPickedUp).toBe(false);
       expect(flags.hasMoved).toBe(false);
     });
+
+    it('treats undefined reorder mode as inactive (the !!isReorderMode coercion)', () => {
+      // BoxRenderer leaves isReorderMode undefined (no default), unlike CollectionContentRenderer.
+      // The original `isReorderMode && …` returned undefined; the helper's `!!isReorderMode`
+      // returns false. This locks that exact divergent input.
+      const flags = computeReorderFlags(7, {
+        pickedUpImageId: 7,
+        reorderMoves: [{ imageId: 7, toIndex: 0 }],
+      });
+      expect(flags.isPickedUp).toBe(false);
+      expect(flags.hasMoved).toBe(false);
+    });
   });
 
   describe('isPickedUp', () => {

--- a/tests/components/Content/boxRendererUtils.test.ts
+++ b/tests/components/Content/boxRendererUtils.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the pure helpers extracted from {@link BoxRenderer}.
+ */
+
+import { computeReorderFlags } from '@/app/components/Content/boxRendererUtils';
+
+describe('computeReorderFlags', () => {
+  describe('when not in reorder mode', () => {
+    it('never marks an item picked up or moved', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: false,
+        pickedUpImageId: 7,
+        reorderMoves: [{ imageId: 7, toIndex: 0 }],
+        reorderDisplayOrder: [7, 8, 9],
+      });
+      expect(flags.isPickedUp).toBe(false);
+      expect(flags.hasMoved).toBe(false);
+    });
+  });
+
+  describe('isPickedUp', () => {
+    it('is true when the item is the picked-up image in reorder mode', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        pickedUpImageId: 7,
+        reorderMoves: undefined,
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.isPickedUp).toBe(true);
+    });
+
+    it('is false when a different image is picked up', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        pickedUpImageId: 8,
+        reorderMoves: undefined,
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.isPickedUp).toBe(false);
+    });
+  });
+
+  describe('hasMoved', () => {
+    it('is true when the item appears in reorderMoves', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        pickedUpImageId: null,
+        reorderMoves: [
+          { imageId: 9, toIndex: 1 },
+          { imageId: 7, toIndex: 0 },
+        ],
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.hasMoved).toBe(true);
+    });
+
+    it('is false when the item is not in reorderMoves', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        pickedUpImageId: null,
+        reorderMoves: [{ imageId: 9, toIndex: 1 }],
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.hasMoved).toBe(false);
+    });
+
+    it('is false when reorderMoves is undefined', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        pickedUpImageId: null,
+        reorderMoves: undefined,
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.hasMoved).toBe(false);
+    });
+  });
+
+  describe('isFirstInOrder / isLastInOrder', () => {
+    it('marks the first and last items by display order', () => {
+      const order = [5, 6, 7];
+      expect(
+        computeReorderFlags(5, {
+          isReorderMode: true,
+          reorderDisplayOrder: order,
+        }).isFirstInOrder
+      ).toBe(true);
+      expect(
+        computeReorderFlags(7, {
+          isReorderMode: true,
+          reorderDisplayOrder: order,
+        }).isLastInOrder
+      ).toBe(true);
+    });
+
+    it('marks a middle item as neither first nor last', () => {
+      const flags = computeReorderFlags(6, {
+        isReorderMode: true,
+        reorderDisplayOrder: [5, 6, 7],
+      });
+      expect(flags.isFirstInOrder).toBe(false);
+      expect(flags.isLastInOrder).toBe(false);
+    });
+
+    it('treats an id absent from a non-empty order as neither first nor last', () => {
+      // indexOf === -1; isFirst (=== 0) false, isLast (=== len-1, i.e. 2) false
+      const flags = computeReorderFlags(99, {
+        isReorderMode: true,
+        reorderDisplayOrder: [5, 6, 7],
+      });
+      expect(flags.isFirstInOrder).toBe(false);
+      expect(flags.isLastInOrder).toBe(false);
+    });
+
+    it('treats an empty display order as last (preserving -1 === 0 - 1)', () => {
+      // orderIndex = -1, length 0 → isLast === (-1 === -1) → true; isFirst false
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        reorderDisplayOrder: [],
+      });
+      expect(flags.isFirstInOrder).toBe(false);
+      expect(flags.isLastInOrder).toBe(true);
+    });
+
+    it('treats an undefined display order as last (preserving -1 === 0 - 1)', () => {
+      const flags = computeReorderFlags(7, {
+        isReorderMode: true,
+        reorderDisplayOrder: undefined,
+      });
+      expect(flags.isFirstInOrder).toBe(false);
+      expect(flags.isLastInOrder).toBe(true);
+    });
+  });
+});

--- a/tests/components/Content/collectionContentRendererUtils.test.ts
+++ b/tests/components/Content/collectionContentRendererUtils.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the pure helpers extracted from {@link CollectionContentRenderer}.
+ */
+
+import {
+  getClickEligibility,
+  resolveValidDimensions,
+  toCollectionDimensions,
+} from '@/app/components/Content/collectionContentRendererUtils';
+import { type CollectionInfoOptions } from '@/app/components/ContentCollection/CollectionFilterContext';
+
+const dim = (values: readonly string[], filterable: boolean) => ({ values, filterable });
+
+const options = (overrides: Partial<CollectionInfoOptions> = {}): CollectionInfoOptions => ({
+  tags: dim([], false),
+  people: dim([], false),
+  cameras: dim([], false),
+  lenses: dim([], false),
+  locations: dim([], false),
+  lensTypes: { values: [], filterable: false },
+  showHighlyRated: false,
+  ...overrides,
+});
+
+describe('toCollectionDimensions', () => {
+  it('returns no dimensions when nothing is filterable', () => {
+    expect(toCollectionDimensions(options())).toEqual({});
+  });
+
+  it('skips a dimension that is filterable but has no values', () => {
+    expect(toCollectionDimensions(options({ tags: dim([], true) }))).toEqual({});
+  });
+
+  it('maps a filterable dimension with values to a labelled dropdown', () => {
+    const result = toCollectionDimensions(options({ people: dim(['Ann', 'Bo'], true) }));
+    expect(result).toEqual({ selectedPeople: { label: 'People', options: ['Ann', 'Bo'] } });
+  });
+
+  it('maps tags, cameras, and locations with their labels', () => {
+    const result = toCollectionDimensions(
+      options({
+        tags: dim(['x'], true),
+        cameras: dim(['Leica'], true),
+        locations: dim(['Rome'], true),
+      })
+    );
+    expect(result.selectedTags).toEqual({ label: 'Tags', options: ['x'] });
+    expect(result.selectedCameras).toEqual({ label: 'Camera', options: ['Leica'] });
+    expect(result.selectedLocations).toEqual({ label: 'Location', options: ['Rome'] });
+  });
+
+  it('surfaces a lens-names dropdown when lenses are filterable', () => {
+    const result = toCollectionDimensions(options({ lenses: dim(['35mm'], true) }));
+    expect(result.selectedLenses).toEqual({ label: 'Lens', options: ['35mm'] });
+    expect(result.selectedLensTypes).toBeUndefined();
+  });
+
+  it('adds a lens-types dropdown (with display labels) when lens types are present', () => {
+    const result = toCollectionDimensions(
+      options({
+        lenses: dim(['35mm'], true),
+        lensTypes: { values: ['wide', 'telephoto'], filterable: true },
+      })
+    );
+    expect(result.selectedLenses).toEqual({ label: 'Lens', options: ['35mm'] });
+    expect(result.selectedLensTypes).toEqual({
+      label: 'Lens type',
+      options: ['wide', 'telephoto'],
+      optionLabels: { wide: 'Wide', normal: 'Normal', telephoto: 'Telephoto' },
+    });
+  });
+
+  it('still surfaces the lens dropdowns when only lens types are filterable', () => {
+    const result = toCollectionDimensions(
+      options({ lensTypes: { values: ['normal'], filterable: true } })
+    );
+    expect(result.selectedLenses).toEqual({ label: 'Lens', options: [] });
+    expect(result.selectedLensTypes).toMatchObject({ label: 'Lens type', options: ['normal'] });
+  });
+});
+
+describe('getClickEligibility', () => {
+  const base = {
+    contentType: 'IMAGE' as const,
+    isReorderMode: false,
+    hasSlug: undefined as string | undefined,
+    onImageClick: undefined as ((id: number) => void) | undefined,
+    enableFullScreenView: false,
+    onFullScreenImageClick: undefined,
+  };
+
+  it('TEXT content is never clickable nor a slug nav', () => {
+    expect(getClickEligibility({ ...base, contentType: 'TEXT' })).toEqual({
+      hasClickHandler: false,
+      isSlugNav: false,
+    });
+  });
+
+  it('reorder mode disables both eligibility flags', () => {
+    expect(
+      getClickEligibility({ ...base, isReorderMode: true, onImageClick: jest.fn(), hasSlug: 's' })
+    ).toEqual({ hasClickHandler: false, isSlugNav: false });
+  });
+
+  it('a slug with no onImageClick navigates and is clickable', () => {
+    expect(
+      getClickEligibility({ ...base, contentType: 'COLLECTION', hasSlug: 'dolomites' })
+    ).toEqual({ hasClickHandler: true, isSlugNav: true });
+  });
+
+  it('onImageClick beats slug nav (handler, not href)', () => {
+    expect(
+      getClickEligibility({
+        ...base,
+        contentType: 'COLLECTION',
+        hasSlug: 'dolomites',
+        onImageClick: jest.fn(),
+      })
+    ).toEqual({ hasClickHandler: true, isSlugNav: false });
+  });
+
+  it('onImageClick alone makes an item clickable but not slug nav', () => {
+    expect(getClickEligibility({ ...base, onImageClick: jest.fn() })).toEqual({
+      hasClickHandler: true,
+      isSlugNav: false,
+    });
+  });
+
+  it('fullscreen view makes an image clickable without a slug or onImageClick', () => {
+    expect(
+      getClickEligibility({
+        ...base,
+        enableFullScreenView: true,
+        onFullScreenImageClick: jest.fn(),
+      })
+    ).toEqual({ hasClickHandler: true, isSlugNav: false });
+  });
+
+  it('an image with no slug, no handler, and no fullscreen is not clickable', () => {
+    expect(getClickEligibility(base)).toEqual({ hasClickHandler: false, isSlugNav: false });
+  });
+
+  it('an empty-string slug is treated as set for hasClickHandler but falsy for slug nav', () => {
+    // hasSlug !== undefined → true (clickable); !!hasSlug → false (no nav). Mirrors `_hasSlug` use.
+    expect(getClickEligibility({ ...base, hasSlug: '' })).toEqual({
+      hasClickHandler: true,
+      isSlugNav: false,
+    });
+  });
+});
+
+describe('resolveValidDimensions', () => {
+  it('passes finite dimensions through unchanged', () => {
+    expect(resolveValidDimensions({ width: 300, height: 200 })).toEqual({
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it('recovers width from the image aspect ratio when width is NaN', () => {
+    // height 400, image 1920x1080 → width = 400 * 1920 / 1080 ≈ 711.1
+    const result = resolveValidDimensions({
+      width: Number.NaN,
+      height: 400,
+      imageWidth: 1920,
+      imageHeight: 1080,
+    });
+    expect(result.height).toBe(400);
+    expect(result.width).toBeCloseTo(711.11, 1);
+  });
+
+  it('recovers height from the image aspect ratio when height is NaN', () => {
+    // width 600, image 1000x500 → height = 600 * 500 / 1000 = 300
+    const result = resolveValidDimensions({
+      width: 600,
+      height: Number.NaN,
+      imageWidth: 1000,
+      imageHeight: 500,
+    });
+    expect(result).toEqual({ width: 600, height: 300 });
+  });
+
+  it('falls back to 300x200 when both are NaN and image dims exist', () => {
+    expect(
+      resolveValidDimensions({
+        width: Number.NaN,
+        height: Number.NaN,
+        imageWidth: 1920,
+        imageHeight: 1080,
+      })
+    ).toEqual({ width: 300, height: 200 });
+  });
+
+  it('uses a 1.5 aspect ratio off the finite dimension when no image dims', () => {
+    expect(resolveValidDimensions({ width: Number.NaN, height: 200 })).toEqual({
+      width: 300,
+      height: 200,
+    });
+    expect(resolveValidDimensions({ width: 300, height: Number.NaN })).toEqual({
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it('falls back to 300x200 when both are NaN and no image dims', () => {
+    expect(resolveValidDimensions({ width: Number.NaN, height: Number.NaN })).toEqual({
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it('ignores zero image dims and uses the ratio fallback', () => {
+    expect(
+      resolveValidDimensions({ width: Number.NaN, height: 200, imageWidth: 0, imageHeight: 0 })
+    ).toEqual({ width: 300, height: 200 });
+  });
+});

--- a/tests/components/FullScreenModal/FullScreenModal.metadata.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.metadata.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Characterization tests for FullScreenModal's date/location resolution, rendered through the
+ * metadata overlay. These pin the image-vs-collection fallback behavior before the logic is
+ * extracted into fullScreenModalUtils, proving the extraction is behavior-preserving.
+ *
+ * The metadata overlay only renders when the current image is loaded (its id is in
+ * loadedImageIds) AND showMetadata is true.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
+import type { CollectionModel } from '@/app/types/Collection';
+import { CollectionType } from '@/app/types/Collection';
+import type { ContentGifModel, ContentImageModel } from '@/app/types/Content';
+
+// The Modal primitive locks body scroll via useBodyScrollLock, whose cleanup calls
+// window.scrollTo — not implemented in jsdom. We only assert on metadata markup, so stub the
+// lock to keep the test focused and the console clean.
+jest.mock('@/app/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: jest.fn() }));
+
+const img = (id: number, overrides: Partial<ContentImageModel> = {}): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: id,
+    visible: true,
+    title: `Image ${id}`,
+    locations: [],
+    ...overrides,
+  }) as ContentImageModel;
+
+const gif = (id: number, overrides: Partial<ContentGifModel> = {}): ContentGifModel =>
+  ({
+    id,
+    contentType: 'GIF',
+    gifUrl: `https://cdn.example/${id}.mp4`,
+    width: 800,
+    height: 600,
+    orderIndex: id,
+    visible: true,
+    title: `Gif ${id}`,
+    ...overrides,
+  }) as ContentGifModel;
+
+const collection = (overrides: Partial<CollectionModel> = {}): CollectionModel =>
+  ({
+    id: 1,
+    type: CollectionType.PORTFOLIO,
+    title: 'Trip',
+    slug: 'trip',
+    locations: [],
+    ...overrides,
+  }) as CollectionModel;
+
+const noop = () => {};
+
+function renderModal(image: ContentImageModel | ContentGifModel, collectionData?: CollectionModel) {
+  return render(
+    <FullScreenModal
+      fullScreenState={{ images: [image], currentIndex: 0 }}
+      loadedImageIds={new Set<number>([image.id])}
+      setLoadedImageIds={noop}
+      modalRef={{ current: null }}
+      hideImage={noop}
+      isSwiping={{ current: false }}
+      showMetadata
+      toggleMetadata={noop}
+      router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+      collectionData={collectionData}
+      navigateToNext={noop}
+      navigateToPrevious={noop}
+    />
+  );
+}
+
+describe('FullScreenModal — date resolution (characterization)', () => {
+  it('uses the image captureDate when present', () => {
+    renderModal(
+      img(1, { captureDate: '2024-03-01' }),
+      collection({ collectionDate: '2020-01-01' })
+    );
+    expect(screen.getByText('2024-03-01')).toBeInTheDocument();
+  });
+
+  it('falls back to the collection collectionDate when the image has no captureDate', () => {
+    renderModal(img(1, { captureDate: null }), collection({ collectionDate: '2020-01-01' }));
+    expect(screen.getByText('2020-01-01')).toBeInTheDocument();
+  });
+
+  it('GIF blocks ignore any image fields and fall back to the collection collectionDate', () => {
+    renderModal(gif(1), collection({ collectionDate: '2019-06-15' }));
+    expect(screen.getByText('2019-06-15')).toBeInTheDocument();
+  });
+});
+
+describe('FullScreenModal — location resolution (characterization)', () => {
+  it('uses the image locations when present', () => {
+    renderModal(
+      img(1, { locations: [{ id: 5, name: 'Banff', slug: 'banff' }] }),
+      collection({ locations: [{ id: 9, name: 'Elsewhere', slug: 'elsewhere' }] })
+    );
+    expect(screen.getByText('Banff')).toBeInTheDocument();
+    expect(screen.queryByText('Elsewhere')).not.toBeInTheDocument();
+  });
+
+  it('falls back to collection locations when the image has none', () => {
+    renderModal(
+      img(1, { locations: [] }),
+      collection({ locations: [{ id: 9, name: 'Elsewhere', slug: 'elsewhere' }] })
+    );
+    expect(screen.getByText('Elsewhere')).toBeInTheDocument();
+  });
+
+  it('GIF blocks fall back to collection locations', () => {
+    renderModal(
+      gif(1),
+      collection({ locations: [{ id: 9, name: 'Elsewhere', slug: 'elsewhere' }] })
+    );
+    expect(screen.getByText('Elsewhere')).toBeInTheDocument();
+  });
+});

--- a/tests/components/FullScreenModal/fullScreenModalUtils.test.ts
+++ b/tests/components/FullScreenModal/fullScreenModalUtils.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the pure helpers extracted from FullScreenModal.
+ */
+
+import {
+  isGifBlock,
+  resolveDisplayDate,
+  resolveDisplayLocations,
+} from '@/app/components/FullScreenModal/fullScreenModalUtils';
+import type { CollectionModel, LocationModel } from '@/app/types/Collection';
+import { CollectionType } from '@/app/types/Collection';
+import type { ContentGifModel, ContentImageModel } from '@/app/types/Content';
+
+const img = (overrides: Partial<ContentImageModel> = {}): ContentImageModel =>
+  ({
+    id: 1,
+    contentType: 'IMAGE',
+    imageUrl: 'https://cdn.example/1.jpg',
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: 1,
+    visible: true,
+    locations: [],
+    ...overrides,
+  }) as ContentImageModel;
+
+const gif = (overrides: Partial<ContentGifModel> = {}): ContentGifModel =>
+  ({
+    id: 2,
+    contentType: 'GIF',
+    gifUrl: 'https://cdn.example/2.mp4',
+    width: 800,
+    height: 600,
+    orderIndex: 2,
+    visible: true,
+    ...overrides,
+  }) as ContentGifModel;
+
+const collection = (overrides: Partial<CollectionModel> = {}): CollectionModel =>
+  ({
+    id: 9,
+    type: CollectionType.PORTFOLIO,
+    title: 'Trip',
+    slug: 'trip',
+    locations: [],
+    ...overrides,
+  }) as CollectionModel;
+
+const loc = (id: number, name: string): LocationModel => ({ id, name, slug: name.toLowerCase() });
+
+describe('isGifBlock', () => {
+  it('returns true for GIF blocks', () => {
+    expect(isGifBlock(gif())).toBe(true);
+  });
+
+  it('returns false for image blocks', () => {
+    expect(isGifBlock(img())).toBe(false);
+  });
+});
+
+describe('resolveDisplayLocations', () => {
+  it('uses the image locations when present', () => {
+    const image = img({ locations: [loc(1, 'Banff')] });
+    const result = resolveDisplayLocations(
+      image,
+      collection({ locations: [loc(2, 'Elsewhere')] }),
+      false
+    );
+    expect(result).toEqual([loc(1, 'Banff')]);
+  });
+
+  it('falls back to collection locations when the image has an empty array', () => {
+    const result = resolveDisplayLocations(
+      img({ locations: [] }),
+      collection({ locations: [loc(2, 'Elsewhere')] }),
+      false
+    );
+    expect(result).toEqual([loc(2, 'Elsewhere')]);
+  });
+
+  it('returns an empty array when neither the image nor the collection has locations', () => {
+    expect(
+      resolveDisplayLocations(img({ locations: [] }), collection({ locations: [] }), false)
+    ).toEqual([]);
+  });
+
+  it('returns an empty array when collectionData is undefined and the image has none', () => {
+    expect(resolveDisplayLocations(img({ locations: [] }), undefined, false)).toEqual([]);
+  });
+
+  it('GIF blocks ignore image fields and fall back to collection locations', () => {
+    const result = resolveDisplayLocations(
+      gif(),
+      collection({ locations: [loc(2, 'Elsewhere')] }),
+      true
+    );
+    expect(result).toEqual([loc(2, 'Elsewhere')]);
+  });
+});
+
+describe('resolveDisplayDate', () => {
+  it('uses the image captureDate when present', () => {
+    const result = resolveDisplayDate(
+      img({ captureDate: '2024-03-01' }),
+      collection({ collectionDate: '2020-01-01' }),
+      false
+    );
+    expect(result).toBe('2024-03-01');
+  });
+
+  it('falls back to the collection collectionDate when captureDate is null', () => {
+    const result = resolveDisplayDate(
+      img({ captureDate: null }),
+      collection({ collectionDate: '2020-01-01' }),
+      false
+    );
+    expect(result).toBe('2020-01-01');
+  });
+
+  it('falls back to the collection collectionDate when captureDate is undefined', () => {
+    const result = resolveDisplayDate(img(), collection({ collectionDate: '2020-01-01' }), false);
+    expect(result).toBe('2020-01-01');
+  });
+
+  it('returns null when neither captureDate nor collectionDate is set', () => {
+    expect(resolveDisplayDate(img({ captureDate: null }), collection(), false)).toBeNull();
+  });
+
+  it('returns null when collectionData is undefined and the image has no captureDate', () => {
+    expect(resolveDisplayDate(img({ captureDate: null }), undefined, false)).toBeNull();
+  });
+
+  it('GIF blocks ignore image fields and fall back to the collection collectionDate', () => {
+    expect(resolveDisplayDate(gif(), collection({ collectionDate: '2019-06-15' }), true)).toBe(
+      '2019-06-15'
+    );
+  });
+
+  it('GIF blocks return null when the collection has no collectionDate', () => {
+    expect(resolveDisplayDate(gif(), collection(), true)).toBeNull();
+  });
+});

--- a/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
+++ b/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
@@ -78,4 +78,98 @@ describe('EssentialInfoSection', () => {
     const { container } = render(<EssentialInfoSection {...makeProps({ isGif: true })} />);
     expect(container.querySelector('[aria-disabled="true"]')).toBeInTheDocument();
   });
+
+  // Characterization tests for the collection-visibility toggle. These pin the current
+  // append-vs-update junction behavior through the rendered checkbox before the logic is
+  // extracted into essentialInfoUtils, proving the extraction is behavior-preserving.
+  describe('Collection Visibility toggle (characterization)', () => {
+    it('checkbox is checked by default when no junction exists (absent === visible)', () => {
+      render(<EssentialInfoSection {...makeProps({ currentCollectionId: 42 })} />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('checkbox is checked when the existing junction is not explicitly hidden', () => {
+      const updateState: ImageUpdateState = {
+        ...baseUpdateState,
+        collections: [
+          { collectionId: 42, name: 'Pacific Northwest', visible: true, orderIndex: 0 },
+        ],
+      };
+      render(<EssentialInfoSection {...makeProps({ currentCollectionId: 42, updateState })} />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('checkbox is unchecked only when the junction is explicitly visible=false', () => {
+      const updateState: ImageUpdateState = {
+        ...baseUpdateState,
+        collections: [
+          { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 0 },
+        ],
+      };
+      render(<EssentialInfoSection {...makeProps({ currentCollectionId: 42, updateState })} />);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('APPEND branch: unchecking when the image is not yet in the collection appends a new junction with the collection name and trailing orderIndex', () => {
+      const updateStateField = jest.fn();
+      const updateState: ImageUpdateState = {
+        ...baseUpdateState,
+        collections: [{ collectionId: 7, name: 'Other', visible: true, orderIndex: 0 }],
+      };
+      render(
+        <EssentialInfoSection
+          {...makeProps({ currentCollectionId: 42, updateState, updateStateField })}
+        />
+      );
+      // Default-visible (no junction for 42) → checkbox starts checked; uncheck it.
+      fireEvent.click(screen.getByRole('checkbox'));
+      expect(updateStateField).toHaveBeenCalledWith({
+        collections: [
+          { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+          { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 1 },
+        ],
+      });
+    });
+
+    it('APPEND branch: name is undefined when the collection is not in availableCollections', () => {
+      const updateStateField = jest.fn();
+      render(
+        <EssentialInfoSection
+          {...makeProps({
+            currentCollectionId: 999,
+            availableCollections: baseCollections,
+            updateStateField,
+          })}
+        />
+      );
+      fireEvent.click(screen.getByRole('checkbox'));
+      expect(updateStateField).toHaveBeenCalledWith({
+        collections: [{ collectionId: 999, name: undefined, visible: false, orderIndex: 0 }],
+      });
+    });
+
+    it('UPDATE branch: toggling an existing junction updates visible in place without re-ordering', () => {
+      const updateStateField = jest.fn();
+      const updateState: ImageUpdateState = {
+        ...baseUpdateState,
+        collections: [
+          { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+          { collectionId: 42, name: 'Pacific Northwest', visible: true, orderIndex: 1 },
+        ],
+      };
+      render(
+        <EssentialInfoSection
+          {...makeProps({ currentCollectionId: 42, updateState, updateStateField })}
+        />
+      );
+      // Junction for 42 exists and is visible → checkbox starts checked; uncheck it.
+      fireEvent.click(screen.getByRole('checkbox'));
+      expect(updateStateField).toHaveBeenCalledWith({
+        collections: [
+          { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+          { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 1 },
+        ],
+      });
+    });
+  });
 });

--- a/tests/components/Metadata/sections/essentialInfoUtils.test.ts
+++ b/tests/components/Metadata/sections/essentialInfoUtils.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the pure helpers extracted from EssentialInfoSection.
+ */
+
+import {
+  isCurrentCollectionVisible,
+  toggleCollectionVisibility,
+} from '@/app/components/Metadata/sections/essentialInfoUtils';
+import type { ChildCollection, CollectionListModel } from '@/app/types/Collection';
+
+const available: CollectionListModel[] = [
+  { id: 42, name: 'Pacific Northwest', slug: 'pacific-northwest' },
+  { id: 7, name: 'Other', slug: 'other' },
+];
+
+describe('isCurrentCollectionVisible', () => {
+  it('returns true when there is no junction for the current collection (absent === visible)', () => {
+    expect(isCurrentCollectionVisible([], 42)).toBe(true);
+    expect(isCurrentCollectionVisible(undefined, 42)).toBe(true);
+  });
+
+  it('returns true when the junction exists with visible undefined', () => {
+    const collections: ChildCollection[] = [{ collectionId: 42 }];
+    expect(isCurrentCollectionVisible(collections, 42)).toBe(true);
+  });
+
+  it('returns true when the junction is explicitly visible=true', () => {
+    const collections: ChildCollection[] = [{ collectionId: 42, visible: true }];
+    expect(isCurrentCollectionVisible(collections, 42)).toBe(true);
+  });
+
+  it('returns false only when the junction is explicitly visible=false', () => {
+    const collections: ChildCollection[] = [{ collectionId: 42, visible: false }];
+    expect(isCurrentCollectionVisible(collections, 42)).toBe(false);
+  });
+
+  it('ignores junctions for other collections', () => {
+    const collections: ChildCollection[] = [{ collectionId: 7, visible: false }];
+    // No junction for 42 → default visible.
+    expect(isCurrentCollectionVisible(collections, 42)).toBe(true);
+  });
+});
+
+describe('toggleCollectionVisibility', () => {
+  it('returns the input unchanged when currentCollectionId is null/undefined', () => {
+    const collections: ChildCollection[] = [{ collectionId: 42, visible: true, orderIndex: 0 }];
+    expect(toggleCollectionVisibility(collections, undefined, false, available)).toBe(collections);
+  });
+
+  it('treats an undefined collections array as empty', () => {
+    expect(toggleCollectionVisibility(undefined, undefined, false, available)).toEqual([]);
+  });
+
+  describe('UPDATE branch (junction already exists)', () => {
+    it('updates visible in place without re-ordering or touching siblings', () => {
+      const collections: ChildCollection[] = [
+        { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+        { collectionId: 42, name: 'Pacific Northwest', visible: true, orderIndex: 1 },
+      ];
+      expect(toggleCollectionVisibility(collections, 42, false, available)).toEqual([
+        { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+        { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 1 },
+      ]);
+    });
+
+    it('can flip a hidden junction back to visible', () => {
+      const collections: ChildCollection[] = [
+        { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 0 },
+      ];
+      expect(toggleCollectionVisibility(collections, 42, true, available)).toEqual([
+        { collectionId: 42, name: 'Pacific Northwest', visible: true, orderIndex: 0 },
+      ]);
+    });
+
+    it('preserves extra junction fields (slug, coverImageUrl) when updating', () => {
+      const collections: ChildCollection[] = [
+        {
+          collectionId: 42,
+          name: 'Pacific Northwest',
+          slug: 'pnw',
+          coverImageUrl: 'https://cdn/c.jpg',
+          visible: true,
+          orderIndex: 0,
+        },
+      ];
+      const result = toggleCollectionVisibility(collections, 42, false, available);
+      expect(result[0]).toEqual({
+        collectionId: 42,
+        name: 'Pacific Northwest',
+        slug: 'pnw',
+        coverImageUrl: 'https://cdn/c.jpg',
+        visible: false,
+        orderIndex: 0,
+      });
+    });
+  });
+
+  describe('APPEND branch (junction does not exist yet)', () => {
+    it('appends a new junction with the looked-up name and a trailing orderIndex', () => {
+      const collections: ChildCollection[] = [
+        { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+      ];
+      expect(toggleCollectionVisibility(collections, 42, false, available)).toEqual([
+        { collectionId: 7, name: 'Other', visible: true, orderIndex: 0 },
+        { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 1 },
+      ]);
+    });
+
+    it('appends with orderIndex 0 onto an empty list', () => {
+      expect(toggleCollectionVisibility([], 42, true, available)).toEqual([
+        { collectionId: 42, name: 'Pacific Northwest', visible: true, orderIndex: 0 },
+      ]);
+    });
+
+    it('sets name undefined when the collection is not in availableCollections', () => {
+      expect(toggleCollectionVisibility([], 999, false, available)).toEqual([
+        { collectionId: 999, name: undefined, visible: false, orderIndex: 0 },
+      ]);
+    });
+  });
+});

--- a/tests/components/ui/dropdownUtils.test.ts
+++ b/tests/components/ui/dropdownUtils.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the pure helpers extracted from {@link Dropdown}.
+ */
+
+import { type AddNewField, type MetadataItem } from '@/app/components/ui/Dropdown/Dropdown';
+import {
+  findMissingRequiredFields,
+  getItemDisplayName,
+  getKey,
+  isAddNewFormValid,
+  isFieldVisible,
+  isItemSelected,
+  itemExistsInDatabase,
+  processAddNewFormData,
+  removeFromSelection,
+  toggleMultiSelection,
+} from '@/app/components/ui/Dropdown/dropdownUtils';
+
+interface TagItem extends MetadataItem {
+  id: number;
+  name: string;
+}
+
+const tag = (id: number, name: string): TagItem => ({ id, name });
+
+describe('getItemDisplayName', () => {
+  it('returns empty string for null/undefined', () => {
+    const noItem: TagItem | undefined = undefined;
+    expect(getItemDisplayName(null)).toBe('');
+    expect(getItemDisplayName(noItem)).toBe('');
+  });
+
+  it('falls back to displayName then name when no getter is provided', () => {
+    expect(getItemDisplayName({ displayName: 'Disp', name: 'Nm' })).toBe('Disp');
+    expect(getItemDisplayName({ name: 'Nm' })).toBe('Nm');
+    expect(getItemDisplayName({})).toBe('');
+  });
+
+  it('uses the custom getter when provided', () => {
+    expect(getItemDisplayName(tag(1, 'Mountains'), item => `#${item.name}`)).toBe('#Mountains');
+  });
+
+  it('defensively coerces a non-string getter result to empty string', () => {
+    // Simulate a misbehaving getter returning a non-string at runtime.
+    const badGetter = (() => ({ not: 'a string' })) as unknown as (item: TagItem) => string;
+    expect(getItemDisplayName(tag(1, 'Mountains'), badGetter)).toBe('');
+  });
+});
+
+describe('getKey', () => {
+  it('uses the custom getItemKey getter when provided', () => {
+    expect(getKey(tag(5, 'Ocean'), item => `key-${item.id}`)).toBe('key-5');
+  });
+
+  it('falls back to id, then name, then empty string', () => {
+    expect(getKey(tag(5, 'Ocean'))).toBe(5);
+    expect(getKey({ name: 'Ocean' })).toBe('Ocean');
+    expect(getKey({})).toBe('');
+  });
+});
+
+describe('itemExistsInDatabase', () => {
+  it('treats a null/undefined item as existing', () => {
+    const noItem: TagItem | undefined = undefined;
+    expect(itemExistsInDatabase(null)).toBe(true);
+    expect(itemExistsInDatabase(noItem)).toBe(true);
+  });
+
+  it('is true only for a positive id', () => {
+    expect(itemExistsInDatabase(tag(1, 'A'))).toBe(true);
+    expect(itemExistsInDatabase(tag(0, 'New'))).toBe(false);
+    expect(itemExistsInDatabase({ name: 'No id' })).toBe(false);
+    expect(itemExistsInDatabase({ id: -1, name: 'Neg' })).toBe(false);
+  });
+});
+
+describe('isItemSelected', () => {
+  const a = tag(1, 'Mountains');
+  const b = tag(2, 'Ocean');
+
+  it('matches by id in multi-select', () => {
+    expect(isItemSelected(a, null, [a, b], true)).toBe(true);
+    expect(isItemSelected(tag(3, 'Forest'), null, [a, b], true)).toBe(false);
+  });
+
+  it('falls back to display-name match when ids are absent', () => {
+    const x = { name: 'Mountains' };
+    const y = { name: 'Mountains' };
+    expect(isItemSelected(y, null, [x], true)).toBe(true);
+  });
+
+  it('matches the single selectedValue in single-select', () => {
+    expect(isItemSelected(a, a, [], false)).toBe(true);
+    expect(isItemSelected(b, a, [], false)).toBe(false);
+  });
+
+  it('returns false in single-select when nothing is selected', () => {
+    expect(isItemSelected(a, null, [], false)).toBe(false);
+  });
+
+  it('honors the custom getDisplayName when matching by name', () => {
+    const x = { name: 'mountains' };
+    const y = { name: 'MOUNTAINS' };
+    const lower = (item: MetadataItem) => (item.name ?? '').toLowerCase();
+    expect(isItemSelected(y, null, [x], true, lower)).toBe(true);
+  });
+});
+
+describe('removeFromSelection', () => {
+  const a = tag(1, 'Mountains');
+  const b = tag(2, 'Ocean');
+
+  it('removes the matching item by id', () => {
+    expect(removeFromSelection([a, b], a)).toEqual([b]);
+  });
+
+  it('removes by display name when ids are absent', () => {
+    const x = { name: 'Mountains' };
+    const y = { name: 'Ocean' };
+    expect(removeFromSelection([x, y], { name: 'Mountains' })).toEqual([y]);
+  });
+
+  it('returns the array unchanged when the item is not present', () => {
+    expect(removeFromSelection([a], b)).toEqual([a]);
+  });
+});
+
+describe('toggleMultiSelection', () => {
+  const a = tag(1, 'Mountains');
+  const b = tag(2, 'Ocean');
+
+  it('appends an unselected item', () => {
+    expect(toggleMultiSelection([a], b)).toEqual([a, b]);
+  });
+
+  it('removes an already-selected item', () => {
+    expect(toggleMultiSelection([a, b], a)).toEqual([b]);
+  });
+
+  it('appends to an empty selection', () => {
+    expect(toggleMultiSelection([], a)).toEqual([a]);
+  });
+});
+
+describe('isFieldVisible', () => {
+  it('is visible by default when no showWhen predicate is set', () => {
+    const field: AddNewField = { name: 'name', label: 'Name', type: 'text' };
+    expect(isFieldVisible(field, {})).toBe(true);
+  });
+
+  it('defers to the showWhen predicate against the form data', () => {
+    const field: AddNewField = {
+      name: 'defaultFilmFormat',
+      label: 'Format',
+      type: 'text',
+      showWhen: data => data.isFilm === true,
+    };
+    expect(isFieldVisible(field, { isFilm: true })).toBe(true);
+    expect(isFieldVisible(field, { isFilm: false })).toBe(false);
+    expect(isFieldVisible(field, {})).toBe(false);
+  });
+});
+
+describe('findMissingRequiredFields', () => {
+  const nameField: AddNewField = { name: 'name', label: 'Name', type: 'text', required: true };
+  const optionalField: AddNewField = { name: 'note', label: 'Note', type: 'text' };
+
+  it('returns required fields with empty/missing values', () => {
+    expect(findMissingRequiredFields([nameField], {}).map(f => f.name)).toEqual(['name']);
+    expect(findMissingRequiredFields([nameField], { name: '   ' }).map(f => f.name)).toEqual([
+      'name',
+    ]);
+  });
+
+  it('ignores filled required fields and all optional fields', () => {
+    expect(findMissingRequiredFields([nameField, optionalField], { name: 'Sunsets' })).toEqual([]);
+  });
+
+  it('never reports checkboxes as missing', () => {
+    const cb: AddNewField = { name: 'isFilm', label: 'Film', type: 'checkbox', required: true };
+    expect(findMissingRequiredFields([cb], {})).toEqual([]);
+  });
+
+  it('skips hidden (showWhen → false) required fields', () => {
+    const hidden: AddNewField = {
+      name: 'fmt',
+      label: 'Format',
+      type: 'text',
+      required: true,
+      showWhen: data => data.isFilm === true,
+    };
+    expect(findMissingRequiredFields([hidden], { isFilm: false })).toEqual([]);
+  });
+});
+
+describe('processAddNewFormData', () => {
+  it('coerces a checkbox to a boolean', () => {
+    const field: AddNewField = { name: 'isFilm', label: 'Film', type: 'checkbox' };
+    expect(processAddNewFormData([field], { isFilm: true })).toEqual({ isFilm: true });
+    expect(processAddNewFormData([field], {})).toEqual({ isFilm: false });
+  });
+
+  it('parses a number field, or null when empty', () => {
+    const field: AddNewField = { name: 'iso', label: 'ISO', type: 'number' };
+    expect(processAddNewFormData([field], { iso: '400' })).toEqual({ iso: 400 });
+    expect(processAddNewFormData([field], { iso: '' })).toEqual({ iso: null });
+    expect(processAddNewFormData([field], {})).toEqual({ iso: null });
+  });
+
+  it('trims a string field, or null when blank', () => {
+    const field: AddNewField = { name: 'name', label: 'Name', type: 'text' };
+    expect(processAddNewFormData([field], { name: '  Sunsets  ' })).toEqual({ name: 'Sunsets' });
+    expect(processAddNewFormData([field], { name: '   ' })).toEqual({ name: null });
+  });
+
+  it('drops hidden fields entirely from the payload', () => {
+    const visible: AddNewField = { name: 'name', label: 'Name', type: 'text' };
+    const hidden: AddNewField = {
+      name: 'fmt',
+      label: 'Format',
+      type: 'text',
+      showWhen: data => data.isFilm === true,
+    };
+    const result = processAddNewFormData([visible, hidden], {
+      name: 'X',
+      fmt: '35mm',
+      isFilm: false,
+    });
+    expect(result).toEqual({ name: 'X' });
+    expect(result).not.toHaveProperty('fmt');
+  });
+});
+
+describe('isAddNewFormValid', () => {
+  const nameField: AddNewField = { name: 'name', label: 'Name', type: 'text', required: true };
+
+  it('is valid when every visible required field has content', () => {
+    expect(isAddNewFormValid([nameField], { name: 'Sunsets' })).toBe(true);
+  });
+
+  it('is invalid when a required field is empty/whitespace/missing', () => {
+    expect(isAddNewFormValid([nameField], {})).toBe(false);
+    expect(isAddNewFormValid([nameField], { name: '   ' })).toBe(false);
+  });
+
+  it('treats checkboxes as always valid', () => {
+    const cb: AddNewField = { name: 'isFilm', label: 'Film', type: 'checkbox', required: true };
+    expect(isAddNewFormValid([cb], {})).toBe(true);
+  });
+
+  it('requires a positive parseable number for required number fields', () => {
+    const num: AddNewField = { name: 'iso', label: 'ISO', type: 'number', required: true };
+    expect(isAddNewFormValid([num], { iso: '400' })).toBe(true);
+    expect(isAddNewFormValid([num], { iso: '0' })).toBe(false);
+    expect(isAddNewFormValid([num], { iso: 'abc' })).toBe(false);
+    expect(isAddNewFormValid([num], { iso: '' })).toBe(false);
+  });
+
+  it('ignores hidden required fields', () => {
+    const hidden: AddNewField = {
+      name: 'fmt',
+      label: 'Format',
+      type: 'text',
+      required: true,
+      showWhen: data => data.isFilm === true,
+    };
+    expect(isAddNewFormValid([hidden], { isFilm: false })).toBe(true);
+  });
+});

--- a/tests/components/ui/filterToolbarUtils.test.ts
+++ b/tests/components/ui/filterToolbarUtils.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the pure helpers extracted from {@link FilterToolbar}.
+ */
+
+import {
+  computeHasActiveFilters,
+  isOptionAvailable,
+} from '@/app/components/ui/FilterToolbar/filterToolbarUtils';
+import {
+  ARRAY_FILTER_KEYS,
+  type FilterState,
+  INITIAL_FILTER_STATE,
+} from '@/app/types/GalleryFilter';
+
+describe('isOptionAvailable', () => {
+  it('returns true for every option when no filteredAvailable map is given', () => {
+    expect(isOptionAvailable(null, 'selectedTags', 'sunset')).toBe(true);
+    expect(isOptionAvailable(undefined, 'selectedTags', 'sunset')).toBe(true);
+  });
+
+  it('returns true when the dimension has no entry in the map', () => {
+    expect(isOptionAvailable({ selectedPeople: ['Ana'] }, 'selectedTags', 'sunset')).toBe(true);
+  });
+
+  it('returns true when the value is in the dimension subset', () => {
+    expect(
+      isOptionAvailable({ selectedTags: ['sunset', 'forest'] }, 'selectedTags', 'sunset')
+    ).toBe(true);
+  });
+
+  it('returns false when the value is absent from a present, non-empty subset', () => {
+    expect(isOptionAvailable({ selectedTags: ['forest'] }, 'selectedTags', 'sunset')).toBe(false);
+  });
+
+  it('treats an empty subset as "all unavailable" for that dimension', () => {
+    // An empty array is falsy-by-length but the guard is `!avail`, so it falls through to includes.
+    expect(isOptionAvailable({ selectedTags: [] }, 'selectedTags', 'sunset')).toBe(false);
+  });
+});
+
+describe('computeHasActiveFilters', () => {
+  it('returns false when nothing is filtered', () => {
+    expect(computeHasActiveFilters(INITIAL_FILTER_STATE, ARRAY_FILTER_KEYS)).toBe(false);
+  });
+
+  it('returns true when a date sort is active', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, dateSortDirection: 'asc' };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS)).toBe(true);
+  });
+
+  it('returns true when highly-rated is toggled on', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, highlyRatedOnly: true };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS)).toBe(true);
+  });
+
+  it('returns true when the film filter is set', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, filmFilter: 'digital' };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS)).toBe(true);
+  });
+
+  it('returns true when any array dimension is non-empty', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedLenses: ['Zeiss 80mm'] };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS)).toBe(true);
+  });
+
+  it('ignores array dimensions not listed in arrayKeys', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedTags: ['sunset'] };
+    // selectedTags is non-empty but excluded from the scanned keys -> still no active filter.
+    expect(computeHasActiveFilters(state, ['selectedPeople'])).toBe(false);
+  });
+});

--- a/tests/types/GalleryFilter.test.ts
+++ b/tests/types/GalleryFilter.test.ts
@@ -1,5 +1,7 @@
 import {
+  ARRAY_FILTER_KEYS,
   cycleDateSort,
+  cycleFilmFilter,
   type FilterState,
   INITIAL_FILTER_STATE,
   toggleArrayFilter,
@@ -26,6 +28,20 @@ describe('FilterState helpers', () => {
     expect(cycleDateSort('off')).toBe('asc');
     expect(cycleDateSort('asc')).toBe('desc');
     expect(cycleDateSort('desc')).toBe('off');
+  });
+
+  it('cycleFilmFilter uses one canonical order: off -> film -> digital -> off', () => {
+    expect(cycleFilmFilter('off')).toBe('film');
+    expect(cycleFilmFilter('film')).toBe('digital');
+    expect(cycleFilmFilter('digital')).toBe('off');
+  });
+
+  it('ARRAY_FILTER_KEYS lists exactly the array dimensions of INITIAL_FILTER_STATE', () => {
+    const arrayKeysFromState = Object.entries(INITIAL_FILTER_STATE)
+      .filter(([, value]) => Array.isArray(value))
+      .map(([key]) => key)
+      .sort();
+    expect([...ARRAY_FILTER_KEYS].sort()).toEqual(arrayKeysFromState);
   });
 
   it('toggleArrayFilter adds a value not present', () => {

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1,13 +1,24 @@
 import {
   type AnyContentModel,
+  type ContentCollectionModel,
   type ContentImageModel,
   type ContentTextModel,
 } from '@/app/types/Content';
+import { type FilterState, INITIAL_FILTER_STATE, type LensType } from '@/app/types/GalleryFilter';
 import {
+  applyCollectionFilters,
+  buildCollectionCriteria,
+  buildLocationCriteria,
   computeFilterCounts,
   type ContentFilterCriteria,
+  extractCollectionFilterOptions,
   extractFilterOptions,
+  filmFilterFromIsFilm,
   filterContent,
+  hasAnyActiveFilter,
+  hasFilterableOptions,
+  hasValueVariance,
+  mergeDateSortedImages,
   parseFilterFromParams,
   serializeFilterToParams,
 } from '@/app/utils/contentFilter';
@@ -977,5 +988,405 @@ describe('extractFilterOptions tag frequency', () => {
     ];
     const options = extractFilterOptions(images);
     expect(options.tags).toHaveLength(10);
+  });
+});
+
+// ─── Collection-page filter derivations ───
+
+function makeCollectionRef(
+  overrides: Partial<ContentCollectionModel> = {}
+): ContentCollectionModel {
+  return {
+    id: 1000,
+    contentType: 'COLLECTION',
+    orderIndex: 0,
+    slug: 'child',
+    collectionType: 'COLLECTION' as ContentCollectionModel['collectionType'],
+    referencedCollectionId: 1,
+    ...overrides,
+  };
+}
+
+function makeFilterState(overrides: Partial<FilterState> = {}): FilterState {
+  return { ...INITIAL_FILTER_STATE, ...overrides };
+}
+
+describe('extractCollectionFilterOptions', () => {
+  it('returns all dimensions empty for an empty input', () => {
+    const dims = extractCollectionFilterOptions([]);
+    expect(dims.tags.values).toEqual([]);
+    expect(dims.people.values).toEqual([]);
+    expect(dims.cameras.values).toEqual([]);
+    expect(dims.lenses.values).toEqual([]);
+    expect(dims.locations.values).toEqual([]);
+    expect(dims.lensTypes.values).toEqual([]);
+  });
+
+  it('marks tags and people filterable regardless of count', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }], people: [] }),
+    ]);
+    expect(dims.tags.filterable).toBe(true);
+    expect(dims.people.filterable).toBe(true);
+  });
+
+  it('marks single-value cameras/lenses/locations non-filterable (info-mode)', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({
+        id: 1,
+        camera: { id: 1, name: 'Sony A7III' },
+        lens: { id: 1, name: 'FE 35mm' },
+        locations: [{ id: 1, name: 'Seattle', slug: 'seattle' }],
+      }),
+    ]);
+    expect(dims.cameras.values).toEqual(['Sony A7III']);
+    expect(dims.cameras.filterable).toBe(false);
+    expect(dims.lenses.filterable).toBe(false);
+    expect(dims.locations.filterable).toBe(false);
+  });
+
+  it('marks cameras/lenses/locations filterable when 2+ distinct values', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({
+        id: 1,
+        camera: { id: 1, name: 'Sony A7III' },
+        lens: { id: 1, name: 'FE 35mm' },
+        locations: [{ id: 1, name: 'Seattle', slug: 'seattle' }],
+      }),
+      makeImage({
+        id: 2,
+        camera: { id: 2, name: 'Nikon Z6' },
+        lens: { id: 2, name: 'NIKKOR 50mm' },
+        locations: [{ id: 2, name: 'Tokyo', slug: 'tokyo' }],
+      }),
+    ]);
+    expect(dims.cameras.filterable).toBe(true);
+    expect(dims.lenses.filterable).toBe(true);
+    expect(dims.locations.filterable).toBe(true);
+  });
+
+  it('surfaces lens types only with 2+ distinct categories AND 2+ distinct lenses', () => {
+    // wide (24mm) + telephoto (200mm), two distinct lenses → lens types surface, ordered.
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, focalLength: '24mm', lens: { id: 1, name: 'FE 24mm' } }),
+      makeImage({ id: 2, focalLength: '200mm', lens: { id: 2, name: 'FE 200mm' } }),
+    ]);
+    expect(dims.lensTypes.values).toEqual(['wide', 'telephoto']);
+  });
+
+  it('suppresses lens types when only one category present', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, focalLength: '24mm', lens: { id: 1, name: 'FE 24mm' } }),
+      makeImage({ id: 2, focalLength: '28mm', lens: { id: 2, name: 'FE 28mm' } }),
+    ]);
+    // both 'wide' → only one distinct category
+    expect(dims.lensTypes.values).toEqual([]);
+  });
+
+  it('suppresses lens types when fewer than 2 distinct lenses', () => {
+    // two categories but a single lens object → lenses < 2
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, focalLength: '24mm', lens: { id: 1, name: 'FE 24mm' } }),
+      makeImage({ id: 2, focalLength: '200mm', lens: { id: 1, name: 'FE 24mm' } }),
+    ]);
+    expect(dims.lensTypes.values).toEqual([]);
+  });
+
+  it('aggregates tags/people/locations from collection refs', () => {
+    const dims = extractCollectionFilterOptions(
+      [],
+      [
+        makeCollectionRef({
+          id: 2000,
+          tags: [{ id: 1, name: 'travel', slug: 'travel' }],
+          people: [{ id: 1, name: 'Alice', slug: 'alice' }],
+          locations: [{ id: 1, name: 'Rome', slug: 'rome' }],
+        }),
+      ]
+    );
+    expect(dims.tags.values).toEqual(['travel']);
+    expect(dims.people.values).toEqual(['Alice']);
+    expect(dims.locations.values).toEqual(['Rome']);
+  });
+});
+
+describe('buildCollectionCriteria', () => {
+  it('returns an empty object for the initial (no-op) state', () => {
+    expect(buildCollectionCriteria(makeFilterState())).toEqual({});
+  });
+
+  it('maps highlyRatedOnly to minRating 4', () => {
+    expect(buildCollectionCriteria(makeFilterState({ highlyRatedOnly: true }))).toEqual({
+      minRating: 4,
+    });
+  });
+
+  it('uses AND match mode for tags/people/cameras/lenses', () => {
+    const criteria = buildCollectionCriteria(
+      makeFilterState({
+        selectedTags: ['a', 'b'],
+        selectedPeople: ['Alice'],
+        selectedCameras: ['Sony A7III'],
+        selectedLenses: ['FE 35mm'],
+      })
+    );
+    expect(criteria).toEqual({
+      tags: ['a', 'b'],
+      tagMatchMode: 'AND',
+      people: ['Alice'],
+      peopleMatchMode: 'AND',
+      cameras: ['Sony A7III'],
+      cameraMatchMode: 'AND',
+      lenses: ['FE 35mm'],
+      lensMatchMode: 'AND',
+    });
+  });
+
+  it('maps locations with no match mode (OR by default)', () => {
+    expect(buildCollectionCriteria(makeFilterState({ selectedLocations: ['Rome'] }))).toEqual({
+      locations: ['Rome'],
+    });
+  });
+
+  it('omits empty array dimensions', () => {
+    const criteria = buildCollectionCriteria(makeFilterState({ selectedTags: [] }));
+    expect(criteria).toEqual({});
+  });
+
+  it('does not include lens types (applied as a post-filter, not criteria)', () => {
+    const criteria = buildCollectionCriteria(
+      makeFilterState({ selectedLensTypes: ['wide' as LensType] })
+    );
+    expect(criteria).toEqual({});
+  });
+});
+
+describe('hasAnyActiveFilter', () => {
+  it('is false for the initial state', () => {
+    expect(hasAnyActiveFilter(makeFilterState())).toBe(false);
+  });
+
+  it.each<[string, Partial<FilterState>]>([
+    ['highlyRatedOnly', { highlyRatedOnly: true }],
+    ['selectedTags', { selectedTags: ['a'] }],
+    ['selectedPeople', { selectedPeople: ['Alice'] }],
+    ['selectedCameras', { selectedCameras: ['Sony'] }],
+    ['selectedLenses', { selectedLenses: ['FE 35mm'] }],
+    ['selectedLensTypes', { selectedLensTypes: ['wide' as LensType] }],
+    ['selectedLocations', { selectedLocations: ['Rome'] }],
+  ])('is true when %s is active', (_label, overrides) => {
+    expect(hasAnyActiveFilter(makeFilterState(overrides))).toBe(true);
+  });
+
+  it('ignores dateSortDirection (a sort, not a filter)', () => {
+    expect(hasAnyActiveFilter(makeFilterState({ dateSortDirection: 'desc' }))).toBe(false);
+  });
+});
+
+describe('applyCollectionFilters', () => {
+  const images = [
+    makeImage({ id: 1, rating: 5, focalLength: '24mm' }), // wide
+    makeImage({ id: 2, rating: 3, focalLength: '200mm' }), // telephoto
+    makeImage({ id: 3, rating: 5, focalLength: undefined }), // unparseable focal length
+  ];
+  const text = makeTextBlock();
+  const allContent: AnyContentModel[] = [images[0]!, images[1]!, text, images[2]!];
+
+  it('filters images by criteria and keeps non-image content in place', () => {
+    const result = applyCollectionFilters(allContent, images, { minRating: 5 }, []);
+    // images 1 & 3 (rating 5) survive; text block passes through; image 2 dropped
+    expect(result.map(c => `${c.contentType}:${c.id}`)).toEqual(['IMAGE:1', 'TEXT:100', 'IMAGE:3']);
+  });
+
+  it('applies lens-type post-filter, retaining images with unparseable focal length', () => {
+    const result = applyCollectionFilters(allContent, images, {}, ['wide']);
+    // image 1 is wide; image 3 has no parseable focalLength → kept; image 2 (telephoto) dropped
+    expect(result.map(c => `${c.contentType}:${c.id}`)).toEqual(['IMAGE:1', 'TEXT:100', 'IMAGE:3']);
+  });
+
+  it('combines criteria and lens-type post-filter', () => {
+    const result = applyCollectionFilters(allContent, images, { minRating: 5 }, ['telephoto']);
+    // rating 5 → images 1 & 3; telephoto post-filter keeps image 3 (unparseable) only (image 1 is wide)
+    expect(result.map(c => c.id)).toEqual([100, 3]);
+  });
+});
+
+describe('hasValueVariance', () => {
+  it('returns false for an empty array', () => {
+    expect(hasValueVariance([], img => img.rating)).toBe(false);
+  });
+
+  it('returns false when all selected values are identical', () => {
+    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 5 })];
+    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(false);
+  });
+
+  it('returns true when selected values differ', () => {
+    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 3 })];
+    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(true);
+  });
+
+  it('counts a rating of 0 as a distinct value when stringified', () => {
+    // Regression: the helper drops falsy outputs, so 0 must be stringified to count.
+    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 0 })];
+    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(true);
+  });
+
+  it('drops falsy (missing) capture dates so a single real date has no variance', () => {
+    const images = [
+      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
+      makeImage({ id: 2, captureDate: undefined }),
+    ];
+    expect(hasValueVariance(images, img => img.captureDate)).toBe(false);
+  });
+
+  it('returns true when two distinct real dates are present', () => {
+    const images = [
+      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
+      makeImage({ id: 2, captureDate: '2024-06-01T00:00:00Z' }),
+    ];
+    expect(hasValueVariance(images, img => img.captureDate)).toBe(true);
+  });
+});
+
+describe('mergeDateSortedImages', () => {
+  it('replaces image slots in order while leaving non-image blocks in place', () => {
+    const img1 = makeImage({ id: 1 });
+    const img2 = makeImage({ id: 2 });
+    const text = makeTextBlock();
+    const processed: AnyContentModel[] = [img1, text, img2];
+    // Sorted order reverses the two images.
+    const sorted = [img2, img1];
+    const result = mergeDateSortedImages(processed, sorted);
+    expect(result.map(c => `${c.contentType}:${c.id}`)).toEqual(['IMAGE:2', 'TEXT:100', 'IMAGE:1']);
+  });
+
+  it('falls back to the original item when sorted runs out', () => {
+    const img1 = makeImage({ id: 1 });
+    const img2 = makeImage({ id: 2 });
+    const result = mergeDateSortedImages([img1, img2], [img2]);
+    // second image slot has no sorted entry → keeps the original
+    expect(result.map(c => c.id)).toEqual([2, 2]);
+  });
+
+  it('returns the array unchanged when there are no images', () => {
+    const text = makeTextBlock();
+    const result = mergeDateSortedImages([text], []);
+    expect(result).toEqual([text]);
+  });
+});
+
+describe('hasFilterableOptions', () => {
+  const emptyDims = extractCollectionFilterOptions([]);
+
+  it('is false when nothing is filterable', () => {
+    expect(hasFilterableOptions(emptyDims, false, false)).toBe(false);
+  });
+
+  it('is true when Highly Rated is shown', () => {
+    expect(hasFilterableOptions(emptyDims, true, false)).toBe(true);
+  });
+
+  it('is true when capture dates vary', () => {
+    expect(hasFilterableOptions(emptyDims, false, true)).toBe(true);
+  });
+
+  it('is true when a tag dimension has values', () => {
+    // The 0.9 exclusion ratio drops tags on >=90% of images, so the tag must
+    // appear on under that share — give the second image no tags.
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }] }),
+      makeImage({ id: 2, tags: [] }),
+    ]);
+    expect(dims.tags.values).toEqual(['alpine']);
+    expect(hasFilterableOptions(dims, false, false)).toBe(true);
+  });
+
+  it('does not trigger on a single-value (non-filterable) location alone', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, locations: [{ id: 1, name: 'Seattle', slug: 'seattle' }] }),
+    ]);
+    // single location → locations.filterable is false, and no other dimension qualifies
+    expect(dims.locations.filterable).toBe(false);
+    expect(hasFilterableOptions(dims, false, false)).toBe(false);
+  });
+
+  it('triggers on a multi-value (filterable) location', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, locations: [{ id: 1, name: 'Seattle', slug: 'seattle' }] }),
+      makeImage({ id: 2, locations: [{ id: 2, name: 'Tokyo', slug: 'tokyo' }] }),
+    ]);
+    expect(dims.locations.filterable).toBe(true);
+    expect(hasFilterableOptions(dims, false, false)).toBe(true);
+  });
+});
+
+// ─── Location-page filter derivations ───
+
+describe('filmFilterFromIsFilm', () => {
+  it('maps true to film', () => {
+    expect(filmFilterFromIsFilm(true)).toBe('film');
+  });
+
+  it('maps false to digital', () => {
+    expect(filmFilterFromIsFilm(false)).toBe('digital');
+  });
+
+  it('maps undefined to off', () => {
+    const noValue: boolean | undefined = undefined;
+    expect(filmFilterFromIsFilm(noValue)).toBe('off');
+  });
+});
+
+describe('buildLocationCriteria', () => {
+  it('returns an empty object for the initial (no-op) state', () => {
+    expect(buildLocationCriteria(makeFilterState())).toEqual({});
+  });
+
+  it('maps highlyRatedOnly to minRating 4', () => {
+    expect(buildLocationCriteria(makeFilterState({ highlyRatedOnly: true }))).toEqual({
+      minRating: 4,
+    });
+  });
+
+  it('maps film filter to isFilm:true', () => {
+    expect(buildLocationCriteria(makeFilterState({ filmFilter: 'film' }))).toEqual({
+      isFilm: true,
+    });
+  });
+
+  it('maps digital filter to isFilm:false', () => {
+    expect(buildLocationCriteria(makeFilterState({ filmFilter: 'digital' }))).toEqual({
+      isFilm: false,
+    });
+  });
+
+  it('omits isFilm when film filter is off', () => {
+    expect(buildLocationCriteria(makeFilterState({ filmFilter: 'off' }))).toEqual({});
+  });
+
+  it('uses default (OR) match mode for tags and people — no match-mode keys', () => {
+    const criteria = buildLocationCriteria(
+      makeFilterState({ selectedTags: ['a', 'b'], selectedPeople: ['Alice'] })
+    );
+    expect(criteria).toEqual({ tags: ['a', 'b'], people: ['Alice'] });
+    expect(criteria).not.toHaveProperty('tagMatchMode');
+    expect(criteria).not.toHaveProperty('peopleMatchMode');
+  });
+
+  it('does not include collection-only dimensions (locations/cameras/lenses)', () => {
+    const criteria = buildLocationCriteria(
+      makeFilterState({
+        selectedLocations: ['Rome'],
+        selectedCameras: ['Sony'],
+        selectedLenses: ['FE 35mm'],
+      })
+    );
+    expect(criteria).toEqual({});
+  });
+
+  it('round-trips with filmFilterFromIsFilm for the film toggle', () => {
+    const criteria = buildLocationCriteria(makeFilterState({ filmFilter: 'film' }));
+    expect(filmFilterFromIsFilm(criteria.isFilm)).toBe('film');
   });
 });

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1232,6 +1232,14 @@ describe('hasValueVariance', () => {
     expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(true);
   });
 
+  it('drops rating 0 WITHOUT the String() wrapper — proves the call-site wrapper is load-bearing', () => {
+    // CollectionPageClient must pass `String(img.rating ?? 0)`, not the raw number. Without the
+    // wrapper, 0 is falsy → dropped → only {5} remains → no variance, silently hiding the
+    // Highly-Rated control on an all-0-vs-some-rated collection. This documents WHY the wrapper exists.
+    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 0 })];
+    expect(hasValueVariance(images, img => img.rating)).toBe(false);
+  });
+
   it('drops falsy (missing) capture dates so a single real date has no variance', () => {
     const images = [
       makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),


### PR DESCRIPTION
## Summary

Phase 2 of the thin-component extraction sweep (chapter **006 · Code Health**). Extracts inline derivation/business logic out of 8 `'use client'` components into co-located, unit-tested `*Utils.ts` helpers, so each component reads `hooks → helper calls → JSX` — generalizing the `Component.tsx` reference refactor. **Behavior-preserving throughout.**

Executed in parallel by a 5-agent team; verified + committed centrally (one commit per component).

## Components refactored

- **Dropdown** → `dropdownUtils.ts` (10 generic helpers)
- **BoxRenderer** → `boxRendererUtils.ts` (`computeReorderFlags`)
- **CollectionContentRenderer** → `collectionContentRendererUtils.ts` (`toCollectionDimensions`, `resolveValidDimensions`, `getClickEligibility`) — sub-component split left to `006-function-decomposition`
- **EssentialInfoSection** → `essentialInfoUtils.ts` (`toggleCollectionVisibility`, `isCurrentCollectionVisible`)
- **FullScreenModal** → `fullScreenModalUtils.ts` (`resolveDisplayLocations`, `resolveDisplayDate`, `isGifBlock`)
- **FilterToolbar** → `filterToolbarUtils.ts` + `GalleryFilter.ts` (`cycleFilmFilter`, exported `ARRAY_FILTER_KEYS`, `computeHasActiveFilters`, `isOptionAvailable`)
- **CollectionPageClient + LocationPageClient** → consolidated into `contentFilter.ts` (9 helpers; kills the duplicated criteria mapping)

## Verification

- `tsc --noEmit` — clean
- full `jest` — **101 suites / 1925 tests pass** (was 93/1742; +183 from new helper + characterization tests, **every pre-existing test unchanged** → behavior-preserving)
- `prettier` + `eslint` — clean
- **−423 lines** removed from components into tested helpers

## Notes

- Characterization tests were written green against the un-refactored components first where guards were thin (CollectionContentRenderer, EssentialInfoSection, FullScreenModal).
- `ManageClient` (1719 LoC) intentionally **not** included — spun to its own `006-manageclient-decomposition` plan.
- Flags surfaced for follow-up (not fixed here): `_hasSlug` misleading name + per-render inline `style={{}}` objects in CollectionContentRenderer → belong to the inline-style plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
