### PR TITLE
Directional prominence layout rewrite (+ filter-visibility gate, edit sheet)

### DIFF
--- a/app/(admin)/AdminScrollManager.tsx
+++ b/app/(admin)/AdminScrollManager.tsx
@@ -3,16 +3,10 @@
 import { useEffect } from 'react';
 
 /**
- * Forces manual scroll-restoration while any (admin) route is mounted.
- *
- * Admin surfaces (notably the manage page) fetch their content client-side
- * after mount, so the document is ~1 viewport tall on first paint and only
- * grows once the BoxTree grid renders. With the browser default
- * `scrollRestoration: 'auto'`, a full reload restores the pre-reload offset
- * against that asynchronously-growing page and parks the viewport on the global
- * <Footer/> at the bottom of <body>. Setting 'manual' makes every full reload
- * start at the top instead. The prior mode is restored when leaving the admin
- * subtree so the public site keeps native restoration. Renders nothing.
+ * Sets `scrollRestoration: 'manual'` while any admin route is mounted and restores
+ * the previous mode on unmount. Needed because admin pages grow asynchronously after
+ * mount; `'auto'` would restore a stale offset against the not-yet-rendered grid.
+ * Renders nothing.
  */
 export function AdminScrollManager(): null {
   useEffect(() => {

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -6,19 +6,8 @@ import { AdminScrollManager } from './AdminScrollManager';
 import styles from './layout.module.scss';
 
 /**
- * Layout for every (admin) route — the single home for admin gating, and the
- * one place the admin subtree opts into the dark surface.
- *
- * Gating: perimeter-only today (see requireAdmin); when identity/session auth
- * lands (009), the gate goes inside requireAdmin and this is the one
- * enforcement point.
- *
- * Surface: the wrapper carries data-surface="dark" so the scoped token
- * overrides in globals.css apply to every admin descendant, and paints the
- * surface itself (background/color). The page containers (PageShell,
- * the collection manage/edit pages) only own height and otherwise show through to the white body,
- * so this wrapper is what actually makes admin render dark. The public site is
- * untouched — only the (admin) segment opts in.
+ * Root layout for every (admin) route. Gates access via {@link requireAdmin} and
+ * opts the subtree into the dark surface via `data-surface="dark"`.
  */
 export default async function AdminLayout({ children }: { children: ReactNode }) {
   await requireAdmin(); // non-enforcing today

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -3,30 +3,13 @@ import { NextResponse } from 'next/server';
 
 import { logger } from '@/app/utils/logger';
 
-/**
- * Get Backend Base URL
- *
- * Retrieves the backend API base URL from environment variables with
- * fallback to localhost for development. Normalizes URL by removing
- * trailing slashes for consistent path construction.
- *
- * @returns Normalized backend base URL
- */
+/** Returns the backend base URL from `API_URL`, normalized (no trailing slash). */
 function getBackendBase(): string {
   const base = process.env.API_URL || 'http://localhost:8080';
   return base.replace(/\/+$/, '');
 }
 
-/**
- * Build Target URL
- *
- * Constructs the full backend URL from path segments and search parameters.
- * Handles path normalization and query string preservation for proxying.
- *
- * @param pathParts - Array of URL path segments after /api/proxy
- * @param search - Query string including leading '?' if present
- * @returns Complete target URL for backend request
- */
+/** Builds the full backend URL from path segments and the original query string. */
 function buildTargetUrl(pathParts: string[], search: string): string {
   // pathParts already contains everything after /api/proxy
   const targetPath = pathParts.join('/');
@@ -36,14 +19,8 @@ function buildTargetUrl(pathParts: string[], search: string): string {
 }
 
 /**
- * Forward Headers
- *
- * Filters and forwards request headers to the backend, excluding hop-by-hop
- * headers and platform-specific headers that shouldn't be proxied. Ensures
- * JSON accept header for API compatibility.
- *
- * @param req - Incoming Next.js request object
- * @returns Filtered headers safe for backend forwarding
+ * Strips hop-by-hop and platform-specific headers, re-injects a sanitized real-IP,
+ * and adds the internal API secret before forwarding to the backend.
  */
 function forwardHeaders(req: NextRequest): Headers {
   const headers = new Headers();
@@ -71,9 +48,7 @@ function forwardHeaders(req: NextRequest): Headers {
   }
   // Ensure JSON by default for non-multipart when client did not set
   if (!headers.has('accept')) headers.set('accept', 'application/json, */*;q=0.1');
-  // Forward sanitized real client IP for backend rate limiting.
-  // We strip x-forwarded-for / x-vercel-ip-* above to prevent header smuggling,
-  // then re-inject only what we trust.
+  // Re-inject sanitized real IP (stripped above to prevent header smuggling).
   const realIpRaw =
     req.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ??
     req.headers.get('x-real-ip') ??
@@ -85,22 +60,7 @@ function forwardHeaders(req: NextRequest): Headers {
   return headers;
 }
 
-/**
- * Proxy Handler
- *
- * Universal handler for all HTTP methods that forwards requests to the backend
- * API. Handles request transformation, error handling, and response streaming
- * with proper header filtering for both directions.
- *
- * @dependencies
- * - Next.js server APIs for request/response handling
- * - Backend API for actual data processing
- * - Helper functions for URL construction and header filtering
- *
- * @param req - Incoming Next.js request
- * @param context - Route context containing dynamic path parameters
- * @returns Proxied response from backend or error response
- */
+/** Universal proxy handler — forwards all HTTP methods to the backend with CORS and size guards. */
 async function handle(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
   const params = await context.params;
   const method = req.method;
@@ -116,21 +76,15 @@ async function handle(req: NextRequest, context: { params: Promise<{ path: strin
 
   const writeMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
-  // Tiered body size limit. Public write endpoints (contact form, gallery
-  // password) carry tiny JSON payloads — 16 KB is generous. Multipart uploads
-  // (admin image uploads, dev-only) need real headroom. The Content-Length
-  // header is a fast reject, but is not authoritative — clients may omit or
-  // spoof it. We re-check against the actual buffered body size below.
+  // 16 KB for JSON writes; 25 MB for multipart uploads. Content-Length is a fast
+  // reject only — we re-check against the actual buffered size below.
   const contentType = req.headers.get('content-type') ?? '';
   const isMultipart = contentType.startsWith('multipart/form-data');
   const maxBytes = isMultipart ? 25 * 1024 * 1024 : 16 * 1024;
 
   if (writeMethods.has(method)) {
     const origin = req.headers.get('origin');
-    // Dev LAN writes: private addresses + mDNS names on dev ports only.
-    // http origins on ports 3000/3001 from localhost, 127.0.0.1, RFC1918
-    // private IPv4 (10.x, 192.168.x, 172.16-31.x), *.local mDNS hostnames,
-    // or *.localhost. Public IPv4 and arbitrary hostnames are rejected.
+    // Also allow RFC1918/mDNS origins on dev ports (LAN mobile testing).
     const isDevLanOrigin =
       process.env.NODE_ENV === 'development' &&
       !!origin &&
@@ -146,22 +100,13 @@ async function handle(req: NextRequest, context: { params: Promise<{ path: strin
     }
   }
 
-  // Buffer the body: NextRequest.body is a ReadableStream, and undici fetch
-  // requires `duplex: 'half'` to forward streams. Buffering avoids the streaming
-  // path and lets undici set Content-Length.
-  //
-  // The body must be wrapped in a Uint8Array view rather than passed as a raw
-  // ArrayBuffer. AWS Amplify's SSR Lambda runtime ships an undici build that
-  // throws synchronously on bare ArrayBuffer bodies (manifesting as a 502
-  // "Bad Gateway" on every write through this proxy in production while the
-  // Next.js dev server accepts it fine). Uint8Array is what undici handles
-  // uniformly across all Node runtimes — local dev, Vercel, and Amplify.
+  // Uint8Array (not bare ArrayBuffer) — Amplify's undici build rejects ArrayBuffer
+  // bodies with a 502; Uint8Array works uniformly across all runtimes.
   const body = ['GET', 'HEAD'].includes(method)
     ? undefined
     : new Uint8Array(await req.arrayBuffer());
 
-  // Authoritative size check after buffering — guards against missing or
-  // spoofed Content-Length headers that bypassed the early reject above.
+  // Authoritative size check — guards spoofed/missing Content-Length.
   if (writeMethods.has(method) && body && body.byteLength > maxBytes) {
     return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
   }

--- a/app/components/CollectionListSelector/CollectionListSelector.tsx
+++ b/app/components/CollectionListSelector/CollectionListSelector.tsx
@@ -92,10 +92,8 @@ interface CollectionListSelectorProps {
   parentPendingRemoveIds?: Set<number>;
   onToggleParent?: (collection: CollectionListModel) => void;
   /**
-   * Single-column accordion. Groups rows by CollectionType into collapsible sections (names on the
-   * LEFT, one membership toggle on the right) WITHOUT the sibling/parent columns. Lets the image
-   * metadata editor reuse the manage page's grouped layout for its collection-membership picker.
-   * Composes with the single `onToggle` column only — ignore sibling/parent props when set.
+   * Engages accordion grouping with only the single `onToggle` column — no sibling/parent
+   * columns. Lets the image metadata editor reuse the grouped layout without multi-column mode.
    */
   grouped?: boolean;
   /**

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -319,7 +319,7 @@ export default function CollectionContentRenderer({
                       }
                     : null
                 }
-                showDateSort
+                showDateSort={collectionFilter.filterOptions.showDateSort}
                 showHighlyRated={collectionFilter.filterOptions.showHighlyRated}
                 density={collectionFilter.density}
                 densityMax={collectionFilter.densityMax}

--- a/app/components/ContentCollection/CollectionFilterContext.tsx
+++ b/app/components/ContentCollection/CollectionFilterContext.tsx
@@ -21,6 +21,7 @@ export interface CollectionInfoOptions {
   locations: DimensionData;
   lensTypes: DimensionData<LensType>;
   showHighlyRated: boolean;
+  showDateSort: boolean;
 }
 
 /** Subset of options available after current filters are applied (for grey-out logic). null = no active filters. */

--- a/app/components/ContentCollection/CollectionPage.tsx
+++ b/app/components/ContentCollection/CollectionPage.tsx
@@ -22,11 +22,7 @@ interface ContentCollectionPageProps {
   showProtectedCovers?: boolean;
   /** UA-derived SSR fallback viewport from {@link resolveSsrViewport}. */
   ssrViewport?: SsrViewport;
-  /**
-   * When true, mount the consolidated admin edit surface in CollectionPageClient. Only meaningful
-   * for the single-collection branch (admin edits one collection at a time). When false/absent the
-   * render is byte-identical to the public view.
-   */
+  /** Mounts the admin edit surface in CollectionPageClient (single-collection branch only). */
   editMode?: boolean;
 }
 

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -13,10 +13,10 @@ import { type FilterState, INITIAL_FILTER_STATE, type LensType } from '@/app/typ
 import {
   applyCollectionFilters,
   buildCollectionCriteria,
+  computeFilterVisibility,
   extractCollectionFilterOptions,
   hasAnyActiveFilter,
   hasFilterableOptions,
-  hasValueVariance,
   isImageContent,
   mergeDateSortedImages,
 } from '@/app/utils/contentFilter';
@@ -40,7 +40,7 @@ import styles from './CollectionPageClient.module.scss';
  */
 const EditModeLayer = dynamic(() => import('./edit/EditModeLayer'), { ssr: false });
 
-type CollectionDimensions = Omit<CollectionInfoOptions, 'showHighlyRated'>;
+type CollectionDimensions = Omit<CollectionInfoOptions, 'showHighlyRated' | 'showDateSort'>;
 
 interface CollectionPageClientProps {
   collection: CollectionModel;
@@ -148,6 +148,8 @@ export default function CollectionPageClient({
 
   const isCollectionDominant = allCollections.length > allImages.length;
 
+  const visibility = useMemo(() => computeFilterVisibility(allImages), [allImages]);
+
   const baseCollectionOptions = useMemo<CollectionDimensions>(() => {
     const options = extractCollectionFilterOptions(allImages, allCollections);
     if (isCollectionDominant) {
@@ -172,12 +174,10 @@ export default function CollectionPageClient({
 
   const filteredImages = useMemo(() => filteredContent.filter(isImageContent), [filteredContent]);
 
-  const hasRatingVariance = useMemo(
-    () => hasValueVariance(allImages, img => String(img.rating ?? 0)),
-    [allImages]
-  );
-
-  const showHighlyRated = hasRatingVariance && !isCollectionDominant;
+  // Collection-dominant (parent) pages suppress rating even when it varies — too
+  // few images for it to be a useful control there.
+  const showHighlyRated = visibility.highlyRated && !isCollectionDominant;
+  const showDateSort = visibility.dateSort;
 
   const filteredAvailableOptions = useMemo(() => {
     if (!hasActiveFilters) return null;
@@ -196,8 +196,9 @@ export default function CollectionPageClient({
     () => ({
       ...baseCollectionOptions,
       showHighlyRated,
+      showDateSort,
     }),
-    [baseCollectionOptions, showHighlyRated]
+    [baseCollectionOptions, showHighlyRated, showDateSort]
   );
 
   const contentBlocks = useMemo(() => {
@@ -246,12 +247,7 @@ export default function CollectionPageClient({
 
   const pageSize = collection.contentPerPage ?? 30;
 
-  const hasDateVariance = useMemo(
-    () => hasValueVariance(allImages, img => img.captureDate),
-    [allImages]
-  );
-
-  const hasOptions = hasFilterableOptions(baseCollectionOptions, showHighlyRated, hasDateVariance);
+  const hasOptions = hasFilterableOptions(baseCollectionOptions, showHighlyRated, showDateSort);
 
   const grid = (
     <ContentBlockWithFullScreen

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -69,12 +69,7 @@ export default function CollectionPageClient({
   serverIsMobile,
   editMode = false,
 }: CollectionPageClientProps) {
-  /**
-   * While the edit chunk streams in, the public grid doubles as the loading fallback so an
-   * edit-mode load never flashes blank. EditModeLayer flips this flag pre-paint on mount and
-   * takes over the grid render — edit affordances appearing a beat after the content is
-   * consistent with the layer's own editReady gating.
-   */
+  // Public grid is the loading fallback until EditModeLayer mounts and takes over.
   const [editLayerMounted, setEditLayerMounted] = useState(false);
   const handleEditLayerMounted = useCallback(() => setEditLayerMounted(true), []);
 
@@ -128,12 +123,8 @@ export default function CollectionPageClient({
     [isSelectMode, selectedIds, enterSelectMode, exitSelectMode]
   );
 
-  /**
-   * Live content reported up from EditModeLayer (per its onLiveContentChange contract: the
-   * layer's current content on every identity change, null on unmount). The filter options
-   * below must be derived from the SAME content the edit grid renders — the admin DTO after
-   * loads/saves — or in-session uploads and tag edits never surface in the filter UI.
-   */
+  // Live content from EditModeLayer — filter options must match what the edit grid renders
+  // so in-session uploads and tag edits surface in the filter UI.
   const [liveEditContent, setLiveEditContent] = useState<AnyContentModel[] | null>(null);
 
   // Public render works off the server seed; edit mode tracks the layer's live content.

--- a/app/components/ContentCollection/edit/CollectionEditSheet.module.scss
+++ b/app/components/ContentCollection/edit/CollectionEditSheet.module.scss
@@ -12,3 +12,30 @@
     padding-right: var(--default-padding, var(--space-6));
   }
 }
+
+/* Desktop: Info + Structure side-by-side. Columns scroll independently within the sheet so
+   both headings stay anchored and a long Info panel doesn't strand the short Structure panel
+   in whitespace. */
+.twoCol {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  overflow: hidden;
+}
+
+.column {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.columnHeading {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  background: var(--color-bg);
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 600;
+}

--- a/app/components/ContentCollection/edit/CollectionEditSheet.tsx
+++ b/app/components/ContentCollection/edit/CollectionEditSheet.tsx
@@ -18,15 +18,9 @@ interface CollectionEditSheetProps {
 /**
  * Slide-up sheet that renders the collection's edit fields.
  *
- * Mobile (`twoColumn=false`): renders only the active tab's field area. The tab row
- * and Save button live in the consumer's EditBar. ARIA contract: because only one panel
- * is in the DOM at a time (conditional rendering, not hidden), the container takes
- * `role="tabpanel"` and its `id` changes with the active tab. EditBar emits `aria-controls`
- * only for the selected tab, so the reference always resolves to this mounted element.
- *
- * Desktop (`twoColumn=true`): both Info and Structure are shown at once as two labeled
- * regions (no tab semantics — there is no chooser to control them), so the user sees
- * every option without switching tabs.
+ * Mobile: one tab panel at a time; `role="tabpanel"` id tracks the active tab so
+ * EditBar's `aria-controls` always resolves to the mounted element.
+ * Desktop (`twoColumn`): both sections rendered side-by-side, no tab semantics.
  */
 export function CollectionEditSheet({ edit, twoColumn = false }: CollectionEditSheetProps) {
   const { editTab } = edit;

--- a/app/components/ContentCollection/edit/CollectionEditSheet.tsx
+++ b/app/components/ContentCollection/edit/CollectionEditSheet.tsx
@@ -8,21 +8,47 @@ import { type UseCollectionEditResult } from './useCollectionEdit';
 interface CollectionEditSheetProps {
   /** The full hook result — the sheet is purely presentational over this surface. */
   edit: UseCollectionEditResult;
+  /**
+   * Desktop layout: render Info and Structure side-by-side in a two-column grid
+   * instead of one tab at a time. The consumer drops the EditBar tab chooser to match.
+   */
+  twoColumn?: boolean;
 }
 
 /**
- * Slide-up sheet that renders the active edit tab's fields.
+ * Slide-up sheet that renders the collection's edit fields.
  *
- * The tab row and Save button live in the consumer's EditBar — this component
- * renders only the scrollable field area for the active tab.
+ * Mobile (`twoColumn=false`): renders only the active tab's field area. The tab row
+ * and Save button live in the consumer's EditBar. ARIA contract: because only one panel
+ * is in the DOM at a time (conditional rendering, not hidden), the container takes
+ * `role="tabpanel"` and its `id` changes with the active tab. EditBar emits `aria-controls`
+ * only for the selected tab, so the reference always resolves to this mounted element.
  *
- * ARIA contract: because only one panel is in the DOM at a time (conditional
- * rendering, not hidden), the container takes `role="tabpanel"` and its `id`
- * changes with the active tab.  EditBar emits `aria-controls` only for the
- * selected tab, so the reference always resolves to this mounted element.
+ * Desktop (`twoColumn=true`): both Info and Structure are shown at once as two labeled
+ * regions (no tab semantics — there is no chooser to control them), so the user sees
+ * every option without switching tabs.
  */
-export function CollectionEditSheet({ edit }: CollectionEditSheetProps) {
+export function CollectionEditSheet({ edit, twoColumn = false }: CollectionEditSheetProps) {
   const { editTab } = edit;
+
+  if (twoColumn) {
+    return (
+      <div className={`${styles.editSheet} ${styles.twoCol}`}>
+        <section className={styles.column} aria-labelledby="edit-col-info">
+          <h2 id="edit-col-info" className={styles.columnHeading}>
+            Info
+          </h2>
+          <InfoTab edit={edit} />
+        </section>
+        <section className={styles.column} aria-labelledby="edit-col-structure">
+          <h2 id="edit-col-structure" className={styles.columnHeading}>
+            Structure
+          </h2>
+          <StructureTab edit={edit} />
+        </section>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -59,16 +59,9 @@ export interface EditModeLayerProps {
 }
 
 /**
- * Edit Mode Layer (client-only, dynamically imported)
- *
- * Owns the ENTIRE consolidated edit experience for a collection page: the useCollectionEdit hook,
- * the edit-mode grid render, the inline-edit context, the window Escape handler, the
- * select/reorder filter reset, and every edit overlay (error banner, edit sheet, EditBar,
- * metadata + text-block modals).
- *
- * CollectionPageClient loads this component via next/dynamic with ssr: false, so none of this
- * code — nor its transitive admin-only dependencies — ships in the public visitor bundle.
- * editMode is server-gated to local dev, so the chunk is only ever requested on admin pages.
+ * Consolidated edit experience for a collection page: grid, inline-edit context, Escape handler,
+ * filter reset, and all edit overlays (EditBar, sheet, metadata + text-block modals).
+ * Loaded via `next/dynamic` with `ssr: false` — admin-only deps stay out of the public bundle.
  */
 export default function EditModeLayer({
   collection,
@@ -80,14 +73,12 @@ export default function EditModeLayer({
 }: EditModeLayerProps) {
   const router = useRouter();
 
-  // Desktop shows Info + Structure side-by-side (no tab chooser); mobile keeps the either/or
-  // tab row. The role attributes differ per mode, so this is a JS breakpoint, not pure CSS.
-  // EditModeLayer is dynamically imported ssr:false, so useViewport never hydrates server markup.
+  // JS breakpoint: desktop shows both panels side-by-side; mobile uses a tab chooser.
+  // Safe to call — this component is dynamically imported ssr:false.
   const { isMobile } = useViewport();
   const twoColumn = !isMobile;
 
-  // Signal the parent before paint (layout effect, not effect) so the public-grid fallback is
-  // swapped out in the same frame this layer's grid commits — no double-grid flash.
+  // Signal before paint so the public-grid fallback swaps out in the same frame — no double-grid flash.
   useLayoutEffect(() => {
     onMounted();
   }, [onMounted]);
@@ -103,22 +94,14 @@ export default function EditModeLayer({
     onExitManage: handleExitManage,
   });
 
-  /**
-   * Edit interactions are gated until the richer admin DTO (`currentState`) is in. Before that,
-   * inline commits and post-save refreshes hit `!currentState` early-returns in the hook and
-   * silently drop — so until ready the page shows the public read-only render plus a disabled
-   * bar instead of edit affordances that cannot act.
-   */
+  /** True once the admin DTO has loaded; until then edit affordances are disabled. */
   const editReady = !edit.isLoadingState && edit.currentState !== null;
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
-      // Inline editors call event.preventDefault() on their own Escape handler. Bail here so a
-      // single Escape never both reverts an inline edit AND exits manage mode. The activeElement
-      // guard below is a belt-and-braces backup, but it is unreliable in React 19: the component
-      // can unmount (and focus collapse to <body>) via a microtask flush that runs before this
-      // window-level bubble listener fires.
+      // Inline editors preventDefault their own Escape; bail so one keypress never both reverts
+      // an inline edit AND exits manage mode. The activeElement guard is a backup.
       if (event.defaultPrevented) return;
       if (edit.editingContent || edit.isTextBlockModalOpen) return;
       if (
@@ -144,22 +127,17 @@ export default function EditModeLayer({
     handleExitManage,
   ]);
 
-  // Live collection: prefer the admin DTO (reflects saves) over the frozen server seed. The whole
-  // content pipeline below must read from it — e.g. after Reorder auto-converts a CHRONOLOGICAL
-  // collection to ORDERED, only the admin DTO carries the new displayMode, and sorting a saved
-  // reorder by the seed's CHRONOLOGICAL mode would visually revert it until a hard reload.
+  // Prefer the admin DTO (reflects saves) over the frozen server seed — e.g. displayMode updates
+  // after a Reorder only appear in the admin DTO.
   const liveCollection = edit.currentState?.collection ?? collection;
 
-  // Live content (falls back to the seed's content if the admin DTO omits it).
+  // Falls back to the seed's content if the admin DTO omits it.
   const allContent = useMemo(
     () => liveCollection.content ?? collection.content ?? [],
     [liveCollection.content, collection.content]
   );
 
-  // Mirror the live content up to the parent (see the onLiveContentChange contract). Keyed on
-  // the memoized allContent so it only fires when the identity actually changes; the
-  // cleanup-then-setup pair on a change batches into one parent render, and on unmount only the
-  // cleanup runs, resetting the parent to the seed.
+  // Mirror live content to parent (see onLiveContentChange contract); cleanup resets to seed.
   useEffect(() => {
     onLiveContentChange?.(allContent);
     return () => onLiveContentChange?.(null);
@@ -196,9 +174,7 @@ export default function EditModeLayer({
 
   const reorderActive = edit.reorder.active;
 
-  // Both reorder and select modes must operate on the unfiltered list:
-  //   reorder: positions are meaningless on a subset of the collection.
-  //   select: 'All' selects every image in the full collection, so the grid must show all of them.
+  // Reorder and select must operate on the full unfiltered list; clear active filters on entry.
   useEffect(() => {
     if (edit.manageMode !== 'reorder' && edit.manageMode !== 'select') return;
     if (!hasAnyActiveFilter(filterState)) return;
@@ -262,8 +238,7 @@ export default function EditModeLayer({
           <div className={styles.editCanvas}>{grid}</div>
         </InlineEditProvider>
       ) : (
-        // No provider while the admin DTO loads → the header card degrades to the public
-        // read-only render, so a tap cannot buffer an edit the hook would silently drop.
+        // No provider while the admin DTO loads — header card degrades to read-only.
         <div className={styles.editCanvas}>{grid}</div>
       )}
 

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -14,6 +14,7 @@ import ContentBlockWithFullScreen from '@/app/components/Content/ContentBlockWit
 import MetadataModal from '@/app/components/Metadata/MetadataModal';
 import TextBlockCreateModal from '@/app/components/TextBlockCreateModal/TextBlockCreateModal';
 import { EditBar } from '@/app/components/ui/EditBar/EditBar';
+import { useViewport } from '@/app/hooks/useViewport';
 import { type CollectionModel } from '@/app/types/Collection';
 import { type AnyContentModel } from '@/app/types/Content';
 import { type FilterState, INITIAL_FILTER_STATE } from '@/app/types/GalleryFilter';
@@ -78,6 +79,12 @@ export default function EditModeLayer({
   onLiveContentChange,
 }: EditModeLayerProps) {
   const router = useRouter();
+
+  // Desktop shows Info + Structure side-by-side (no tab chooser); mobile keeps the either/or
+  // tab row. The role attributes differ per mode, so this is a JS breakpoint, not pure CSS.
+  // EditModeLayer is dynamically imported ssr:false, so useViewport never hydrates server markup.
+  const { isMobile } = useViewport();
+  const twoColumn = !isMobile;
 
   // Signal the parent before paint (layout effect, not effect) so the public-grid fallback is
   // swapped out in the same frame this layer's grid commits — no double-grid flash.
@@ -274,14 +281,15 @@ export default function EditModeLayer({
         </div>
       )}
 
-      {edit.manageMode === 'edit' && <CollectionEditSheet edit={edit} />}
+      {edit.manageMode === 'edit' && <CollectionEditSheet edit={edit} twoColumn={twoColumn} />}
 
       {!edit.editingContent && !edit.isTextBlockModalOpen && (
         <EditBar
           ariaLabel="Manage"
           fixed
           cells={edit.bottomBarCells}
-          tabs={edit.bottomBarTabs}
+          // On desktop both panels are shown side-by-side, so the Info/Structure chooser is dropped.
+          tabs={twoColumn ? undefined : edit.bottomBarTabs}
           activeTab={edit.editTab}
           onTabChange={id => edit.setEditTab(id as typeof edit.editTab)}
         />

--- a/app/components/ContentCollection/edit/collectionEditUtils.ts
+++ b/app/components/ContentCollection/edit/collectionEditUtils.ts
@@ -24,26 +24,14 @@ import { logger } from '@/app/utils/logger';
 
 export const COVER_IMAGE_FLASH_DURATION = 500; // milliseconds
 
-/**
- * Re-export the shared, pure collection-toggle engine so existing collection-side callers
- * (the edit sheet / useCollectionEdit pickers) and tests keep importing it from here
- * unchanged. The implementation now lives in `@/app/utils/collectionToggle` so the image
- * side can adapt the same engine.
- */
+/** Re-export of {@link toggleRelation} so existing callers import from here unchanged. */
 export { toggleRelation };
 
 /**
- * Build an update payload containing only changed fields.
- * Compares form data with original collection and only includes differences.
- *
- * @remarks
- * - `undefined` and `null` and `''` are treated as equivalent (normalized to `undefined`).
- * - `collectionDate`: `null` means "explicitly clear"; `''` means unchanged from a null original.
- *   When the date is cleared and was previously set, `clearCollectionDate: true` is sent instead.
- * - `coverImageId`, `collections`, `siblings`, `parents`, `locations`, and `tags` use presence-check
- *   (`!== undefined`) rather than value-diff because each has its own update semantics.
- * - New text blocks are added via a separate POST endpoint, not through this payload.
- * - Content reordering is handled via the Image Update endpoint (orderIndex field).
+ * Build an update payload containing only changed scalar fields. Relational fields
+ * (`collections`, `siblings`, `parents`, `locations`, `tags`, `coverImageId`) are included
+ * as-is when present. `clearCollectionDate: true` is substituted when a previously-set date
+ * is removed. `null`/`undefined`/`''` are treated as equivalent for scalar comparison.
  */
 export function buildUpdatePayload(
   formData: CollectionUpdateRequest,
@@ -116,10 +104,7 @@ export function buildUpdatePayload(
   return payload;
 }
 
-/**
- * Find an image block by ID from the collection's blocks
- * Returns the block if found and it's an image, otherwise undefined
- */
+/** Returns the image block with the given ID, or undefined if absent or wrong type. */
 export function findImageBlockById(
   blocks: AnyContentModel[] | undefined,
   imageId: number | undefined
@@ -130,10 +115,7 @@ export function findImageBlockById(
   return block && isContentImage(block) ? block : undefined;
 }
 
-/**
- * Validate that a cover image selection is valid
- * Returns true if the image exists and is an image block
- */
+/** Returns true if `imageId` resolves to an image block in `blocks`. */
 export function validateCoverImageSelection(
   imageId: number | undefined,
   blocks: AnyContentModel[] | undefined
@@ -143,19 +125,11 @@ export function validateCoverImageSelection(
   return imageBlock !== undefined;
 }
 
-/**
- * Handle cover image selection
- * Validates the selection and returns the result
- *
- * @param imageId - ID of the image to set as cover
- * @param content - Array of content blocks from the collection
- * @returns Object with success status and coverImageId if valid, or error message if invalid
- */
+/** Validates that `imageId` is a real image block; returns a success/error discriminant. */
 export function handleCoverImageSelection(
   imageId: number,
   content: AnyContentModel[] | undefined
 ): { success: true; coverImageId: number } | { success: false; error: string } {
-  // Validate that the selected image exists and is an image block
   if (!validateCoverImageSelection(imageId, content)) {
     return {
       success: false,
@@ -169,14 +143,7 @@ export function handleCoverImageSelection(
   };
 }
 
-/**
- * Handle collection navigation
- * Finds the collection block and returns the navigation path
- *
- * @param imageId - ID of the clicked image (which may be a collection block)
- * @param content - Array of content blocks from the collection
- * @returns Collection slug if found, null otherwise
- */
+/** Returns the slug of the collection block with the given ID, or null if not found. */
 export function handleCollectionNavigation(
   imageId: number,
   content: AnyContentModel[] | undefined
@@ -190,29 +157,14 @@ export function handleCollectionNavigation(
 }
 
 /**
- * Handle multi-select toggle.
- *
- * Thin re-export of the shared {@link toggleImageSelection} util — the toggling logic now lives in
- * `app/utils/imageSelection.ts` so the public client-gallery "Select" flow can reuse it. The name
- * is preserved here for existing admin/manage callers and tests.
- *
- * @param imageId - ID of the image to toggle
- * @param currentSelectedIds - Current array of selected image IDs
- * @returns New array of selected image IDs
+ * Toggle an image in the multi-select list. Delegates to {@link toggleImageSelection}.
+ * Name preserved here for existing callers and tests.
  */
 export function handleMultiSelectToggle(imageId: number, currentSelectedIds: number[]): number[] {
   return toggleImageSelection(imageId, currentSelectedIds);
 }
 
-/**
- * Handle single image edit
- * Finds the image block and returns it for editing
- *
- * @param imageId - ID of the image to edit
- * @param content - Array of content blocks from the collection
- * @param processedContent - Processed content array (may contain converted collection blocks)
- * @returns Image block if found, null otherwise
- */
+/** Returns the image or GIF block with the given ID from content or processedContent, else null. */
 export function handleSingleImageEdit(
   imageId: number,
   content: AnyContentModel[] | undefined,
@@ -228,13 +180,7 @@ export function handleSingleImageEdit(
   return null;
 }
 
-/**
- * Revalidate Next.js cache for a collection
- * Calls the revalidate API endpoint to invalidate Next.js cache
- *
- * @param slug - Collection slug to revalidate
- * @returns Promise that resolves when revalidation is complete (or fails silently)
- */
+/** POSTs to /api/revalidate for the collection's tag, path, and the global indexes. Fails silently in production. */
 export async function revalidateCollectionCache(slug: string): Promise<void> {
   const revalidate = (body: Record<string, string>) =>
     fetch('/api/revalidate', {
@@ -256,10 +202,7 @@ export async function revalidateCollectionCache(slug: string): Promise<void> {
   }
 }
 
-/**
- * Revalidate Next.js cache for metadata (tags, people, cameras, locations, lenses, film)
- * Called after operations that create, update, or delete metadata entities.
- */
+/** Invalidates all metadata cache tags (tags, people, cameras, locations, lenses, film). */
 export async function revalidateMetadataCache(): Promise<void> {
   try {
     await fetch('/api/revalidate', {
@@ -285,12 +228,8 @@ export async function revalidateMetadataCache(): Promise<void> {
 }
 
 /**
- * Merge new metadata entities into current state
- * Combines new metadata from API response with existing metadata in state
- *
- * @param response - ContentImageUpdateResponse containing newMetadata
- * @param _currentState - Current CollectionUpdateResponseDTO state (unused, kept for API compatibility)
- * @returns State updater function for React setState, or null if no new metadata
+ * Returns a setState updater that appends `response.newMetadata` into the DTO's lookup arrays,
+ * or null if there is nothing new to merge.
  */
 export function mergeNewMetadata(
   response: ContentImageUpdateResponse,
@@ -314,21 +253,8 @@ export function mergeNewMetadata(
 }
 
 /**
- * Refresh collection data after an operation
- * Common pattern used by handleImageUpload, handleTextBlockSubmit, etc.
- *
- * Pattern:
- * 1. Execute the operation (async function)
- * 2. Re-fetch collection using admin endpoint
- * 3. Update state with refreshed collection (preserving metadata)
- * 4. Update cache with full admin data
- *
- * @param slug - Collection slug
- * @param operation - Async function to execute before refresh
- * @param getCollectionUpdateMetadata - Function to fetch collection data (injected for testability)
- * @param collectionStorage - Collection storage instance (injected for testability)
- * @returns Promise that resolves with the refreshed CollectionUpdateResponseDTO
- * @throws Error if operation or refresh fails
+ * Execute `operation`, then re-fetch the admin DTO for `slug` and update the cache.
+ * Dependencies are injected for testability. Throws if either step fails.
  */
 export async function refreshCollectionAfterOperation(
   slug: string,
@@ -362,14 +288,7 @@ export async function refreshCollectionAfterOperation(
  */
 export type ReorderChange = { contentId: number; newOrderIndex: number };
 
-/**
- * Apply reorder changes directly to a collection model (for optimistic updates)
- * Simply updates each block's orderIndex according to the provided changes
- *
- * @param collection - Collection model to update
- * @param reorders - Array of ReorderChange with new orderIndex values
- * @returns Updated collection model with new orderIndex values
- */
+/** Returns a new collection model with each listed block's `orderIndex` updated optimistically. */
 export function applyReorderChangesOptimistically(
   collection: CollectionModel,
   reorders: ReorderChange[]
@@ -382,7 +301,6 @@ export function applyReorderChangesOptimistically(
     const newOrderIndex = reorderMap.get(block.id);
     if (newOrderIndex === undefined) return block;
 
-    // All content types have orderIndex in collections array (collection-specific)
     return updateBlockOrderIndex(block, newOrderIndex);
   });
 
@@ -392,12 +310,7 @@ export function applyReorderChangesOptimistically(
   };
 }
 
-/**
- * Execute reorder operation - calls the API and returns the updated collection
- * @param collectionId - ID of the collection
- * @param reorders - Array of {contentId, newOrderIndex} changes
- * @param slug - Collection slug for cache revalidation
- */
+/** Calls the reorder API, revalidates the cache, and returns the updated collection. */
 export async function executeReorderOperation(
   collectionId: number,
   reorders: ReorderChange[],
@@ -420,13 +333,7 @@ export async function executeReorderOperation(
   return response;
 }
 
-/**
- * Update orderIndex for a content block
- * Updates the direct orderIndex property - works for all content types
- * @param block - Content block (any type) to update
- * @param newOrderIndex - New orderIndex value
- * @returns Updated content block
- */
+/** Returns the block with `orderIndex` replaced. */
 export function updateBlockOrderIndex(
   block: AnyContentModel,
   newOrderIndex: number
@@ -459,9 +366,7 @@ export function replayMoves(originalOrder: number[], moves: ReorderMove[]): numb
       );
       continue;
     }
-    // Remove from current position
     order.splice(fromIndex, 1);
-    // Insert at target position
     order.splice(move.toIndex, 0, move.imageId);
   }
   return order;
@@ -483,7 +388,6 @@ export function applyArrowMove(
   if (toIndex < 0 || toIndex >= currentOrder.length) return null;
 
   const newOrder = [...currentOrder];
-  // Swap adjacent items
   newOrder[fromIndex] = currentOrder[toIndex]!;
   newOrder[toIndex] = imageId;
 
@@ -504,9 +408,8 @@ export function applyPickAndPlace(
   if (fromIndex === -1 || targetIndex === -1 || fromIndex === targetIndex) return null;
 
   const newOrder = [...currentOrder];
-  // Remove from current position
   newOrder.splice(fromIndex, 1);
-  // Insert at target position (targetIndex may have shifted after splice)
+  // targetIndex shifts after the splice; re-locate the target
   const insertIndex = newOrder.indexOf(targetId);
   newOrder.splice(insertIndex, 0, pickedId);
 

--- a/app/components/ContentCollection/edit/hooks/useCollectionRetype.ts
+++ b/app/components/ContentCollection/edit/hooks/useCollectionRetype.ts
@@ -13,18 +13,11 @@ interface UseCollectionRetypeParams {
 }
 
 /**
- * Drag-and-drop collection retype. Optimistically moves the dragged collection to
- * its new type in `allCollections` (which re-buckets it in the manage-page
- * accordion), then persists via PUT /api/admin/collections/{id}. On any
- * non-success the optimistic move is reverted and an error is surfaced.
- *
- * The PUT response describes the DRAGGED collection (not the manage-page
- * collection being edited), so it is intentionally ignored beyond success/failure
- * — it must never be written into `currentState`.
- *
- * A retype for a given collection is single-flight: while its PUT is in flight,
- * a second drag on the SAME collection is ignored, so a fast double-drag can't
- * revert to a stale `previousType` after the first request settles.
+ * Drag-and-drop collection retype. Optimistically re-buckets the dragged collection
+ * in `allCollections`, then persists via PUT. Reverts on failure. Single-flight per
+ * collection — a second drag while the PUT is in-flight is ignored. The PUT response
+ * describes the dragged collection, not the current page's collection, and is never
+ * written into `currentState`.
  */
 export function useCollectionRetype({ setAllCollections, setError }: UseCollectionRetypeParams) {
   const inFlightRef = useRef<Set<number>>(new Set());
@@ -32,7 +25,7 @@ export function useCollectionRetype({ setAllCollections, setError }: UseCollecti
   const handleChangeType = useCallback(
     async (collection: CollectionListModel, targetType: CollectionType) => {
       const previousType = collection.type;
-      if (previousType === targetType) return; // no-op: already this type
+      if (previousType === targetType) return;
       if (inFlightRef.current.has(collection.id)) return;
 
       const setType = (type: CollectionType | string | undefined) =>

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -249,8 +249,6 @@ export function useCollectionEdit({
         const response = await getCollectionUpdateMetadata(slug);
         if (isMounted && !abortController.signal.aborted) {
           if (response === null) {
-            // A null response leaves currentState null forever — surface it instead of
-            // silently rendering an edit page whose edit affordances never become ready.
             setError('Failed to load collection data — editing is unavailable. Reload to retry.');
           } else {
             collectionStorage.update(slug, response.collection);
@@ -279,11 +277,7 @@ export function useCollectionEdit({
 
   const collection = currentState?.collection ?? seedCollection;
 
-  /**
-   * Latest derived collection, readable from stable callbacks (`resetToBrowse`) without adding
-   * `collection` to their deps — identity churn there would re-trigger the `!enabled` reset
-   * effect on every background refresh and wipe typed-but-unsaved buffer edits.
-   */
+  /** Stable ref so `resetToBrowse` can read the current collection without taking it as a dep. */
   const latestCollectionRef = useRef(collection);
   useEffect(() => {
     latestCollectionRef.current = collection;
@@ -343,11 +337,7 @@ export function useCollectionEdit({
   );
 
   const seededCollectionIdRef = useRef(collection.id);
-  /**
-   * Whether the current buffer seed came from the admin DTO (`currentState`) rather than the
-   * public seed prop. `currentState` is always null on first render, so the initial seed is
-   * always the public DTO; the reseed effect below adopts the admin DTO exactly once.
-   */
+  /** True once the buffer has been seeded from the admin DTO (not the public seed prop). */
   const seededFromAdminRef = useRef(currentState !== null);
 
   const setUpdateField = useCallback(
@@ -491,14 +481,7 @@ export function useCollectionEdit({
     setIsAddMode(false);
     setIsEditSheetOpen(false);
     if (isSelectingCoverImage) setIsSelectingCoverImage(false);
-    // Cancel any active reorder session so Escape and the enabled=false path both land in a
-    // clean browse state.  handleCancelReorder has an empty dep array (stable identity) so
-    // adding it here does not cause the identity churn that latestCollectionRef was introduced
-    // to prevent.
     handleCancelReorder();
-    // Discard moment of the reseed policy (see the reseed effect below): leaving an edit
-    // surface (Cancel, Escape, or the hook becoming disabled) drops uncommitted buffer edits,
-    // so abandoned sheet changes can't silently ride along on a later inline save.
     setUpdateData(seedUpdateData(latestCollectionRef.current));
   }, [isSelectingCoverImage, setIsSelectingCoverImage, handleCancelReorder, seedUpdateData]);
 
@@ -507,22 +490,8 @@ export function useCollectionEdit({
   }, [enabled, resetToBrowse]);
 
   /**
-   * The edit buffer reseeds at exactly three moments:
-   *
-   * 1. IDENTITY change (here): a different collection id (e.g. a soft-nav between two
-   *    `?manage=1` pages) re-seeds the buffer and resets modes/selection.
-   * 2. Seed → admin adoption (here, once): the buffer is initially seeded from the PUBLIC DTO,
-   *    whose normalized fallbacks (`visibility ?? HIDDEN`, `displayMode || 'CHRONOLOGICAL'`, …)
-   *    can diverge from the authoritative admin DTO. The first time `currentState` arrives for
-   *    the SAME id, adopt it — otherwise `isUpdateDirty` reports phantom diffs that silently
-   *    write back on the next save. Safe: edit interactions are gated until `currentState`
-   *    exists, so there is no typed input to wipe at that moment.
-   * 3. Save / Cancel (elsewhere): `handleUpdate` rebases the buffer from the save response, and
-   *    `resetToBrowse` discards it back to the current collection.
-   *
-   * Subsequent background refreshes deliberately do NOT reseed — re-seeding on every
-   * `collection` reference change would wipe typed-but-unsaved buffer edits on each
-   * save/background refresh.
+   * Reseed the edit buffer on collection identity change or on first admin DTO arrival.
+   * Background refreshes do NOT reseed to avoid wiping in-progress edits.
    */
   useEffect(() => {
     const identityChanged = collection.id !== seededCollectionIdRef.current;
@@ -561,8 +530,6 @@ export function useCollectionEdit({
   const handleUpdate = useCallback(
     async (patch?: Partial<CollectionUpdateRequest>) => {
       if (!collection || !currentState) {
-        // Defense-in-depth: edit affordances are gated on readiness upstream, but if a save
-        // does land here before the admin DTO exists, say so instead of silently dropping it.
         setError('Collection data has not loaded — your change was not saved.');
         return;
       }
@@ -576,12 +543,7 @@ export function useCollectionEdit({
 
         if (response !== null) {
           setCurrentState(response);
-          // Rebase moment of the reseed policy (see the reseed effect): the response is the new
-          // saved baseline. Reseeding from it clears already-applied relational diffs
-          // (tags/locations/children/siblings/parents/cover), so they can't replay on the next
-          // save — or resurrect a child the user removes later — and `isUpdateDirty` clears.
-          // Nothing typed is lost: the payload above sent the whole dirty buffer.
-          setUpdateData(seedUpdateData(response.collection));
+          setUpdateData(seedUpdateData(response.collection)); // rebase buffer on saved baseline
           seededCollectionIdRef.current = response.collection.id;
           seededFromAdminRef.current = true;
           collectionStorage.update(response.collection.slug, response.collection);
@@ -718,10 +680,7 @@ export function useCollectionEdit({
         const response = await refreshCollectionAfterOperation(
           collection.slug,
           async () => {
-            // One POST per still image: dev admin writes go through the same-origin
-            // proxy, whose 25 MB multipart cap a whole batch easily exceeds (413).
-            // Per-file requests stay under the cap and make failures attributable.
-            for (const file of imageFiles) {
+            for (const file of imageFiles) { // one POST per file to stay under the proxy's multipart cap
               try {
                 const formData = new FormData();
                 formData.append('files', file);
@@ -1169,8 +1128,6 @@ export function useCollectionEdit({
       return;
     }
     if (!currentState) {
-      // Defense-in-depth: browse cells are disabled while the admin DTO loads, but after a
-      // FAILED load they re-enable with currentState still null — say so instead of no-opping.
       setError('Collection data has not loaded — reorder is unavailable.');
       return;
     }
@@ -1300,13 +1257,7 @@ export function useCollectionEdit({
       ];
     }
 
-    // Browse cells stay disabled until the admin DTO load (or any operation) settles, so the
-    // bar communicates "not ready yet" instead of offering modes that cannot act. An in-flight
-    // inline save (`saving`) gates them too: entering a mode mid-save races the save's
-    // setCurrentState/buffer reseed (Reorder's auto-convert even fires a SECOND concurrent
-    // updateCollection, and a late inline response could reinstate displayMode CHRONOLOGICAL
-    // mid-reorder-session). Cancel stays enabled — leaving the manage surface never needs the
-    // richer DTO and mutates nothing.
+    // Disabled until admin DTO settles and no operation is in flight (including a mid-save state machine race).
     const browseBusy = isLoading || saving;
     const cells: EditBarCell[] = [
       {

--- a/app/components/LocationPage/LocationPageClient.tsx
+++ b/app/components/LocationPage/LocationPageClient.tsx
@@ -9,8 +9,10 @@ import { type CollectionModel } from '@/app/types/Collection';
 import { type ContentImageModel } from '@/app/types/Content';
 import { type FilterState, INITIAL_FILTER_STATE } from '@/app/types/GalleryFilter';
 import {
+  applyActiveOverride,
   buildLocationCriteria,
   computeFilterCounts,
+  computeFilterVisibility,
   extractFilterOptions,
   filmFilterFromIsFilm,
   filterContent,
@@ -40,6 +42,12 @@ export default function LocationPageClient({ images, collections }: LocationPage
   }));
 
   const availableOptions = useMemo(() => extractFilterOptions(images), [images]);
+
+  const baseVisibility = useMemo(() => computeFilterVisibility(images), [images]);
+  const visibility = useMemo(
+    () => applyActiveOverride(baseVisibility, filterState),
+    [baseVisibility, filterState]
+  );
 
   const criteria = useMemo(() => buildLocationCriteria(filterState), [filterState]);
 
@@ -96,7 +104,7 @@ export default function LocationPageClient({ images, collections }: LocationPage
         filterState={filterState}
         onFilterChange={handleFilterChange}
         dimensions={{
-          ...(availableOptions.tags.length > 0
+          ...(visibility.tags
             ? {
                 selectedTags: {
                   label: 'Tags',
@@ -105,7 +113,7 @@ export default function LocationPageClient({ images, collections }: LocationPage
                 },
               }
             : {}),
-          ...(availableOptions.people.length >= 2
+          ...(visibility.people
             ? {
                 selectedPeople: {
                   label: 'People',
@@ -120,9 +128,9 @@ export default function LocationPageClient({ images, collections }: LocationPage
           film: filterCounts.film,
           digital: filterCounts.digital,
         }}
-        showDateSort
-        showHighlyRated
-        showFilm
+        showDateSort={visibility.dateSort}
+        showHighlyRated={visibility.highlyRated}
+        showFilm={visibility.film}
       />
 
       {contentBlocks.length > 0 ? (

--- a/app/components/Metadata/MetadataModal.tsx
+++ b/app/components/Metadata/MetadataModal.tsx
@@ -222,9 +222,7 @@ export default function MetadataModal({
               activeTab={activeTab}
               onTabChange={id => setActiveTab(id as TabId)}
               cells={[
-                // Remove is only available when viewing images inside a collection context.
-                // It is rendered before Delete (less destructive first) and uses the default
-                // variant to visually distinguish it from the permanent Delete action.
+                // Remove: only available in a collection context; less destructive than Delete.
                 ...(currentCollectionId
                   ? [
                       {
@@ -236,8 +234,7 @@ export default function MetadataModal({
                       },
                     ]
                   : []),
-                // Delete is always rendered — permanent deletion must always be reachable,
-                // including for GIFs which have no Remove equivalent.
+                // Delete: always present, including for GIFs (which have no Remove).
                 {
                   key: 'delete',
                   label: 'Delete',

--- a/app/components/ui/EditBar/EditBar.tsx
+++ b/app/components/ui/EditBar/EditBar.tsx
@@ -16,18 +16,13 @@ function cellClassName(variant: EditBarCell['variant'], disabled?: boolean): str
 }
 
 /**
- * EditBar — the single shared bottom bar used across collection-edit, image-edit,
- * and the transient manage modes. Two shapes: an optional tab row above an action
- * row of uniform-height cells. Emphasis is by color/weight, never size.
+ * Shared bottom bar for collection-edit, image-edit, and manage modes. Two shapes:
+ * an optional tab row above a uniform-height action row. Emphasis is by color/weight.
  *
- * Pass `fixed={false}` when embedding as a flex footer inside a modal sheet — the bar
- * then participates in normal block flow instead of escaping to the viewport bottom.
+ * Pass `fixed={false}` to embed as a flex footer inside a modal sheet.
  *
- * ARIA contract for tabs: `aria-controls` is emitted only for the SELECTED tab.
- * The inactive tab's panel may not be in the DOM (CollectionEditSheet uses conditional
- * rendering), so emitting `aria-controls` unconditionally would create dangling
- * references that axe flags as aria-valid-attr-value violations.  The selected tab's
- * panel is always present — both consumers guarantee this.
+ * ARIA: `aria-controls` is emitted only for the SELECTED tab — inactive tab panels
+ * may not be in the DOM, and unconditional `aria-controls` produces dangling references.
  */
 export function EditBar({
   tabs,

--- a/app/components/ui/Modal/Modal.tsx
+++ b/app/components/ui/Modal/Modal.tsx
@@ -50,16 +50,12 @@ export function Modal({ open, onClose, variant = 'overlay', labelledBy, children
   useEffect(() => {
     if (!open) return;
 
-    // Capture the element that had focus before the modal opened. If a child
-    // already has focus via autoFocus (committed before this effect runs), the
-    // active element is already inside the dialog — storing it as "previously
-    // focused" would restore focus to an unmounted node on close, so store null.
+    // Store the pre-open trigger; skip if a child already has focus (autoFocus), so
+    // we don't restore to an unmounted node on close.
     const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     previouslyFocusedRef.current = dialogRef.current?.contains(active) ? null : active;
 
-    // Only move focus to the dialog container when nothing inside the dialog
-    // already has focus. This lets child autoFocus win (e.g. the ClientGalleryGate
-    // password input) without stealing it back.
+    // Let child autoFocus win; only move focus to the container as a fallback.
     if (!dialogRef.current?.contains(document.activeElement)) {
       dialogRef.current?.focus();
     }

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -65,6 +65,14 @@ export const LAYOUT = {
   ssrRecomputeToleranceWidth: 64,
 } as const;
 
+// Density → row-width multiplier: rowWidth = round(chunkSize × this). The packing
+// cost is the width-cost Hv = √(P·AR) (orientation-agnostic), so K is calibrated
+// against Hv, not cv. At K below, a default 4-chunk collection of normal 3★
+// landscapes (Hv ≈ 2.108) packs the same 4-per-row it did under the old cv scale
+// (cv 2.5, rowWidth 10). Used by contentLayout.ts (desktop + mobile) and referenced
+// by the calibration test so code and test never drift.
+export const DENSITY_ROW_WIDTH_MULTIPLIER = 2.1;
+
 // Fixed-weight cv formula: cv = BASE_WEIGHT[rating] × arFactor
 // cv is a fixed cost. rowWidth is the budget. fraction = cv / rowWidth.
 export const BASE_WEIGHT: Record<number, number> = {

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -89,6 +89,13 @@ export const PANORAMA_AR = 2.0;
 export const PANORAMA_AR_FACTOR = 1.4; // arFactor exactly at PANORAMA_AR (5★ → 7.0)
 export const PANORAMA_AR_SLOPE = 0.6; // arFactor gained per 1.0 of AR beyond PANORAMA_AR
 
+// Prominence ramp keyed on aspect-ratio EXTREMENESS = max(AR, 1/AR).
+// EXTREMENESS_RAMP_* temporarily mirrors PANORAMA_AR_* values; both sets are
+// retired together in a later phase when getComponentValue is replaced by getProminence.
+export const EXTREMENESS_RAMP_START = 2.0;
+export const EXTREMENESS_RAMP_BASE = 1.4;
+export const EXTREMENESS_RAMP_SLOPE = 0.6;
+
 // =============================================================================
 // INTERACTION & TIMING
 // =============================================================================

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -79,6 +79,16 @@ export const BASE_WEIGHT: Record<number, number> = {
 // Reference AR for the AR factor in cv calculation
 export const REFERENCE_AR = 1.5;
 
+// Panorama prominence scale. At/above PANORAMA_AR (a 2:1+ wide image) the arFactor
+// stops being capped and climbs linearly, so a panorama is worth far more than a
+// normal horizontal of the same rating: for a 5★ (base weight 5.0) cv goes
+// 2:1 → 7.0, 3:1 → 10.0, 4:1 → 13.0. Below PANORAMA_AR the legacy sqrt/cap curve
+// is unchanged (normal 16:9 horizontals stay at their base weight; verticals keep
+// their penalty). Tune these two knobs to reshape the ramp.
+export const PANORAMA_AR = 2.0;
+export const PANORAMA_AR_FACTOR = 1.4; // arFactor exactly at PANORAMA_AR (5★ → 7.0)
+export const PANORAMA_AR_SLOPE = 0.6; // arFactor gained per 1.0 of AR beyond PANORAMA_AR
+
 // =============================================================================
 // INTERACTION & TIMING
 // =============================================================================

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -73,8 +73,8 @@ export const LAYOUT = {
 // by the calibration test so code and test never drift.
 export const DENSITY_ROW_WIDTH_MULTIPLIER = 2.1;
 
-// Fixed-weight cv formula: cv = BASE_WEIGHT[rating] × arFactor
-// cv is a fixed cost. rowWidth is the budget. fraction = cv / rowWidth.
+// Per-rating base weight feeding the prominence value P = BASE_WEIGHT[rating] ×
+// prominenceFactor(extremeness). Higher-rated images get more visual weight.
 export const BASE_WEIGHT: Record<number, number> = {
   5: 5.0,
   4: 3.5,
@@ -84,17 +84,8 @@ export const BASE_WEIGHT: Record<number, number> = {
   0: 1.0,
 };
 
-// Reference AR for the AR factor in cv calculation
-export const REFERENCE_AR = 1.5;
-
-// Panorama arFactor ramp: at/above PANORAMA_AR the arFactor climbs linearly instead of
-// being sqrt-capped, giving wide panoramas substantially more cv than same-rated horizontals.
-export const PANORAMA_AR = 2.0;
-export const PANORAMA_AR_FACTOR = 1.4; // arFactor exactly at PANORAMA_AR (5★ → 7.0)
-export const PANORAMA_AR_SLOPE = 0.6; // arFactor gained per 1.0 of AR beyond PANORAMA_AR
-
-// Prominence extremeness ramp: symmetric version of the panorama ramp (applies to tall images too).
-// Keyed on EXTREMENESS = max(AR, 1/AR). Currently mirrors PANORAMA_AR_* values.
+// Prominence extremeness ramp: above EXTREMENESS_RAMP_START the prominence factor climbs
+// linearly so very wide OR very tall images get extra weight. Keyed on EXTREMENESS = max(AR, 1/AR).
 export const EXTREMENESS_RAMP_START = 2.0;
 export const EXTREMENESS_RAMP_BASE = 1.4;
 export const EXTREMENESS_RAMP_SLOPE = 0.6;

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -79,19 +79,14 @@ export const BASE_WEIGHT: Record<number, number> = {
 // Reference AR for the AR factor in cv calculation
 export const REFERENCE_AR = 1.5;
 
-// Panorama prominence scale. At/above PANORAMA_AR (a 2:1+ wide image) the arFactor
-// stops being capped and climbs linearly, so a panorama is worth far more than a
-// normal horizontal of the same rating: for a 5★ (base weight 5.0) cv goes
-// 2:1 → 7.0, 3:1 → 10.0, 4:1 → 13.0. Below PANORAMA_AR the legacy sqrt/cap curve
-// is unchanged (normal 16:9 horizontals stay at their base weight; verticals keep
-// their penalty). Tune these two knobs to reshape the ramp.
+// Panorama arFactor ramp: at/above PANORAMA_AR the arFactor climbs linearly instead of
+// being sqrt-capped, giving wide panoramas substantially more cv than same-rated horizontals.
 export const PANORAMA_AR = 2.0;
 export const PANORAMA_AR_FACTOR = 1.4; // arFactor exactly at PANORAMA_AR (5★ → 7.0)
 export const PANORAMA_AR_SLOPE = 0.6; // arFactor gained per 1.0 of AR beyond PANORAMA_AR
 
-// Prominence ramp keyed on aspect-ratio EXTREMENESS = max(AR, 1/AR).
-// EXTREMENESS_RAMP_* temporarily mirrors PANORAMA_AR_* values; both sets are
-// retired together in a later phase when getComponentValue is replaced by getProminence.
+// Prominence extremeness ramp: symmetric version of the panorama ramp (applies to tall images too).
+// Keyed on EXTREMENESS = max(AR, 1/AR). Currently mirrors PANORAMA_AR_* values.
 export const EXTREMENESS_RAMP_START = 2.0;
 export const EXTREMENESS_RAMP_BASE = 1.4;
 export const EXTREMENESS_RAMP_SLOPE = 0.6;

--- a/app/lib/components/CollectionPageWrapper.tsx
+++ b/app/lib/components/CollectionPageWrapper.tsx
@@ -54,19 +54,10 @@ export default async function CollectionPageWrapper({
 
     const chunkSize = collection.rowsWide ?? LAYOUT.defaultChunkSize;
 
-    // Gate any password-protected gallery — CLIENT_GALLERY directly, and PARENT collections
-    // that have a password (typically set with propagate=true to share with their CLIENT_GALLERY
-    // children). Auth signal: backend (CollectionControllerProd.getCollectionBySlug) sets
-    // `content` to null when neither the per-slug nor the shared password-fingerprint cookie
-    // validates, and returns an array (possibly empty) once a cookie validates. So
-    // `Array.isArray(content)` is the authoritative authenticated signal — `isPasswordProtected`
-    // describes the gallery, not the viewer's session.
-    //
-    // Routing here, rather than wrapping <CollectionPage> as gate children, means we never
-    // serialize the page's RSC payload (cover image, grid) for a locked viewer (FE-H6 invariant,
-    // structurally enforced).
-    // editMode is admin-only: bypass the per-gallery password gate entirely (an admin editing
-    // their own gallery shouldn't be password-walled). The non-edit path below is unchanged.
+    // Gate password-protected galleries. `Array.isArray(content)` is the auth signal —
+    // the backend sets content to null when the password cookie fails to validate.
+    // Routing here (not wrapping children) prevents RSC payload serialization for locked viewers.
+    // editMode bypasses the gate entirely — admins are never password-walled.
     const isGateableType =
       !editMode &&
       (collection.type === CollectionType.CLIENT_GALLERY ||

--- a/app/utils/admin.ts
+++ b/app/utils/admin.ts
@@ -38,16 +38,10 @@ export const hasValidAdminAuth = (request: NextRequest): boolean => {
 };
 
 /**
- * Admin gate seam (SERVER-SIDE). The single future home for "is this request an authenticated
- * admin principal?". TODAY it is PERIMETER-ONLY and NON-ENFORCING — prod protection is the BFF
- * `INTERNAL_API_SECRET` channel gate (app/api/proxy/[...path]/route.ts) plus route-hiding in the
- * (currently UNWIRED) root `proxy.ts` (wiring that is the open 007 task). This function does NOT
- * block today; it is the seam where per-user identity / session / MFA will plug in (see
- * docs/superpowers/specs/009-abac-access-control.md). Called by app/(admin)/layout.tsx so that
- * when 009 lands, enforcement is added in exactly one place.
+ * Admin gate seam (SERVER-SIDE). No-op today — enforcement is perimeter-only via
+ * `INTERNAL_API_SECRET`. This is the single future hook point for identity/session
+ * auth; when that lands, add redirect()/notFound() here.
  */
 export async function requireAdmin(): Promise<void> {
-  // No-op today. Future: resolve the admin principal from the session; redirect()/notFound()
-  // when absent.
   return;
 }

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -752,12 +752,29 @@ export function extractCollectionFilterOptions(
       ? typeOrder.filter(t => lensTypeSet.has(t))
       : [];
 
+  const combined = [...images, ...collectionRefs];
+
   return {
-    tags: { values: baseOptions.tags, filterable: true },
-    people: { values: baseOptions.people, filterable: true },
-    cameras: { values: baseOptions.cameras, filterable: baseOptions.cameras.length >= 2 },
-    lenses: { values: baseOptions.lenses, filterable: baseOptions.lenses.length >= 2 },
-    locations: { values: baseOptions.locations, filterable: baseOptions.locations.length >= 2 },
+    tags: {
+      values: baseOptions.tags,
+      filterable: canFilter(combined, item => (item.tags ?? []).map(t => t.name)),
+    },
+    people: {
+      values: baseOptions.people,
+      filterable: canFilter(combined, item => (item.people ?? []).map(p => p.name)),
+    },
+    cameras: {
+      values: baseOptions.cameras,
+      filterable: canFilter(images, img => (img.camera?.name ? [img.camera.name] : [])),
+    },
+    lenses: {
+      values: baseOptions.lenses,
+      filterable: canFilter(images, img => (img.lens?.name ? [img.lens.name] : [])),
+    },
+    locations: {
+      values: baseOptions.locations,
+      filterable: canFilter(combined, item => (item.locations ?? []).map(l => l.name)),
+    },
     lensTypes: { values: lensTypes, filterable: true },
   };
 }

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -360,17 +360,7 @@ export function extractFilterOptions(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// The single filter-visibility gate
-//
-// One predicate decides whether ANY filter control is shown. A dimension can
-// filter the page iff some value it carries matches a proper, non-empty subset
-// of the items — ∃ v : 0 < count(v) < total. Below 2 items nothing can be split
-// (or reordered), so it returns false. Each item is counted once per DISTINCT
-// value it carries, so a multi-valued dimension (e.g. tags) can't inflate one
-// item's weight. Every control type reduces to this by supplying a projection:
-// boolean toggles project to a two-label space, single-valued dims (camera /
-// lens / date) to one value, multi-valued dims (tags / people / locations) to a
-// value list. See computeFilterVisibility and extractCollectionFilterOptions.
+// The single filter-visibility gate — {@link canFilter}
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -753,10 +743,8 @@ export function extractCollectionFilterOptions(
       ? typeOrder.filter(t => lensTypeSet.has(t))
       : [];
 
-  // For cameras/lenses/locations: require 2+ distinct values to become a dropdown.
-  // A single distinct value stays an info chip regardless of coverage.  The canFilter
-  // half additionally suppresses the case where 2+ values each blanket every item
-  // (no value splits) — a bare length>=2 check alone would wrongly mark that filterable.
+  // cameras/lenses/locations: need 2+ distinct values AND canFilter (length>=2 alone
+  // would wrongly mark a dimension filterable when all values blanket every item).
   return {
     tags: {
       values: baseOptions.tags,

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -753,6 +753,10 @@ export function extractCollectionFilterOptions(
       ? typeOrder.filter(t => lensTypeSet.has(t))
       : [];
 
+  // For cameras/lenses/locations: require 2+ distinct values to become a dropdown.
+  // A single distinct value stays an info chip regardless of coverage.  The canFilter
+  // half additionally suppresses the case where 2+ values each blanket every item
+  // (no value splits) — a bare length>=2 check alone would wrongly mark that filterable.
   return {
     tags: {
       values: baseOptions.tags,
@@ -764,15 +768,21 @@ export function extractCollectionFilterOptions(
     },
     cameras: {
       values: baseOptions.cameras,
-      filterable: canFilter(images, img => (img.camera?.name ? [img.camera.name] : [])),
+      filterable:
+        canFilter(images, img => (img.camera?.name ? [img.camera.name] : [])) &&
+        baseOptions.cameras.length >= 2,
     },
     lenses: {
       values: baseOptions.lenses,
-      filterable: canFilter(images, img => (img.lens?.name ? [img.lens.name] : [])),
+      filterable:
+        canFilter(images, img => (img.lens?.name ? [img.lens.name] : [])) &&
+        baseOptions.lenses.length >= 2,
     },
     locations: {
       values: baseOptions.locations,
-      filterable: canFilter(combined, item => (item.locations ?? []).map(l => l.name)),
+      filterable:
+        canFilter(combined, item => (item.locations ?? []).map(l => l.name)) &&
+        baseOptions.locations.length >= 2,
     },
     lensTypes: { values: lensTypes, filterable: true },
   };

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -738,7 +738,8 @@ export function extractCollectionFilterOptions(
   // dimensions from collection refs too. This is what populates the filter bar
   // on synthetic PARENT pages whose `content` is 100% collection refs and 0
   // images (e.g. /all-collections, /all-blog).
-  const baseOptions = extractFilterOptions([...images, ...collectionRefs], 0.9);
+  const combined = [...images, ...collectionRefs];
+  const baseOptions = extractFilterOptions(combined, 0.9);
 
   // Lens types: only show if 2+ distinct categories present (image-only signal)
   const lensTypeSet = new Set<LensType>();
@@ -751,8 +752,6 @@ export function extractCollectionFilterOptions(
     lensTypeSet.size >= 2 && baseOptions.lenses.length >= 2
       ? typeOrder.filter(t => lensTypeSet.has(t))
       : [];
-
-  const combined = [...images, ...collectionRefs];
 
   return {
     tags: {

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -859,23 +859,6 @@ export function applyCollectionFilters(
 }
 
 /**
- * Whether a per-image selector yields more than one distinct value across the
- * images (drives "show this control only when it varies"). Covers both rating
- * variance and capture-date variance. Returns false for an empty array.
- *
- * @param images - Images to inspect
- * @param selector - Maps an image to the value whose variance is checked
- */
-export function hasValueVariance<T>(
-  images: ContentImageModel[],
-  selector: (image: ContentImageModel) => T
-): boolean {
-  if (images.length === 0) return false;
-  const values = new Set(images.map(selector).filter(Boolean));
-  return values.size > 1;
-}
-
-/**
  * Re-interleave date-sorted images back into a processed content array.
  *
  * Date sort runs after `processContentBlocks` (which sorts by orderIndex), so

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -359,6 +359,45 @@ export function extractFilterOptions(
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// The single filter-visibility gate
+//
+// One predicate decides whether ANY filter control is shown. A dimension can
+// filter the page iff some value it carries matches a proper, non-empty subset
+// of the items — ∃ v : 0 < count(v) < total. Below 2 items nothing can be split
+// (or reordered), so it returns false. Each item is counted once per DISTINCT
+// value it carries, so a multi-valued dimension (e.g. tags) can't inflate one
+// item's weight. Every control type reduces to this by supplying a projection:
+// boolean toggles project to a two-label space, single-valued dims (camera /
+// lens / date) to one value, multi-valued dims (tags / people / locations) to a
+// value list. See computeFilterVisibility and extractCollectionFilterOptions.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Whether a dimension can meaningfully filter the given items.
+ *
+ * @param items - The full, unfiltered item set. Visibility MUST be derived from
+ *   the full set, never a filtered subset, or a control could vanish mid-interaction.
+ * @param valuesOf - The dimension's projection: the value(s) an item contributes.
+ */
+export function canFilter<T>(
+  items: readonly T[],
+  valuesOf: (item: T) => readonly string[]
+): boolean {
+  const total = items.length;
+  if (total < 2) return false;
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    for (const value of new Set(valuesOf(item))) {
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+  }
+  for (const count of counts.values()) {
+    if (count > 0 && count < total) return true;
+  }
+  return false;
+}
+
 /**
  * Per-option image counts for filter chips, computed contextually.
  * Each count represents: "how many images match if I select only this option

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -393,7 +393,7 @@ export function canFilter<T>(
     }
   }
   for (const count of counts.values()) {
-    if (count > 0 && count < total) return true;
+    if (count < total) return true;
   }
   return false;
 }

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -887,16 +887,16 @@ export function mergeDateSortedImages(
  *
  * @param baseOptions - The page's base dimensions
  * @param showHighlyRated - Whether the Highly Rated control is shown
- * @param hasDateVariance - Whether capture dates vary (date-sort control)
+ * @param showDateSort - Whether the Date Sort control should be shown
  */
 export function hasFilterableOptions(
   baseOptions: CollectionFilterDimensions,
   showHighlyRated: boolean,
-  hasDateVariance: boolean
+  showDateSort: boolean
 ): boolean {
   return (
     showHighlyRated ||
-    hasDateVariance ||
+    showDateSort ||
     baseOptions.tags.values.length > 0 ||
     baseOptions.people.values.length > 0 ||
     baseOptions.cameras.values.length > 0 ||

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -398,6 +398,42 @@ export function canFilter<T>(
   return false;
 }
 
+/** Per-dimension verdict from the single gate ({@link canFilter}). */
+export interface FilterVisibility {
+  dateSort: boolean;
+  highlyRated: boolean;
+  film: boolean;
+  tags: boolean;
+  people: boolean;
+  cameras: boolean;
+  lenses: boolean;
+  locations: boolean;
+  lensTypes: boolean;
+}
+
+/**
+ * Run the single gate across every image-derived dimension once. Visibility is
+ * computed from the FULL image set so controls don't appear/disappear as filters
+ * are applied. The projections here are the canonical home for "what value(s)
+ * does an image contribute to dimension X".
+ */
+export function computeFilterVisibility(images: ContentImageModel[]): FilterVisibility {
+  return {
+    dateSort: canFilter(images, img => (img.captureDate ? [img.captureDate] : [])),
+    highlyRated: canFilter(images, img => [(img.rating ?? 0) >= 4 ? 'hi' : 'lo']),
+    film: canFilter(images, img => [img.isFilm ? 'film' : 'digital']),
+    tags: canFilter(images, img => (img.tags ?? []).map(t => t.name)),
+    people: canFilter(images, img => (img.people ?? []).map(p => p.name)),
+    cameras: canFilter(images, img => (img.camera?.name ? [img.camera.name] : [])),
+    lenses: canFilter(images, img => (img.lens?.name ? [img.lens.name] : [])),
+    locations: canFilter(images, img => (img.locations ?? []).map(l => l.name)),
+    lensTypes: canFilter(images, img => {
+      const lensType = getLensType(img.focalLength);
+      return lensType ? [lensType] : [];
+    }),
+  };
+}
+
 /**
  * Per-option image counts for filter chips, computed contextually.
  * Each count represents: "how many images match if I select only this option

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -444,6 +444,9 @@ export function applyActiveOverride(
   visibility: FilterVisibility,
   filterState: FilterState
 ): FilterVisibility {
+  // dateSort and film are included here (unlike hasAnyActiveFilter, which scopes
+  // to content-reducing collection filters) because this is a visibility concern:
+  // if a control's filter is active, keep the control on screen so it can be cleared.
   return {
     dateSort: visibility.dateSort || filterState.dateSortDirection !== 'off',
     highlyRated: visibility.highlyRated || filterState.highlyRatedOnly,

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -435,6 +435,29 @@ export function computeFilterVisibility(images: ContentImageModel[]): FilterVisi
 }
 
 /**
+ * OR "this filter is currently active" onto a {@link FilterVisibility} verdict so
+ * a control is never hidden while it is the active filter — e.g. a `?isFilm=` /
+ * `?rating=` deep-link onto a page where the dimension is otherwise trivial.
+ * Without this the only way to clear such a filter would be the bulk reset.
+ */
+export function applyActiveOverride(
+  visibility: FilterVisibility,
+  filterState: FilterState
+): FilterVisibility {
+  return {
+    dateSort: visibility.dateSort || filterState.dateSortDirection !== 'off',
+    highlyRated: visibility.highlyRated || filterState.highlyRatedOnly,
+    film: visibility.film || filterState.filmFilter !== 'off',
+    tags: visibility.tags || filterState.selectedTags.length > 0,
+    people: visibility.people || filterState.selectedPeople.length > 0,
+    cameras: visibility.cameras || filterState.selectedCameras.length > 0,
+    lenses: visibility.lenses || filterState.selectedLenses.length > 0,
+    locations: visibility.locations || filterState.selectedLocations.length > 0,
+    lensTypes: visibility.lensTypes || filterState.selectedLensTypes.length > 0,
+  };
+}
+
+/**
  * Per-option image counts for filter chips, computed contextually.
  * Each count represents: "how many images match if I select only this option
  * in this dimension, while keeping all other active filters?"

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -1,4 +1,4 @@
-import { IMAGE, LAYOUT } from '@/app/constants';
+import { DENSITY_ROW_WIDTH_MULTIPLIER, IMAGE, LAYOUT } from '@/app/constants';
 import { type CollectionModel } from '@/app/types/Collection';
 import {
   type AnyContentModel,
@@ -78,11 +78,11 @@ function createSimpleHorizontalBoxTree(items: AnyContentModel[]): BoxTree {
  * Process content for display, returning sized rows ready to render.
  *
  * Runs the single row-composition algorithm: {@link buildRows} greedily fills
- * each row to the per-viewport cv budget, then composes its BoxTree via
+ * each row to the per-viewport width-cost budget, then composes its BoxTree via
  * {@link buildAtomic}. The only mobile/desktop difference is the row-width budget
- * (desktop derives it from the density chunkSize; mobile derives it from the
- * 1-5 mobileChunkSize when supplied, else pins to a narrow slot width) — there
- * is no separate pattern-detection or slot-based mode.
+ * (desktop derives it from the density chunkSize × {@link DENSITY_ROW_WIDTH_MULTIPLIER};
+ * mobile derives it from the 1-5 mobileChunkSize when supplied, else pins to a
+ * narrow slot width) — there is no separate pattern-detection or slot-based mode.
  *
  * If collectionData is provided, creates a header row (cover image + metadata)
  * as the first row, before processing regular content.
@@ -119,9 +119,9 @@ export function processContentForDisplay(
 
   const rowWidth = options?.isMobile
     ? (options?.mobileChunkSize !== undefined
-      ? Math.round(options.mobileChunkSize * 2.5)
+      ? Math.round(options.mobileChunkSize * DENSITY_ROW_WIDTH_MULTIPLIER)
       : LAYOUT.mobileSlotWidth)
-    : Math.round(chunkSize * 2.5);
+    : Math.round(chunkSize * DENSITY_ROW_WIDTH_MULTIPLIER);
   const effectiveGap = options?.isMobile ? LAYOUT.mobileGridGap : LAYOUT.gridGap;
   const targetAR = options?.targetAR ?? 1.5;
 

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -57,40 +57,30 @@ export function getRating(item: AnyContentModel, asStarValue: boolean = false): 
 /**
  * Get the effective rating of an item based on its orientation.
  *
- * The effective rating accounts for:
- * 1. **Vertical penalty**: Vertical images are treated as one rating lower than horizontal
- *    (V5★ → H4★ equivalent, V4★ → H3★ equivalent, etc.)
- *
- * Examples:
- * - H5★ → effectiveRating 5
- * - V5★ → effectiveRating 4 (vertical penalty)
- * - H3★ → effectiveRating 3
- * - V5★ → 4, V4★ → 3, V3★ → 2, V2★ → 1, V1★ → 1, V0★ → 0
- *
- * Note: Slot-width-dependent scaling is handled downstream in getComponentValue().
+ * Orientation-agnostic: the vertical penalty was RETIRED in the directional-
+ * prominence rewrite. A V5★ and an H5★ now both return 5 — directionality is
+ * expressed downstream by AR extremeness (width-cost Hv / height-demand Vv),
+ * not by demoting the rating. Collection cards → 4, non-image/gif → 1, else the
+ * raw 0-5 rating. (Now identical to {@link getProminenceRating}; the two are
+ * slated to consolidate in the Phase 5 cleanup.)
  *
  * @param item - The content item to evaluate
- * @returns The effective rating (0-5) after applying orientation penalty
+ * @returns The effective rating (0-5), clamped, with no orientation penalty
  */
 export function getEffectiveRating(item: AnyContentModel): number {
   if (isCollectionCard(item)) {
     return 4;
   }
 
-  // Animated GIF/MP4 blocks share the image rating semantics (0-5 with vertical penalty). The
-  // earlier `return 1` short-circuit here is what made GIFs always pack as low-priority filler in
-  // the row algorithm even after we added rating to the backend.
+  // Animated GIF/MP4 blocks share the image rating semantics (0-5). The earlier `return 1`
+  // short-circuit here is what made GIFs always pack as low-priority filler in the row algorithm
+  // even after we added rating to the backend.
   if (!isContentImage(item) && !isGifContent(item)) {
     return 1;
   }
 
   const baseRating = (item as { rating?: number | null }).rating ?? 0;
-  const ratio = getAspectRatio(item);
-  const isVertical = ratio <= 1.0;
-
-  const effectiveRating = isVertical ? Math.max(baseRating - 1, 0) : baseRating;
-
-  return Math.min(Math.max(effectiveRating, 0), 5);
+  return Math.min(Math.max(baseRating, 0), 5);
 }
 
 /**

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -10,10 +10,6 @@ import {
   EXTREMENESS_RAMP_BASE,
   EXTREMENESS_RAMP_SLOPE,
   EXTREMENESS_RAMP_START,
-  PANORAMA_AR,
-  PANORAMA_AR_FACTOR,
-  PANORAMA_AR_SLOPE,
-  REFERENCE_AR,
 } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import { getAspectRatio, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
@@ -83,39 +79,6 @@ export function getEffectiveRating(item: AnyContentModel): number {
   return Math.min(Math.max(baseRating, 0), 5);
 }
 
-/**
- * Calculate component value (cv) for an image: cv = BASE_WEIGHT[effectiveRating] × arFactor.
- * Below {@link PANORAMA_AR} uses a sqrt curve; at/above it switches to a linear ramp so panoramas
- * get substantially more weight than same-rated normal horizontals. cv is a FIXED WEIGHT —
- * the caller divides cv / rowWidth to get the fill fraction.
- *
- * @param effectiveRating - The effective rating (0-5) from getEffectiveRating()
- * @param imageAR - The actual aspect ratio of the image (width/height)
- * @returns The component value (fixed weight, independent of rowWidth)
- */
-export function getComponentValue(effectiveRating: number, imageAR: number): number {
-  const clampedRating = Math.min(Math.max(effectiveRating, 0), 5);
-  const baseWeight = BASE_WEIGHT[clampedRating] ?? 1.0;
-  const arFactor =
-    imageAR >= PANORAMA_AR
-      ? PANORAMA_AR_FACTOR + PANORAMA_AR_SLOPE * (imageAR - PANORAMA_AR)
-      : Math.sqrt(Math.min(imageAR, REFERENCE_AR) / REFERENCE_AR);
-  return baseWeight * arFactor;
-}
-
-/**
- * Convenience function: Get component value directly from an item.
- * Combines getEffectiveRating() and getComponentValue() in one call.
- *
- * @param item - The content item to evaluate
- * @returns The component value for this item (fixed weight, rowWidth-independent)
- */
-export function getItemComponentValue(item: AnyContentModel): number {
-  const effectiveRating = getEffectiveRating(item);
-  const imageAR = getAspectRatio(item);
-  return getComponentValue(effectiveRating, imageAR);
-}
-
 // =============================================================================
 // Phase 0 — Orientation-agnostic prominence P
 // =============================================================================
@@ -134,8 +97,8 @@ export function getArExtremeness(imageAR: number): number {
 
 /**
  * Internal multiplier applied to BASE_WEIGHT when an image's extremeness
- * exceeds EXTREMENESS_RAMP_START. Mirrors the PANORAMA_AR ramp in
- * getComponentValue but is symmetric (applies to tall images too).
+ * exceeds EXTREMENESS_RAMP_START. Above the start the factor climbs linearly so
+ * very wide OR very tall images get extra weight (symmetric in orientation).
  */
 function prominenceFactor(extremeness: number): number {
   return extremeness >= EXTREMENESS_RAMP_START
@@ -163,9 +126,10 @@ export function getProminenceRating(item: AnyContentModel): number {
  *
  * P = BASE_WEIGHT[prominenceRating] × prominenceFactor(extremeness)
  *
- * Unlike getItemComponentValue (which applies a vertical penalty via
- * getEffectiveRating), P treats a 5★ portrait and a 5★ panorama as equally
- * rated and only scales by how extreme the aspect ratio is — wide OR tall.
+ * Directionality is never expressed by demoting the rating: P treats a 5★
+ * portrait and a 5★ panorama as equally rated and only scales by how extreme
+ * the aspect ratio is — wide OR tall. The width-cost Hv = √(P·AR) and
+ * height-demand Vv = √(P/AR) split that prominence into the two axes.
  *
  * @param item - The content item to evaluate
  * @returns Prominence value > 0

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -195,3 +195,36 @@ export function getProminence(item: AnyContentModel): number {
   const baseWeight = BASE_WEIGHT[getProminenceRating(item)] ?? 1.0;
   return baseWeight * prominenceFactor(getArExtremeness(getAspectRatio(item)));
 }
+
+/**
+ * Horizontal cost (Hv): the "width" dimension of prominence.
+ *
+ * Hv = sqrt(P × AR)
+ *
+ * A wide panorama has a high Hv (demands horizontal space).
+ * A tall portrait has a low Hv (costs little horizontal space).
+ * Identity: Hv × Vv = P and Hv / Vv = AR.
+ *
+ * @param item - The content item to evaluate
+ * @returns Width cost > 0
+ */
+export function getWidthCost(item: AnyContentModel): number {
+  return Math.sqrt(getProminence(item) * getAspectRatio(item));
+}
+
+/**
+ * Vertical demand (Vv): the "height" dimension of prominence.
+ *
+ * Vv = sqrt(P / AR)
+ *
+ * A tall portrait has a high Vv (demands vertical space).
+ * A wide panorama has a low Vv (costs little vertical space).
+ * Identity: Hv × Vv = P and Hv / Vv = AR.
+ *
+ * @param item - The content item to evaluate
+ * @returns Height demand > 0
+ */
+export function getHeightDemand(item: AnyContentModel): number {
+  const ar = getAspectRatio(item);
+  return ar > 0 ? Math.sqrt(getProminence(item) / ar) : Math.sqrt(getProminence(item));
+}

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -5,7 +5,13 @@
  * Used by both contentLayout.ts (mobile/fallback) and rowStructureAlgorithm.ts (desktop).
  */
 
-import { BASE_WEIGHT, REFERENCE_AR } from '@/app/constants';
+import {
+  BASE_WEIGHT,
+  PANORAMA_AR,
+  PANORAMA_AR_FACTOR,
+  PANORAMA_AR_SLOPE,
+  REFERENCE_AR,
+} from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import { getAspectRatio, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
 
@@ -89,6 +95,15 @@ export function getEffectiveRating(item: AnyContentModel): number {
  *
  * cv = BASE_WEIGHT[effectiveRating] × arFactor
  *
+ * The arFactor has two regimes:
+ * - Below the panorama threshold (AR < PANORAMA_AR): the legacy curve
+ *   `sqrt(min(AR, REFERENCE_AR) / REFERENCE_AR)`. Verticals (AR < 1.5) are
+ *   reduced; normal-to-wide horizontals (1.5 ≤ AR < 2) sit at the 1.0 cap.
+ * - At/above the panorama threshold (AR ≥ PANORAMA_AR): a linear ramp
+ *   `PANORAMA_AR_FACTOR + PANORAMA_AR_SLOPE × (AR − PANORAMA_AR)`, so a panorama
+ *   is worth much more than a normal horizontal of the same rating. For a 5★:
+ *   2:1 → 7.0, 3:1 → 10.0, 4:1 → 13.0.
+ *
  * cv is a FIXED WEIGHT — it does NOT scale with rowWidth.
  * The caller divides cv / rowWidth to get the fill fraction.
  *
@@ -99,7 +114,10 @@ export function getEffectiveRating(item: AnyContentModel): number {
 export function getComponentValue(effectiveRating: number, imageAR: number): number {
   const clampedRating = Math.min(Math.max(effectiveRating, 0), 5);
   const baseWeight = BASE_WEIGHT[clampedRating] ?? 1.0;
-  const arFactor = Math.sqrt(Math.min(imageAR, REFERENCE_AR) / REFERENCE_AR);
+  const arFactor =
+    imageAR >= PANORAMA_AR
+      ? PANORAMA_AR_FACTOR + PANORAMA_AR_SLOPE * (imageAR - PANORAMA_AR)
+      : Math.sqrt(Math.min(imageAR, REFERENCE_AR) / REFERENCE_AR);
   return baseWeight * arFactor;
 }
 

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -7,6 +7,9 @@
 
 import {
   BASE_WEIGHT,
+  EXTREMENESS_RAMP_BASE,
+  EXTREMENESS_RAMP_SLOPE,
+  EXTREMENESS_RAMP_START,
   PANORAMA_AR,
   PANORAMA_AR_FACTOR,
   PANORAMA_AR_SLOPE,
@@ -132,4 +135,63 @@ export function getItemComponentValue(item: AnyContentModel): number {
   const effectiveRating = getEffectiveRating(item);
   const imageAR = getAspectRatio(item);
   return getComponentValue(effectiveRating, imageAR);
+}
+
+// =============================================================================
+// Phase 0 — Orientation-agnostic prominence P
+// =============================================================================
+
+/**
+ * Aspect-ratio extremeness: how far the image departs from square, direction-
+ * agnostic. A 3:1 panorama and a 1:3 portrait both have extremeness 3.0.
+ *
+ * @param imageAR - Aspect ratio (width / height). Must be > 0.
+ * @returns extremeness ≥ 1.0 (1.0 for a perfect square)
+ */
+export function getArExtremeness(imageAR: number): number {
+  if (imageAR <= 0) return 1;
+  return imageAR >= 1 ? imageAR : 1 / imageAR;
+}
+
+/**
+ * Internal multiplier applied to BASE_WEIGHT when an image's extremeness
+ * exceeds EXTREMENESS_RAMP_START. Mirrors the PANORAMA_AR ramp in
+ * getComponentValue but is symmetric (applies to tall images too).
+ */
+function prominenceFactor(extremeness: number): number {
+  return extremeness >= EXTREMENESS_RAMP_START
+    ? EXTREMENESS_RAMP_BASE + EXTREMENESS_RAMP_SLOPE * (extremeness - EXTREMENESS_RAMP_START)
+    : 1.0;
+}
+
+/**
+ * Raw prominence rating for an item — like getRating but without the vertical
+ * penalty applied by getEffectiveRating. Both a 5★ portrait and a 5★ landscape
+ * return 5; the AR extremeness multiplier handles directionality instead.
+ *
+ * @param item - The content item to evaluate
+ * @returns rating in [0, 5], or 4 for collection cards, or 1 for non-image content
+ */
+export function getProminenceRating(item: AnyContentModel): number {
+  if (isCollectionCard(item)) return 4;
+  if (!isContentImage(item) && !isGifContent(item)) return 1;
+  const rating = (item as { rating?: number | null }).rating ?? 0;
+  return Math.min(Math.max(rating, 0), 5);
+}
+
+/**
+ * Orientation-agnostic prominence P for an item.
+ *
+ * P = BASE_WEIGHT[prominenceRating] × prominenceFactor(extremeness)
+ *
+ * Unlike getItemComponentValue (which applies a vertical penalty via
+ * getEffectiveRating), P treats a 5★ portrait and a 5★ panorama as equally
+ * rated and only scales by how extreme the aspect ratio is — wide OR tall.
+ *
+ * @param item - The content item to evaluate
+ * @returns Prominence value > 0
+ */
+export function getProminence(item: AnyContentModel): number {
+  const baseWeight = BASE_WEIGHT[getProminenceRating(item)] ?? 1.0;
+  return baseWeight * prominenceFactor(getArExtremeness(getAspectRatio(item)));
 }

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -94,21 +94,10 @@ export function getEffectiveRating(item: AnyContentModel): number {
 }
 
 /**
- * Calculate component value (cv) for an image using the fixed-weight formula.
- *
- * cv = BASE_WEIGHT[effectiveRating] × arFactor
- *
- * The arFactor has two regimes:
- * - Below the panorama threshold (AR < PANORAMA_AR): the legacy curve
- *   `sqrt(min(AR, REFERENCE_AR) / REFERENCE_AR)`. Verticals (AR < 1.5) are
- *   reduced; normal-to-wide horizontals (1.5 ≤ AR < 2) sit at the 1.0 cap.
- * - At/above the panorama threshold (AR ≥ PANORAMA_AR): a linear ramp
- *   `PANORAMA_AR_FACTOR + PANORAMA_AR_SLOPE × (AR − PANORAMA_AR)`, so a panorama
- *   is worth much more than a normal horizontal of the same rating. For a 5★:
- *   2:1 → 7.0, 3:1 → 10.0, 4:1 → 13.0.
- *
- * cv is a FIXED WEIGHT — it does NOT scale with rowWidth.
- * The caller divides cv / rowWidth to get the fill fraction.
+ * Calculate component value (cv) for an image: cv = BASE_WEIGHT[effectiveRating] × arFactor.
+ * Below {@link PANORAMA_AR} uses a sqrt curve; at/above it switches to a linear ramp so panoramas
+ * get substantially more weight than same-rated normal horizontals. cv is a FIXED WEIGHT —
+ * the caller divides cv / rowWidth to get the fill fraction.
  *
  * @param effectiveRating - The effective rating (0-5) from getEffectiveRating()
  * @param imageAR - The actual aspect ratio of the image (width/height)

--- a/app/utils/rowCombination.md
+++ b/app/utils/rowCombination.md
@@ -3,6 +3,77 @@
 `buildAtomic` is the canonical row composer. It builds each row's `AtomicComponent`
 tree in two phases. Leaves stay in input order — no reordering, only adjacent splits.
 
+## The value model — directional prominence (P / Hv / Vv)
+
+The layout is driven by a single, **orientation-agnostic** prominence value `P`
+(see `app/utils/contentRatingUtils.ts`). There is **no vertical penalty** — a 5★
+portrait and a 5★ panorama both have the same rating; directionality is expressed
+by aspect-ratio extremeness, not by demoting the rating.
+
+```
+P  = BASE_WEIGHT[rating] × prominenceFactor(extremeness)
+Hv = √(P · AR)     // width-cost   — how much horizontal space the image demands
+Vv = √(P / AR)     // height-demand — how much vertical space the image demands
+```
+
+with the identities `Hv · Vv = P` and `Hv / Vv = AR`.
+
+- `extremeness = max(AR, 1/AR)` (direction-agnostic — a 3:1 pano and a 1:3
+  portrait both have extremeness 3.0).
+- `prominenceFactor` is `1.0` below `EXTREMENESS_RAMP_START` (2.0) and climbs
+  linearly above it, so very wide **or** very tall images get extra weight.
+- **Width-cost `Hv`** is the Stage-1 packing metric: a row is "full" when the sum
+  of its leaves' `Hv` reaches `rowWidth`. A wide panorama has a high `Hv` (eats
+  the budget); a tall portrait has a low `Hv` (cheap to pack horizontally).
+- **Height-demand `Vv`** drives the per-row target AR (see `rowTargetAR`): a tall
+  hero raises the row's peak `Vv`, pulling the target toward a taller shape.
+
+This replaces the **retired `cv` value-model** (`getComponentValue` /
+`getItemComponentValue` / `PANORAMA_AR_*`), which combined a `BASE_WEIGHT` with a
+one-sided `arFactor` and a `−1` vertical penalty. `cv` is gone; `Hv` is the packing
+cost and `P` is the equity target.
+
+### Density → row width
+
+`rowWidth = round(chunkSize × K)` where `K = DENSITY_ROW_WIDTH_MULTIPLIER` (2.1).
+`K` is calibrated against the width-cost `Hv`, not the old `cv` scale: at this `K`
+a default 4-chunk collection of normal 3★ landscapes (`Hv ≈ 2.108`) packs the same
+4-per-row it did under the old `cv` scale. Used by `contentLayout.ts` (desktop and
+mobile).
+
+### Per-row target AR (`rowTargetAR`)
+
+Each row derives its own target AR from the viewport baseline, pulled toward a
+floor in proportion to the row's **peak height-demand** (`Vv`). A bland horizontal
+row (peak `Vv` below `ROW_TARGET_AR_VV_LOW`) keeps the baseline; a row holding a
+tall vertical hero targets a taller (lower-AR) shape so the hero renders bigger.
+The pull is content-driven (peak `Vv`), not count-driven, so it does not affect
+the density→size monotonicity. Clamped so a row never drops below
+`ROW_TARGET_AR_MIN_FRACTION` (0.6) of the baseline.
+
+### Solo hero (`isSoloHero`)
+
+`isSoloHero` is the emergent successor to the **retired `isFullWidthHero` rule**.
+An item claims its own full-width row only when **both** gates pass:
+
+1. **Extremeness gate** (`getArExtremeness ≥ EXTREMENESS_RAMP_START`): only images
+   far from square in either direction are eligible — subsumes the old `AR ≥ 2`
+   gate with no new magic number, and the old rating gate is dropped per the
+   prominence philosophy.
+2. **Width-cost gate** (`Hv / rowWidth ≥ HERO_SOLO_WIDTH_FRACTION`, 0.5): the
+   item's width-cost must dominate the row budget — subsumes the old density
+   ceiling (a wide pano solos at low density, shares at high density).
+
+A tall portrait passes the extremeness gate but its small `Hv` keeps its
+width-fraction below the bar, so it never solos — its prominence is expressed as
+row height via `rowTargetAR`, not a solo row. Disabled on mobile (`rowWidth ≤ 2`).
+
+> **Deferred — AR-floor relaxation (taller-than-wide hero rows).** Letting a
+> high-prominence vertical hero claim a row that is intentionally taller than wide
+> is **not implemented**. The AR floor below stays hard at 1.0 on the desktop path
+> (it is only disabled on the `rowWidth ≤ 2` mobile branch). See the known
+> limitation at the bottom.
+
 ## Phase 1 — point-balance split (`splitByPointBalance`)
 
 Split the row hierarchically at the adjacent boundary where the left and right
@@ -11,8 +82,9 @@ halves have the closest `effectiveRating` sums — minimise
 uniform-rating rows) break toward the middle gap, yielding structurally-balanced
 trees.
 
-Uses `effectiveRating`, not `cv`: it's perceived prominence. `cv` would
-double-penalise verticals by reapplying the AR factor on top of the rating.
+Balances on `effectiveRating` (now penalty-free — equal to the raw rating for
+images): it's perceived prominence, not packing width. The width-cost `Hv` is the
+packing metric, not the balance metric.
 
 ## Phase 2 — direction enumeration (`pickRootAssignment`)
 
@@ -23,15 +95,17 @@ to hPair — rows are horizontal by definition), then select two-tiered:
    Sub-1.0 candidates carry a large penalty. Within a small AR band
    (`AR_EQUITY_BAND`) of the best-scoring candidate…
 2. **…pick the most equitable** — the tree whose leaf areas best track each
-   image's `cv`, so equal-rated images render at similar size instead of one
-   ballooning while its siblings are crushed.
+   image's **prominence `P`** (`equitySpread` / `leafShares`), so equal-prominence
+   images render at similar size instead of one ballooning while its siblings are
+   crushed. Using `P` (orientation-agnostic) is what lets a high-rated vertical
+   claim area rather than being shrunk by the old one-sided `cv`.
 
 `MAX_ROW_IMAGES` (12) bounds both greedy fill and this enumeration (~2^(n-1)
 candidates for an n-leaf row).
 
 ## Design rationale
 
-**Why point-balance over sum-cv merge or AR-gap split.** Sum-cv merge produces
+**Why point-balance over sum-value merge or AR-gap split.** Sum-value merge produces
 "dominant emergence" — the heaviest item ends up alone at the root, visually
 singling it out even on uniformly-rated rows. AR-gap split makes structural
 choices off an orientation-boundary signal that isn't always meaningful (with
@@ -63,7 +137,7 @@ cases older composers needed:
 
 Selection is two-tiered, not a stack of special-case rules: (1) the AR floor plus closeness
 to the target row AR pick the acceptable band; (2) within it, the lowest
-area-vs-cv spread wins, so sizing tracks `cv` (the intended signal) rather than
+area-vs-prominence spread wins, so sizing tracks `P` (the intended signal) rather than
 being an artifact of which subtree a leaf landed in.
 
 ## Known limitation — vertical prominence is decided by STRUCTURE, not rating
@@ -72,17 +146,18 @@ being an artifact of which subtree a leaf landed in.
 > This is the concrete, quantified instance of the directional-prominence plan's
 > "Issue #4 — Reachability" ([2026-06-09-directional-prominence.md](../../docs/superpowers/plans/2026-06-09-directional-prominence.md)).
 
-**Symptom:** the two highest-rated images in a row can render as the *smallest*.
+**Symptom:** the two highest-rated images in a row can render as the _smallest_.
 For the reported row `V4★, H3★, V4★, V5★, V5★` (all but the 3★ are 9:16 verticals),
-forced into one row at `rowWidth = 8`, `targetWidth = 1274`:
+forced into one row at `rowWidth = 8`, `targetWidth = 1274`. Under the retired
+`cv` model the realized sizes (smallest were the two 5★ heroes) were captured as:
 
-| Image | effectiveRating | cv | rendered (w×h) | area |
-|------|----|----|----|----|
-| V4★ #1 | 3 | 1.53 | 552×982 | **542,631 ← biggest** |
-| H3★ #2 | 3 | 2.50 | 420×233 | 97,785 |
-| V4★ #3 | 3 | 1.53 | 420×736 | 309,050 |
-| V5★ #4 | 4 | 2.14 | 276×485 | **133,890 ← smallest** |
-| V5★ #5 | 4 | 2.14 | 276×485 | **133,890 ← smallest** |
+| Image  | effectiveRating | cv   | rendered (w×h) | area                   |
+| ------ | --------------- | ---- | -------------- | ---------------------- |
+| V4★ #1 | 3               | 1.53 | 552×982        | **542,631 ← biggest**  |
+| H3★ #2 | 3               | 2.50 | 420×233        | 97,785                 |
+| V4★ #3 | 3               | 1.53 | 420×736        | 309,050                |
+| V5★ #4 | 4               | 2.14 | 276×485        | **133,890 ← smallest** |
+| V5★ #5 | 4               | 2.14 | 276×485        | **133,890 ← smallest** |
 
 Winning tree:
 
@@ -100,27 +175,24 @@ H (root, forced hPair)
    tall, full-height column." Phase 1 (`splitByPointBalance`) groups the two adjacent,
    equal-rated 5★s into one sibling subtree; Phase 2 can then only `hPair` them (too wide)
    or `vStack` them (halves each one's height). It picks `vStack` because that lands the
-   *whole row* near target AR (~1.27). Meanwhile a lone vertical (#1) that happens to land
+   _whole row_ near target AR (~1.27). Meanwhile a lone vertical (#1) that happens to land
    as its own leaf inherits the full row height and balloons. **Which vertical lands solo
    vs. stacked is not monotonic in rating** — it falls out of adjacency + AR-fitting.
 2. **The AR floor is enforced only at the ROOT**, not at internal nodes
    ([`rowAR_Cost`](rowCombination.ts) / `pickRootAssignment`), so a sub-tree `vStack` of two
    verticals at AR 0.28 is permitted as long as the root row clears 1.0.
 3. **The equity tiebreak can't rescue it.** `equitySpread` (the only mechanism that tries to
-   make area track value) is confined to `AR_EQUITY_BAND` (0.3) around the AR-optimal
-   candidate — and every tree where both 5★s get a full-height column falls *outside* that
-   band, so it is never even considered. The realized area/cv spread here is ~5.7×.
+   make area track prominence) is confined to `AR_EQUITY_BAND` (0.3) around the AR-optimal
+   candidate — and every tree where both 5★s get a full-height column falls _outside_ that
+   band, so it is never even considered.
 
-**Proof the cv penalty is NOT the cause (counterfactual):** rerunning the identical row with
-the vertical penalty *removed* (so V5★ cv = 3.06, unambiguously the highest value in the row)
-produces **byte-for-byte identical** rendered sizes. Penalty-free ratings `[4,3,4,5,5]` still
-point-balance-split into `left[V4,H3,V4] / right[V5,V5]`, so the two heroes stay grouped and
-stacked. The `−1` penalty does invert the *cv ranking* (V5★ 2.14 < H3★ 2.50 — a latent bug,
-the unresolved "Q9" in the 2026-03-30 design doc), but it does not change *this* layout.
-
-**Implication for the fix:** feeding prominence `P` to the equity metric (plan Phase 1) and
-removing the penalty (plan Phase 3.2) are **insufficient** for this case — neither changes the
-Phase-1 grouping. A row whose top item should dominate needs a **structural / hero-isolation**
-step that pulls a high-prominence vertical out to its own full-height column (analogous to
-`isFullWidthHero` for panoramas, which has no vertical equivalent today). Tracked as the
-upgraded Issue #4 in the directional-prominence plan.
+**Why the prominence rewrite alone did not fix it.** Feeding prominence `P` to the
+equity metric (plan Phase 1) and removing the vertical penalty (plan Phase 3.2) are
+**insufficient** for this case — neither changes the Phase-1 grouping. With penalty-free
+ratings `[4,3,4,5,5]` the row still point-balance-splits into
+`left[V4,H3,V4] / right[V5,V5]`, so the two heroes stay grouped and stacked, and the
+realized sizes are unchanged. A row whose top item should dominate needs a **structural /
+hero-isolation** step that pulls a high-prominence vertical out to its own full-height
+column. `isSoloHero` provides this for **wide** extreme-AR items (width-cost gated), but
+its tall counterpart — a taller-than-wide hero row via AR-floor relaxation — is **deferred,
+not implemented**. Tracked as the upgraded Issue #4 in the directional-prominence plan.

--- a/app/utils/rowCombination.md
+++ b/app/utils/rowCombination.md
@@ -65,3 +65,62 @@ Selection is two-tiered, not a stack of special-case rules: (1) the AR floor plu
 to the target row AR pick the acceptable band; (2) within it, the lowest
 area-vs-cv spread wins, so sizing tracks `cv` (the intended signal) rather than
 being an artifact of which subtree a leaf landed in.
+
+## Known limitation — vertical prominence is decided by STRUCTURE, not rating
+
+> Reproduced 2026-06-10 on `/oval-lakes?manage=1` (branch `0179-mobile-first-admin`).
+> This is the concrete, quantified instance of the directional-prominence plan's
+> "Issue #4 — Reachability" ([2026-06-09-directional-prominence.md](../../docs/superpowers/plans/2026-06-09-directional-prominence.md)).
+
+**Symptom:** the two highest-rated images in a row can render as the *smallest*.
+For the reported row `V4★, H3★, V4★, V5★, V5★` (all but the 3★ are 9:16 verticals),
+forced into one row at `rowWidth = 8`, `targetWidth = 1274`:
+
+| Image | effectiveRating | cv | rendered (w×h) | area |
+|------|----|----|----|----|
+| V4★ #1 | 3 | 1.53 | 552×982 | **542,631 ← biggest** |
+| H3★ #2 | 3 | 2.50 | 420×233 | 97,785 |
+| V4★ #3 | 3 | 1.53 | 420×736 | 309,050 |
+| V5★ #4 | 4 | 2.14 | 276×485 | **133,890 ← smallest** |
+| V5★ #5 | 4 | 2.14 | 276×485 | **133,890 ← smallest** |
+
+Winning tree:
+
+```
+H (root, forced hPair)
+├─ H
+│  ├─ leaf V4★ #1            ← solo leaf in an hPair → full row height → BIG
+│  └─ V (vStack) [ H3★ #2, V4★ #3 ]
+└─ V (vStack) [ V5★ #4, V5★ #5 ]   ← two heroes stacked → each half-height, narrow → SMALL
+```
+
+**Root cause (in order of impact):**
+
+1. **Composition geometry, not the value model.** In a justified row, "big" = "got a
+   tall, full-height column." Phase 1 (`splitByPointBalance`) groups the two adjacent,
+   equal-rated 5★s into one sibling subtree; Phase 2 can then only `hPair` them (too wide)
+   or `vStack` them (halves each one's height). It picks `vStack` because that lands the
+   *whole row* near target AR (~1.27). Meanwhile a lone vertical (#1) that happens to land
+   as its own leaf inherits the full row height and balloons. **Which vertical lands solo
+   vs. stacked is not monotonic in rating** — it falls out of adjacency + AR-fitting.
+2. **The AR floor is enforced only at the ROOT**, not at internal nodes
+   ([`rowAR_Cost`](rowCombination.ts) / `pickRootAssignment`), so a sub-tree `vStack` of two
+   verticals at AR 0.28 is permitted as long as the root row clears 1.0.
+3. **The equity tiebreak can't rescue it.** `equitySpread` (the only mechanism that tries to
+   make area track value) is confined to `AR_EQUITY_BAND` (0.3) around the AR-optimal
+   candidate — and every tree where both 5★s get a full-height column falls *outside* that
+   band, so it is never even considered. The realized area/cv spread here is ~5.7×.
+
+**Proof the cv penalty is NOT the cause (counterfactual):** rerunning the identical row with
+the vertical penalty *removed* (so V5★ cv = 3.06, unambiguously the highest value in the row)
+produces **byte-for-byte identical** rendered sizes. Penalty-free ratings `[4,3,4,5,5]` still
+point-balance-split into `left[V4,H3,V4] / right[V5,V5]`, so the two heroes stay grouped and
+stacked. The `−1` penalty does invert the *cv ranking* (V5★ 2.14 < H3★ 2.50 — a latent bug,
+the unresolved "Q9" in the 2026-03-30 design doc), but it does not change *this* layout.
+
+**Implication for the fix:** feeding prominence `P` to the equity metric (plan Phase 1) and
+removing the penalty (plan Phase 3.2) are **insufficient** for this case — neither changes the
+Phase-1 grouping. A row whose top item should dominate needs a **structural / hero-isolation**
+step that pulls a high-prominence vertical out to its own full-height column (analogous to
+`isFullWidthHero` for panoramas, which has no vertical equivalent today). Tracked as the
+upgraded Issue #4 in the directional-prominence plan.

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -187,33 +187,20 @@ export const AR_FLOOR_MULTIPLIER = 0.7;
 export const MAX_ROW_IMAGES = 12;
 
 /**
- * Full-width hero promotion thresholds.
- *
- * A wide, top-rated horizontal panorama is the one composition the in-row
- * algorithm structurally cannot serve. A 2:1+ image forced into a near-square
- * shared row is always crushed into a vStack sliver (vStack area ∝ 1/AR), and
- * giving it a proportional area would push the row AR far past the floor/target
- * — so it can never both share a row AND be sized to its prominence. The only
- * correct answer is to promote it to its own full-width row.
- *
- * Gated three ways so only genuine heroes qualify (product decision 2026-06-09:
- * "a 5★ horizontal panorama, 1:2 and up, should always be full width, up until
- * the higher density numbers"): wide enough (AR), rated highly enough (rating),
- * and not at high density — at high density (large rowWidth) even a wide
- * panorama shares the row.
+ * Full-width hero promotion thresholds. A wide, top-rated horizontal panorama
+ * can't be sized to its prominence inside a shared row, so it gets its own
+ * full-width row. Gated by AR, rating, and density (at high density even a wide
+ * panorama shares the row).
  */
 export const HERO_FULLWIDTH_MIN_AR = 2.0;
 export const HERO_FULLWIDTH_MIN_RATING = 5;
 export const HERO_FULLWIDTH_MAX_ROWWIDTH = 15;
 
 /**
- * Whether an item should claim its own full-width row. True only for a
- * horizontal image at least {@link HERO_FULLWIDTH_MIN_AR} wide and rated at
- * least {@link HERO_FULLWIDTH_MIN_RATING}, and only while the row-width budget
- * is at or below {@link HERO_FULLWIDTH_MAX_ROWWIDTH} (low/medium density).
- *
- * AR ≥ 2 already implies horizontal, so {@link getEffectiveRating} (which only
- * penalises verticals) equals the raw rating here.
+ * Whether an item should claim its own full-width row: a horizontal image at
+ * least {@link HERO_FULLWIDTH_MIN_AR} wide, rated at least
+ * {@link HERO_FULLWIDTH_MIN_RATING}, while the row-width budget is at or below
+ * {@link HERO_FULLWIDTH_MAX_ROWWIDTH} (low/medium density).
  */
 export function isFullWidthHero(item: AnyContentModel, rowWidth: number): boolean {
   if (rowWidth > HERO_FULLWIDTH_MAX_ROWWIDTH) return false;
@@ -252,20 +239,11 @@ function collectRowItems(
 }
 
 /**
- * Row-first layout algorithm. Builds rows one at a time over a lookahead
- * window: promote a full-width hero (see isFullWidthHero) to its own row,
- * standalone-skip a hero past low-rated items, greedy sequential fill, best-fit
- * fallback, then build each row's atomic tree.
- *
- * A full-width hero is promoted whether it leads the window (handled before
- * fill) or appears mid-window (skipped during fill so it surfaces as a leading
- * hero on the next iteration); the first window slot is therefore never a hero
- * by the time the fill loop runs.
- *
- * A would-overfill item that fills a row on its own (cv >= rowWidth *
- * MIN_FILL_RATIO) is skipped to get its own row next iteration. The AR-floor
- * check is disabled on mobile (rowWidth <= 2), where items render full-width or
- * stacked and single verticals naturally have low AR.
+ * Row-first layout algorithm. Builds rows over a lookahead window: promotes a
+ * full-width hero ({@link isFullWidthHero}) to its own row (whether leading or
+ * mid-window), standalone-skips a hero past low-rated items, greedy sequential
+ * fill, best-fit fallback, then builds each row's atomic tree. AR-floor check
+ * is disabled on mobile (rowWidth <= 2).
  *
  * @param rowWidth - Row width budget (5 for desktop, 4 for tablet, etc.)
  * @param targetAR - Target aspect ratio for AR-aware fill (default 1.5)
@@ -582,16 +560,11 @@ function rowAR_Cost(rowAR: number, target: number): number {
 const AR_EQUITY_BAND = 0.3;
 
 /**
- * Relative area each leaf occupies (and its prominence) for a fully
- * direction-assigned subtree. Area splits geometrically at each node: an hPair
- * divides area in proportion to child AR (siblings share height, so width —
- * hence area — ∝ AR); a vStack divides ∝ 1/AR (siblings share width, so
- * height ∝ 1/AR). Returned leaf shares sum to 1 within the subtree.
- *
- * `value` is the prominence P of each leaf (orientation-agnostic, no vertical
- * penalty). This is the equity target: equitySpread compares area/value across
- * leaves, so the tiebreak naturally rewards high-rated verticals with more area
- * rather than penalising them for having a low packing cv.
+ * Relative area each leaf occupies (and its prominence P) for a fully
+ * direction-assigned subtree. Area splits geometrically: hPair ∝ AR, vStack ∝ 1/AR.
+ * Leaf shares sum to 1 within the subtree. `value` is prominence P (orientation-agnostic),
+ * so {@link equitySpread} rewards high-rated verticals with more area rather than
+ * penalising them via the packing cv.
  */
 function leafShares(ac: AtomicComponent): {
   ar: number;
@@ -621,14 +594,10 @@ function leafShares(ac: AtomicComponent): {
 
 /**
  * How unevenly a candidate sizes its images relative to their prominence.
- * Returns max(area/value) / min(area/value) across leaves: 1.0 means every
- * image's area is exactly proportional to its prominence (equal-rated →
- * equal-size); larger means some image is over- or under-sized for its
- * prominence. Lower is more equitable.
- *
- * Using prominence (orientation-agnostic P) rather than packing cv ensures
- * that a high-rated vertical is not penalised by the vertical-penalty built
- * into cv — the equity tiebreak rewards it with more area instead.
+ * Returns max(area/value) / min(area/value) across leaves: 1.0 = perfectly
+ * proportional; larger = some image is over- or under-sized. Lower is better.
+ * Uses prominence P (orientation-agnostic) so high-rated verticals are not
+ * penalised by the vertical-penalty baked into packing cv.
  */
 function equitySpread(ac: AtomicComponent): number {
   const { leaves } = leafShares(ac);

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -2,7 +2,7 @@
  * Row Combination — row layout engine (two stages).
  *
  * Stage 1 (`buildRows`): greedy sequential fill decides which items go in each
- * row, using a per-row cv budget (rowWidth) and an AR-floor check.
+ * row, using a per-row width-cost budget (rowWidth) and an AR-floor check.
  * Stage 2 (`buildAtomic`): for each row, a point-balance split builds a binary tree,
  * then every hPair/vStack direction assignment is enumerated and scored — a hard
  * AR floor at 1.0 ("never taller than wide") plus closeness to the target row AR,
@@ -10,16 +10,20 @@
  *
  * Key concepts:
  * - A "component" is anything that occupies row space: a single image, gif, text, or combined block.
- * - Component value (cv) = proportion of row width an item occupies (effectiveRating / rowWidth).
- * - A row is "complete" when total component values >= 0.9 (90% threshold).
+ * - Width-cost Hv = √(P·AR) is each item's packing cost (orientation-agnostic): a wide
+ *   panorama costs more horizontal space, a tall portrait less. fill = ΣHv / rowWidth.
+ * - A row is "complete" when total width-cost >= 0.9 of rowWidth (90% threshold).
  */
 
+import { EXTREMENESS_RAMP_START } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import {
+  getArExtremeness,
   getEffectiveRating,
   getHeightDemand,
   getItemComponentValue,
   getProminence,
+  getWidthCost,
 } from '@/app/utils/contentRatingUtils';
 import { getAspectRatio } from '@/app/utils/contentTypeGuards';
 import { calculateBoxTreeAspectRatio } from '@/app/utils/rowStructureAlgorithm';
@@ -42,10 +46,11 @@ export type BoxTree =
 // =============================================================================
 
 /**
- * Calculate the total component value of a set of items.
+ * Total Stage-1 packing cost of a set of items, summing the width-cost
+ * Hv = √(P·AR) (orientation-agnostic) rather than the vertical-biased cv.
  */
 function getTotalCV(components: AnyContentModel[], _rowWidth: number): number {
-  return components.reduce((sum, item) => sum + getItemComponentValue(item), 0);
+  return components.reduce((sum, item) => sum + getWidthCost(item), 0);
 }
 
 // =============================================================================
@@ -71,7 +76,7 @@ export const LOW_RATED_THRESHOLD = 2;
 export function isRowComplete(components: AnyContentModel[], rowWidth: number): boolean {
   if (components.length === 0) return false;
 
-  const totalValue = components.reduce((sum, item) => sum + getItemComponentValue(item), 0);
+  const totalValue = components.reduce((sum, item) => sum + getWidthCost(item), 0);
 
   const fill = totalValue / rowWidth;
   return fill >= MIN_FILL_RATIO && fill <= MAX_FILL_RATIO;
@@ -227,25 +232,39 @@ export function rowTargetAR(items: ImageType[], baseline: number): number {
 export const MAX_ROW_IMAGES = 12;
 
 /**
- * Full-width hero promotion thresholds. A wide, top-rated horizontal panorama
- * can't be sized to its prominence inside a shared row, so it gets its own
- * full-width row. Gated by AR, rating, and density (at high density even a wide
- * panorama shares the row).
+ * Width-cost fraction at or above which an extreme-AR item claims its OWN
+ * full-width row. Paired with an extremeness gate (see {@link isSoloHero}); the
+ * fraction alone is not enough because a normal landscape at a small rowWidth can
+ * exceed it (a 3★ landscape Hv ≈ 2.11 is 0.53 of a rowWidth-4 budget) — that
+ * would collapse low-density rows into full-width singles.
  */
-export const HERO_FULLWIDTH_MIN_AR = 2.0;
-export const HERO_FULLWIDTH_MIN_RATING = 5;
-export const HERO_FULLWIDTH_MAX_ROWWIDTH = 15;
+export const HERO_SOLO_WIDTH_FRACTION = 0.5;
 
 /**
- * Whether an item should claim its own full-width row: a horizontal image at
- * least {@link HERO_FULLWIDTH_MIN_AR} wide, rated at least
- * {@link HERO_FULLWIDTH_MIN_RATING}, while the row-width budget is at or below
- * {@link HERO_FULLWIDTH_MAX_ROWWIDTH} (low/medium density).
+ * Whether an item should claim its own full-width row — the emergent successor to
+ * the retired isFullWidthHero rule. Two gates, both required:
+ *
+ * 1. **Extremeness gate** ({@link getArExtremeness} ≥ {@link EXTREMENESS_RAMP_START}):
+ *    only images far from square in EITHER direction are solo-eligible. This ties
+ *    eligibility to the prominence model's own extremeness concept (no new magic
+ *    number) and subsumes the old AR≥2 gate. A normal landscape (ext 1.78 < 2) is
+ *    never eligible at any rowWidth; the rating gate is correctly dropped per the
+ *    prominence philosophy.
+ * 2. **Width-cost gate** (Hv / rowWidth ≥ {@link HERO_SOLO_WIDTH_FRACTION}):
+ *    the item's width-cost must dominate the row budget. This subsumes the old
+ *    density ceiling — a wide 5★ pano (Hv ≈ 5.48) clears 0.5 of a rowWidth-10
+ *    budget (low/medium density → solos) but only 0.27 of a rowWidth-20 budget
+ *    (high density → shares).
+ *
+ * A tall portrait passes the extremeness gate but its small Hv keeps its
+ * width-fraction below the bar, so it never solos — its prominence is expressed
+ * as row height via {@link rowTargetAR}, not a solo row. Disabled on mobile
+ * (rowWidth ≤ 2) to keep the narrow-slot path unchanged.
  */
-export function isFullWidthHero(item: AnyContentModel, rowWidth: number): boolean {
-  if (rowWidth > HERO_FULLWIDTH_MAX_ROWWIDTH) return false;
-  if (getAspectRatio(item) < HERO_FULLWIDTH_MIN_AR) return false;
-  return getEffectiveRating(item) >= HERO_FULLWIDTH_MIN_RATING;
+export function isSoloHero(item: AnyContentModel, rowWidth: number): boolean {
+  if (rowWidth <= 2) return false;
+  if (getArExtremeness(getAspectRatio(item)) < EXTREMENESS_RAMP_START) return false;
+  return getWidthCost(item) / rowWidth >= HERO_SOLO_WIDTH_FRACTION;
 }
 
 /**
@@ -279,11 +298,12 @@ function collectRowItems(
 }
 
 /**
- * Row-first layout algorithm. Builds rows over a lookahead window: promotes a
- * full-width hero ({@link isFullWidthHero}) to its own row (whether leading or
- * mid-window), standalone-skips a hero past low-rated items, greedy sequential
- * fill, best-fit fallback, then builds each row's atomic tree. AR-floor check
- * is disabled on mobile (rowWidth <= 2).
+ * Row-first layout algorithm. Builds rows over a lookahead window:
+ * standalone-skips a hero past low-rated items, greedy sequential fill (by the
+ * width-cost Hv = √(P·AR)), best-fit fallback, then builds each row's atomic
+ * tree. A wide top-rated panorama claiming its own row at low/medium density is
+ * an EMERGENT consequence of its large Hv exceeding the row budget — no longer a
+ * hard-coded special case. AR-floor check is disabled on mobile (rowWidth <= 2).
  *
  * @param rowWidth - Row width budget (5 for desktop, 4 for tablet, etc.)
  * @param targetARBaseline - Baseline (viewport) target AR. Fill/estimate use it directly;
@@ -304,7 +324,11 @@ export function buildRows(
   while (remaining.length > 0) {
     const window = remaining.slice(0, 5);
 
-    if (isFullWidthHero(window[0]!, rowWidth)) {
+    // Emergent full-width hero: a leading extreme-AR item whose width-cost
+    // dominates the row budget claims its own row (see {@link isSoloHero}).
+    // Replaces the retired isFullWidthHero AR+rating rule — a wide top-rated
+    // panorama qualifies at low/medium density and shares at high density.
+    if (isSoloHero(window[0]!, rowWidth)) {
       const heroItem = window[0]!;
       rows.push({
         components: [heroItem],
@@ -321,9 +345,7 @@ export function buildRows(
       let heroIdx = -1;
 
       for (let i = 1; i < maxSearch; i++) {
-        const candidate = window[i]!;
-        const cv = getItemComponentValue(candidate);
-        if (cv / rowWidth >= 0.95) {
+        if (isSoloHero(window[i]!, rowWidth)) {
           heroIdx = i;
           break;
         }
@@ -353,19 +375,20 @@ export function buildRows(
     let slotCountComplete = false;
 
     for (let i = 0; i < expandedWindow.length; i++) {
-      if (seqCount > 0 && isFullWidthHero(expandedWindow[i]!, rowWidth)) {
+      const cv = getWidthCost(expandedWindow[i]!);
+
+      // Emergent full-width hero (mid-window): once the row has started, a later
+      // solo-eligible item (see {@link isSoloHero}) is skipped here so it surfaces
+      // as a leading solo hero on the next iteration. Mirrors the leading-item
+      // check above; replaces the retired isFullWidthHero skip.
+      if (seqCount > 0 && isSoloHero(expandedWindow[i]!, rowWidth)) {
         skippedStandalones.push(i);
         continue;
       }
 
-      const cv = getItemComponentValue(expandedWindow[i]!);
       const newFill = (seqTotal + cv) / rowWidth;
 
       if (newFill > MAX_FILL_RATIO && !slotCountComplete) {
-        if (seqCount > 0 && cv / rowWidth >= 0.95) {
-          skippedStandalones.push(i);
-          continue;
-        }
         // Accept moderate overfill when the row is still under the density-
         // scaled MIN_FILL bar — solo underfilled row is worse than slight overfill.
         const currentFill = seqTotal / rowWidth;
@@ -450,7 +473,7 @@ export function buildRows(
         if (!available.has(idx)) continue;
 
         const currentTotal = getTotalCV(bfComponents, rowWidth);
-        const candidateCV = getItemComponentValue(window[idx]!);
+        const candidateCV = getWidthCost(window[idx]!);
         const newTotal = currentTotal + candidateCV;
         const newFill = newTotal / rowWidth;
 

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -541,7 +541,9 @@ type AbstractNode =
  * boundary whose two halves have the closest effectiveRating sums. Order
  * preserved — no swaps, only splits.
  *
- * effectiveRating (not cv): cv would double-penalise verticals. See ./rowCombination.md.
+ * Balances on effectiveRating (now penalty-free — equal to the raw rating for
+ * both orientations) rather than the width-cost cv, so the split point reflects
+ * prominence, not packing width. See ./rowCombination.md.
  */
 function splitByPointBalance(items: ImageType[]): AbstractNode {
   if (items.length === 0) throw new Error('buildAtomic requires at least 1 image');

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -21,7 +21,6 @@ import {
   getArExtremeness,
   getEffectiveRating,
   getHeightDemand,
-  getItemComponentValue,
   getProminence,
   getWidthCost,
 } from '@/app/utils/contentRatingUtils';
@@ -106,7 +105,6 @@ export interface ImageType {
   ar: OrientationShort;
   numericAR: number;
   effectiveRating: number;
-  componentValue: number;
   /** Orientation-agnostic prominence P — used as the equity-target for area allocation. */
   prominence: number;
   /** Height demand Vv = √(P/AR) — drives the per-row target AR (taller rows for tall heroes). */
@@ -131,7 +129,6 @@ export function toImageType(item: AnyContentModel, _rowWidth: number): ImageType
   const numericAR = getAspectRatio(item);
   const ar: OrientationShort = numericAR > 1.0 ? 'H' : 'V';
   const effectiveRating = getEffectiveRating(item);
-  const componentValue = getItemComponentValue(item);
   const prominence = getProminence(item);
   const heightDemand = getHeightDemand(item);
   const title = 'title' in item ? String(item.title) : `item-${item.id}`;
@@ -142,7 +139,6 @@ export function toImageType(item: AnyContentModel, _rowWidth: number): ImageType
     ar,
     numericAR,
     effectiveRating,
-    componentValue,
     prominence,
     heightDemand,
   };

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -17,6 +17,7 @@
 import type { AnyContentModel } from '@/app/types/Content';
 import {
   getEffectiveRating,
+  getHeightDemand,
   getItemComponentValue,
   getProminence,
 } from '@/app/utils/contentRatingUtils';
@@ -103,6 +104,8 @@ export interface ImageType {
   componentValue: number;
   /** Orientation-agnostic prominence P — used as the equity-target for area allocation. */
   prominence: number;
+  /** Height demand Vv = √(P/AR) — drives the per-row target AR (taller rows for tall heroes). */
+  heightDemand: number;
 }
 
 /** Recursive composition structure */
@@ -125,9 +128,19 @@ export function toImageType(item: AnyContentModel, _rowWidth: number): ImageType
   const effectiveRating = getEffectiveRating(item);
   const componentValue = getItemComponentValue(item);
   const prominence = getProminence(item);
+  const heightDemand = getHeightDemand(item);
   const title = 'title' in item ? String(item.title) : `item-${item.id}`;
 
-  return { source: item, title, ar, numericAR, effectiveRating, componentValue, prominence };
+  return {
+    source: item,
+    title,
+    ar,
+    numericAR,
+    effectiveRating,
+    componentValue,
+    prominence,
+    heightDemand,
+  };
 }
 
 /** Create a single-image AtomicComponent */
@@ -179,6 +192,33 @@ export function acToBoxTree(ac: AtomicComponent): BoxTree {
 
 /** AR floor multiplier: row AR must be at least targetAR * this value */
 export const AR_FLOOR_MULTIPLIER = 0.7;
+
+// Per-row target AR band (Phase 2 — directional prominence). rowTargetAR pulls the
+// viewport baseline toward a floor in proportion to the row's peak height-demand
+// (Vv) ABOVE the Vv ceiling of wide/normal images, so a row holding a tall hero
+// targets a taller (lower-AR) shape and sizes the hero bigger, while rows of
+// landscapes/panos keep the baseline. Two anchors: peak Vv at/below
+// ROW_TARGET_AR_VV_LOW pulls nothing; at/above ROW_TARGET_AR_VV_HIGH the pull is
+// full. Clamped so a row never drops below ROW_TARGET_AR_MIN_FRACTION of the
+// baseline, preserving the density→size monotonicity shipped 2026-05-29.
+export const ROW_TARGET_AR_MIN_FRACTION = 0.6; // never below 60% of the baseline
+export const ROW_TARGET_AR_VV_LOW = 1.85; // ≈ just above a 5★ pano's Vv (1.826)
+export const ROW_TARGET_AR_VV_HIGH = 5.0; // ≈ a 1:3 portrait hero → full pull-down
+
+/**
+ * Per-row target AR: the viewport baseline pulled toward a floor by the row's peak
+ * height-demand (Vv). A bland horizontal row (peak Vv below the wide-image ceiling
+ * ROW_TARGET_AR_VV_LOW) keeps the baseline; a row with a tall vertical hero targets
+ * a taller (lower-AR) shape so the hero renders bigger. The pull is content-driven
+ * (peak Vv), not count-driven, so it does not affect density→size monotonicity.
+ */
+export function rowTargetAR(items: ImageType[], baseline: number): number {
+  const peakVv = items.reduce((max, it) => Math.max(max, it.heightDemand), 0);
+  const span = ROW_TARGET_AR_VV_HIGH - ROW_TARGET_AR_VV_LOW;
+  const pull = Math.min(1, Math.max(0, (peakVv - ROW_TARGET_AR_VV_LOW) / span));
+  const floor = baseline * ROW_TARGET_AR_MIN_FRACTION;
+  return baseline - pull * (baseline - floor);
+}
 
 /**
  * Maximum images per row. Caps greedy fill AND bounds buildAtomic's Phase 2
@@ -246,12 +286,13 @@ function collectRowItems(
  * is disabled on mobile (rowWidth <= 2).
  *
  * @param rowWidth - Row width budget (5 for desktop, 4 for tablet, etc.)
- * @param targetAR - Target aspect ratio for AR-aware fill (default 1.5)
+ * @param targetARBaseline - Baseline (viewport) target AR. Fill/estimate use it directly;
+ *   each row's final composition derives a per-row target from it via {@link rowTargetAR}.
  */
 export function buildRows(
   items: AnyContentModel[],
   rowWidth: number,
-  targetAR: number = 1.5
+  targetARBaseline: number = 1.5
 ): RowResult[] {
   const rows: RowResult[] = [];
   const remaining = [...items];
@@ -304,7 +345,7 @@ export function buildRows(
       }
     }
 
-    const arFloor = rowWidth <= 2 ? 0 : targetAR * AR_FLOOR_MULTIPLIER;
+    const arFloor = rowWidth <= 2 ? 0 : targetARBaseline * AR_FLOOR_MULTIPLIER;
     const expandedWindow = remaining.slice(0, MAX_ROW_IMAGES);
     let seqTotal = 0;
     let seqCount = 0;
@@ -348,7 +389,7 @@ export function buildRows(
         // Re-check AR with the expanded set
         const expandedItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
         const expandedImgs = expandedItems.map(item => toImageType(item, rowWidth));
-        const expandedAR = estimateRowAR(expandedImgs, targetAR, rowWidth);
+        const expandedAR = estimateRowAR(expandedImgs, targetARBaseline, rowWidth);
         if (expandedAR >= arFloor) break;
         continue;
       }
@@ -359,7 +400,7 @@ export function buildRows(
       if (newFill >= effectiveMinFill) {
         const rowItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
         const rowImgs = rowItems.map(item => toImageType(item, rowWidth));
-        const rowAR = estimateRowAR(rowImgs, targetAR, rowWidth);
+        const rowAR = estimateRowAR(rowImgs, targetARBaseline, rowWidth);
 
         if (rowAR >= arFloor) {
           break;
@@ -371,7 +412,7 @@ export function buildRows(
     if (seqCount > 0) {
       const rowItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
       const rowImgs = rowItems.map(item => toImageType(item, rowWidth));
-      const composition = buildAtomic(rowImgs, targetAR, rowWidth);
+      const composition = buildAtomic(rowImgs, rowTargetAR(rowImgs, targetARBaseline), rowWidth);
       const boxTree = acToBoxTree(composition);
 
       rows.push({
@@ -440,7 +481,7 @@ export function buildRows(
     }
 
     const bfImgs = bfComponents.map(item => toImageType(item, rowWidth));
-    const composition = buildAtomic(bfImgs, targetAR, rowWidth);
+    const composition = buildAtomic(bfImgs, rowTargetAR(bfImgs, targetARBaseline), rowWidth);
     const boxTree = acToBoxTree(composition);
 
     rows.push({

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -180,6 +180,41 @@ export const AR_FLOOR_MULTIPLIER = 0.7;
 export const MAX_ROW_IMAGES = 12;
 
 /**
+ * Full-width hero promotion thresholds.
+ *
+ * A wide, top-rated horizontal panorama is the one composition the in-row
+ * algorithm structurally cannot serve. A 2:1+ image forced into a near-square
+ * shared row is always crushed into a vStack sliver (vStack area ∝ 1/AR), and
+ * giving it a proportional area would push the row AR far past the floor/target
+ * — so it can never both share a row AND be sized to its prominence. The only
+ * correct answer is to promote it to its own full-width row.
+ *
+ * Gated three ways so only genuine heroes qualify (product decision 2026-06-09:
+ * "a 5★ horizontal panorama, 1:2 and up, should always be full width, up until
+ * the higher density numbers"): wide enough (AR), rated highly enough (rating),
+ * and not at high density — at high density (large rowWidth) even a wide
+ * panorama shares the row.
+ */
+export const HERO_FULLWIDTH_MIN_AR = 2.0;
+export const HERO_FULLWIDTH_MIN_RATING = 5;
+export const HERO_FULLWIDTH_MAX_ROWWIDTH = 15;
+
+/**
+ * Whether an item should claim its own full-width row. True only for a
+ * horizontal image at least {@link HERO_FULLWIDTH_MIN_AR} wide and rated at
+ * least {@link HERO_FULLWIDTH_MIN_RATING}, and only while the row-width budget
+ * is at or below {@link HERO_FULLWIDTH_MAX_ROWWIDTH} (low/medium density).
+ *
+ * AR ≥ 2 already implies horizontal, so {@link getEffectiveRating} (which only
+ * penalises verticals) equals the raw rating here.
+ */
+export function isFullWidthHero(item: AnyContentModel, rowWidth: number): boolean {
+  if (rowWidth > HERO_FULLWIDTH_MAX_ROWWIDTH) return false;
+  if (getAspectRatio(item) < HERO_FULLWIDTH_MIN_AR) return false;
+  return getEffectiveRating(item) >= HERO_FULLWIDTH_MIN_RATING;
+}
+
+/**
  * Estimate a row's combined aspect ratio. Routes through the canonical composer
  * so the Stage-1 estimate matches the composition that actually renders.
  */
@@ -211,8 +246,14 @@ function collectRowItems(
 
 /**
  * Row-first layout algorithm. Builds rows one at a time over a lookahead
- * window: standalone-skip a hero past low-rated items, greedy sequential fill,
- * best-fit fallback, then build each row's atomic tree.
+ * window: promote a full-width hero (see isFullWidthHero) to its own row,
+ * standalone-skip a hero past low-rated items, greedy sequential fill, best-fit
+ * fallback, then build each row's atomic tree.
+ *
+ * A full-width hero is promoted whether it leads the window (handled before
+ * fill) or appears mid-window (skipped during fill so it surfaces as a leading
+ * hero on the next iteration); the first window slot is therefore never a hero
+ * by the time the fill loop runs.
  *
  * A would-overfill item that fills a row on its own (cv >= rowWidth *
  * MIN_FILL_RATIO) is skipped to get its own row next iteration. The AR-floor
@@ -236,6 +277,16 @@ export function buildRows(
 
   while (remaining.length > 0) {
     const window = remaining.slice(0, 5);
+
+    if (isFullWidthHero(window[0]!, rowWidth)) {
+      const heroItem = window[0]!;
+      rows.push({
+        components: [heroItem],
+        boxTree: acToBoxTree(single(toImageType(heroItem, rowWidth))),
+      });
+      remaining.splice(0, 1);
+      continue;
+    }
 
     const item0Rating = getEffectiveRating(window[0]!);
 
@@ -276,6 +327,11 @@ export function buildRows(
     let slotCountComplete = false;
 
     for (let i = 0; i < expandedWindow.length; i++) {
+      if (seqCount > 0 && isFullWidthHero(expandedWindow[i]!, rowWidth)) {
+        skippedStandalones.push(i);
+        continue;
+      }
+
       const cv = getItemComponentValue(expandedWindow[i]!);
       const newFill = (seqTotal + cv) / rowWidth;
 

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -15,7 +15,11 @@
  */
 
 import type { AnyContentModel } from '@/app/types/Content';
-import { getEffectiveRating, getItemComponentValue } from '@/app/utils/contentRatingUtils';
+import {
+  getEffectiveRating,
+  getItemComponentValue,
+  getProminence,
+} from '@/app/utils/contentRatingUtils';
 import { getAspectRatio } from '@/app/utils/contentTypeGuards';
 import { calculateBoxTreeAspectRatio } from '@/app/utils/rowStructureAlgorithm';
 
@@ -97,6 +101,8 @@ export interface ImageType {
   numericAR: number;
   effectiveRating: number;
   componentValue: number;
+  /** Orientation-agnostic prominence P — used as the equity-target for area allocation. */
+  prominence: number;
 }
 
 /** Recursive composition structure */
@@ -118,9 +124,10 @@ export function toImageType(item: AnyContentModel, _rowWidth: number): ImageType
   const ar: OrientationShort = numericAR > 1.0 ? 'H' : 'V';
   const effectiveRating = getEffectiveRating(item);
   const componentValue = getItemComponentValue(item);
+  const prominence = getProminence(item);
   const title = 'title' in item ? String(item.title) : `item-${item.id}`;
 
-  return { source: item, title, ar, numericAR, effectiveRating, componentValue };
+  return { source: item, title, ar, numericAR, effectiveRating, componentValue, prominence };
 }
 
 /** Create a single-image AtomicComponent */
@@ -575,18 +582,23 @@ function rowAR_Cost(rowAR: number, target: number): number {
 const AR_EQUITY_BAND = 0.3;
 
 /**
- * Relative area each leaf occupies (and its cv) for a fully direction-assigned
- * subtree. Area splits geometrically at each node: an hPair divides area in
- * proportion to child AR (siblings share height, so width — hence area — ∝ AR);
- * a vStack divides ∝ 1/AR (siblings share width, so height ∝ 1/AR). Returned
- * leaf shares sum to 1 within the subtree.
+ * Relative area each leaf occupies (and its prominence) for a fully
+ * direction-assigned subtree. Area splits geometrically at each node: an hPair
+ * divides area in proportion to child AR (siblings share height, so width —
+ * hence area — ∝ AR); a vStack divides ∝ 1/AR (siblings share width, so
+ * height ∝ 1/AR). Returned leaf shares sum to 1 within the subtree.
+ *
+ * `value` is the prominence P of each leaf (orientation-agnostic, no vertical
+ * penalty). This is the equity target: equitySpread compares area/value across
+ * leaves, so the tiebreak naturally rewards high-rated verticals with more area
+ * rather than penalising them for having a low packing cv.
  */
 function leafShares(ac: AtomicComponent): {
   ar: number;
-  leaves: Array<{ cv: number; share: number }>;
+  leaves: Array<{ value: number; share: number }>;
 } {
   if (ac.type === 'single') {
-    return { ar: ac.img.numericAR, leaves: [{ cv: ac.img.componentValue, share: 1 }] };
+    return { ar: ac.img.numericAR, leaves: [{ value: ac.img.prominence, share: 1 }] };
   }
   const left = leafShares(ac.children[0]);
   const right = leafShares(ac.children[1]);
@@ -601,25 +613,30 @@ function leafShares(ac: AtomicComponent): {
   return {
     ar,
     leaves: [
-      ...left.leaves.map(l => ({ cv: l.cv, share: l.share * leftFactor })),
-      ...right.leaves.map(l => ({ cv: l.cv, share: l.share * rightFactor })),
+      ...left.leaves.map(l => ({ value: l.value, share: l.share * leftFactor })),
+      ...right.leaves.map(l => ({ value: l.value, share: l.share * rightFactor })),
     ],
   };
 }
 
 /**
- * How unevenly a candidate sizes its images relative to their cv. Returns
- * max(area/cv) / min(area/cv) across leaves: 1.0 means every image's area is
- * exactly proportional to its cv (equal-rated → equal-size); larger means some
- * image is over- or under-sized for its rating. Lower is more equitable.
+ * How unevenly a candidate sizes its images relative to their prominence.
+ * Returns max(area/value) / min(area/value) across leaves: 1.0 means every
+ * image's area is exactly proportional to its prominence (equal-rated →
+ * equal-size); larger means some image is over- or under-sized for its
+ * prominence. Lower is more equitable.
+ *
+ * Using prominence (orientation-agnostic P) rather than packing cv ensures
+ * that a high-rated vertical is not penalised by the vertical-penalty built
+ * into cv — the equity tiebreak rewards it with more area instead.
  */
 function equitySpread(ac: AtomicComponent): number {
   const { leaves } = leafShares(ac);
   let min = Infinity;
   let max = 0;
-  for (const { cv, share } of leaves) {
-    if (cv <= 0) continue;
-    const ratio = share / cv;
+  for (const { value, share } of leaves) {
+    if (value <= 0) continue;
+    const ratio = share / value;
     if (ratio < min) min = ratio;
     if (ratio > max) max = ratio;
   }

--- a/tests/components/Content/collectionContentRendererUtils.test.ts
+++ b/tests/components/Content/collectionContentRendererUtils.test.ts
@@ -18,6 +18,7 @@ const options = (overrides: Partial<CollectionInfoOptions> = {}): CollectionInfo
   locations: dim([], false),
   lensTypes: { values: [], filterable: false },
   showHighlyRated: false,
+  showDateSort: false,
   ...overrides,
 });
 

--- a/tests/components/ContentCollection/CollectionEditSheet.test.tsx
+++ b/tests/components/ContentCollection/CollectionEditSheet.test.tsx
@@ -351,3 +351,20 @@ describe('CollectionEditSheet — ARIA tabpanel wiring', () => {
     expect(document.getElementById('tabpanel-info')).toBeNull();
   });
 });
+
+describe('CollectionEditSheet — desktop two-column layout', () => {
+  it('renders Info and Structure fields at the same time', () => {
+    // editTab is irrelevant in two-column mode — both panels mount regardless.
+    render(<CollectionEditSheet edit={makeEdit({ editTab: 'info' })} twoColumn />);
+    expect(screen.getByLabelText('Title')).toBeInTheDocument(); // Info
+    expect(screen.getByLabelText('Order')).toBeInTheDocument(); // Structure
+    expect(screen.getByTestId('collection-list-selector')).toBeInTheDocument(); // Structure
+  });
+
+  it('exposes the Info and Structure columns as labeled regions and no tabpanel (the chooser is dropped on desktop)', () => {
+    render(<CollectionEditSheet edit={makeEdit()} twoColumn />);
+    expect(screen.getByRole('region', { name: 'Info' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Structure' })).toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel')).not.toBeInTheDocument();
+  });
+});

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -11,9 +11,11 @@ import {
   buildLocationCriteria,
   canFilter,
   computeFilterCounts,
+  computeFilterVisibility,
   type ContentFilterCriteria,
   extractCollectionFilterOptions,
   extractFilterOptions,
+  type FilterVisibility,
   filmFilterFromIsFilm,
   filterContent,
   hasAnyActiveFilter,
@@ -1397,6 +1399,43 @@ describe('buildLocationCriteria', () => {
   it('round-trips with filmFilterFromIsFilm for the film toggle', () => {
     const criteria = buildLocationCriteria(makeFilterState({ filmFilter: 'film' }));
     expect(filmFilterFromIsFilm(criteria.isFilm)).toBe('film');
+  });
+});
+
+describe('computeFilterVisibility', () => {
+  it('hides every control for an empty or single-image page', () => {
+    expect(computeFilterVisibility([])).toEqual({
+      dateSort: false, highlyRated: false, film: false, tags: false,
+      people: false, cameras: false, lenses: false, locations: false, lensTypes: false,
+    });
+    expect(computeFilterVisibility([makeImage({ id: 1, isFilm: true, rating: 5 })]).film).toBe(false);
+  });
+
+  it('shows film only when both film and digital are present', () => {
+    const filmOnly = [makeImage({ id: 1, isFilm: true }), makeImage({ id: 2, isFilm: true })];
+    const mixed = [makeImage({ id: 1, isFilm: true }), makeImage({ id: 2, isFilm: false })];
+    expect(computeFilterVisibility(filmOnly).film).toBe(false);
+    expect(computeFilterVisibility(mixed).film).toBe(true);
+  });
+
+  it('shows highlyRated only when images straddle the 4-star line', () => {
+    const allHigh = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 4 })];
+    const straddle = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 2 })];
+    expect(computeFilterVisibility(allHigh).highlyRated).toBe(false);
+    expect(computeFilterVisibility(straddle).highlyRated).toBe(true);
+  });
+
+  it('shows dateSort only with 2+ distinct capture dates', () => {
+    const sameDate = [
+      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
+      makeImage({ id: 2, captureDate: '2024-01-01T00:00:00Z' }),
+    ];
+    const varied = [
+      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
+      makeImage({ id: 2, captureDate: '2024-02-01T00:00:00Z' }),
+    ];
+    expect(computeFilterVisibility(sameDate).dateSort).toBe(false);
+    expect(computeFilterVisibility(varied).dateSort).toBe(true);
   });
 });
 

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -16,12 +16,10 @@ import {
   type ContentFilterCriteria,
   extractCollectionFilterOptions,
   extractFilterOptions,
-  type FilterVisibility,
   filmFilterFromIsFilm,
   filterContent,
   hasAnyActiveFilter,
   hasFilterableOptions,
-  hasValueVariance,
   mergeDateSortedImages,
   parseFilterFromParams,
   serializeFilterToParams,
@@ -1041,7 +1039,13 @@ describe('extractCollectionFilterOptions', () => {
     // Now alpine (2/2) is still excluded but forest (1/2) is included. One value
     // does not cover all items → filterable.
     const splits = extractCollectionFilterOptions([
-      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }, { id: 2, name: 'forest', slug: 'forest' }] }),
+      makeImage({
+        id: 1,
+        tags: [
+          { id: 1, name: 'alpine', slug: 'alpine' },
+          { id: 2, name: 'forest', slug: 'forest' },
+        ],
+      }),
       makeImage({ id: 2, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }] }),
     ]);
     expect(splits.tags.filterable).toBe(true);
@@ -1228,52 +1232,6 @@ describe('applyCollectionFilters', () => {
   });
 });
 
-describe('hasValueVariance', () => {
-  it('returns false for an empty array', () => {
-    expect(hasValueVariance([], img => img.rating)).toBe(false);
-  });
-
-  it('returns false when all selected values are identical', () => {
-    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 5 })];
-    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(false);
-  });
-
-  it('returns true when selected values differ', () => {
-    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 3 })];
-    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(true);
-  });
-
-  it('counts a rating of 0 as a distinct value when stringified', () => {
-    // Regression: the helper drops falsy outputs, so 0 must be stringified to count.
-    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 0 })];
-    expect(hasValueVariance(images, img => String(img.rating ?? 0))).toBe(true);
-  });
-
-  it('drops rating 0 WITHOUT the String() wrapper — proves the call-site wrapper is load-bearing', () => {
-    // CollectionPageClient must pass `String(img.rating ?? 0)`, not the raw number. Without the
-    // wrapper, 0 is falsy → dropped → only {5} remains → no variance, silently hiding the
-    // Highly-Rated control on an all-0-vs-some-rated collection. This documents WHY the wrapper exists.
-    const images = [makeImage({ id: 1, rating: 5 }), makeImage({ id: 2, rating: 0 })];
-    expect(hasValueVariance(images, img => img.rating)).toBe(false);
-  });
-
-  it('drops falsy (missing) capture dates so a single real date has no variance', () => {
-    const images = [
-      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
-      makeImage({ id: 2, captureDate: undefined }),
-    ];
-    expect(hasValueVariance(images, img => img.captureDate)).toBe(false);
-  });
-
-  it('returns true when two distinct real dates are present', () => {
-    const images = [
-      makeImage({ id: 1, captureDate: '2024-01-01T00:00:00Z' }),
-      makeImage({ id: 2, captureDate: '2024-06-01T00:00:00Z' }),
-    ];
-    expect(hasValueVariance(images, img => img.captureDate)).toBe(true);
-  });
-});
-
 describe('mergeDateSortedImages', () => {
   it('replaces image slots in order while leaving non-image blocks in place', () => {
     const img1 = makeImage({ id: 1 });
@@ -1419,10 +1377,19 @@ describe('buildLocationCriteria', () => {
 describe('computeFilterVisibility', () => {
   it('hides every control for an empty or single-image page', () => {
     expect(computeFilterVisibility([])).toEqual({
-      dateSort: false, highlyRated: false, film: false, tags: false,
-      people: false, cameras: false, lenses: false, locations: false, lensTypes: false,
+      dateSort: false,
+      highlyRated: false,
+      film: false,
+      tags: false,
+      people: false,
+      cameras: false,
+      lenses: false,
+      locations: false,
+      lensTypes: false,
     });
-    expect(computeFilterVisibility([makeImage({ id: 1, isFilm: true, rating: 5 })]).film).toBe(false);
+    expect(computeFilterVisibility([makeImage({ id: 1, isFilm: true, rating: 5 })]).film).toBe(
+      false
+    );
   });
 
   it('shows film only when both film and digital are present', () => {
@@ -1455,7 +1422,9 @@ describe('computeFilterVisibility', () => {
 
 describe('canFilter', () => {
   it('returns false below 2 items (nothing to split)', () => {
-    expect(canFilter([makeImage({ id: 1, isFilm: true })], img => [img.isFilm ? 'film' : 'digital'])).toBe(false);
+    expect(
+      canFilter([makeImage({ id: 1, isFilm: true })], img => [img.isFilm ? 'film' : 'digital'])
+    ).toBe(false);
     expect(canFilter([], () => ['x'])).toBe(false);
   });
 
@@ -1472,7 +1441,13 @@ describe('canFilter', () => {
   it('counts each item once per distinct value (multi-valued dimensions)', () => {
     // both images carry 'sky'; only img 1 also carries 'sea' → 'sea' splits the set.
     const images = [
-      makeImage({ id: 1, tags: [{ id: 1, name: 'sky', slug: 'sky' }, { id: 2, name: 'sea', slug: 'sea' }] }),
+      makeImage({
+        id: 1,
+        tags: [
+          { id: 1, name: 'sky', slug: 'sky' },
+          { id: 2, name: 'sea', slug: 'sea' },
+        ],
+      }),
       makeImage({ id: 2, tags: [{ id: 1, name: 'sky', slug: 'sky' }] }),
     ];
     expect(canFilter(images, img => (img.tags ?? []).map(t => t.name))).toBe(true);
@@ -1498,8 +1473,15 @@ describe('canFilter', () => {
 
 describe('applyActiveOverride', () => {
   const hiddenAll = {
-    dateSort: false, highlyRated: false, film: false, tags: false,
-    people: false, cameras: false, lenses: false, locations: false, lensTypes: false,
+    dateSort: false,
+    highlyRated: false,
+    film: false,
+    tags: false,
+    people: false,
+    cameras: false,
+    lenses: false,
+    locations: false,
+    lensTypes: false,
   };
 
   it('keeps a control visible when its filter is active even if the gate hid it', () => {
@@ -1514,8 +1496,12 @@ describe('applyActiveOverride', () => {
   });
 
   it('forces dateSort and highlyRated visible when those filters are active', () => {
-    expect(applyActiveOverride(hiddenAll, makeFilterState({ dateSortDirection: 'desc' })).dateSort).toBe(true);
-    expect(applyActiveOverride(hiddenAll, makeFilterState({ highlyRatedOnly: true })).highlyRated).toBe(true);
+    expect(
+      applyActiveOverride(hiddenAll, makeFilterState({ dateSortDirection: 'desc' })).dateSort
+    ).toBe(true);
+    expect(
+      applyActiveOverride(hiddenAll, makeFilterState({ highlyRatedOnly: true })).highlyRated
+    ).toBe(true);
   });
 
   it('leaves an all-false verdict untouched when no filter is active', () => {

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -9,6 +9,7 @@ import {
   applyCollectionFilters,
   buildCollectionCriteria,
   buildLocationCriteria,
+  canFilter,
   computeFilterCounts,
   type ContentFilterCriteria,
   extractCollectionFilterOptions,
@@ -1396,5 +1397,48 @@ describe('buildLocationCriteria', () => {
   it('round-trips with filmFilterFromIsFilm for the film toggle', () => {
     const criteria = buildLocationCriteria(makeFilterState({ filmFilter: 'film' }));
     expect(filmFilterFromIsFilm(criteria.isFilm)).toBe('film');
+  });
+});
+
+describe('canFilter', () => {
+  it('returns false below 2 items (nothing to split)', () => {
+    expect(canFilter([makeImage({ id: 1, isFilm: true })], img => [img.isFilm ? 'film' : 'digital'])).toBe(false);
+    expect(canFilter([], () => ['x'])).toBe(false);
+  });
+
+  it('returns false when one value covers every item', () => {
+    const allDigital = [makeImage({ id: 1, isFilm: false }), makeImage({ id: 2, isFilm: false })];
+    expect(canFilter(allDigital, img => [img.isFilm ? 'film' : 'digital'])).toBe(false);
+  });
+
+  it('returns true when a value matches a proper non-empty subset', () => {
+    const mixed = [makeImage({ id: 1, isFilm: true }), makeImage({ id: 2, isFilm: false })];
+    expect(canFilter(mixed, img => [img.isFilm ? 'film' : 'digital'])).toBe(true);
+  });
+
+  it('counts each item once per distinct value (multi-valued dimensions)', () => {
+    // both images carry 'sky'; only img 1 also carries 'sea' → 'sea' splits the set.
+    const images = [
+      makeImage({ id: 1, tags: [{ id: 1, name: 'sky', slug: 'sky' }, { id: 2, name: 'sea', slug: 'sea' }] }),
+      makeImage({ id: 2, tags: [{ id: 1, name: 'sky', slug: 'sky' }] }),
+    ];
+    expect(canFilter(images, img => (img.tags ?? []).map(t => t.name))).toBe(true);
+  });
+
+  it('returns false when a single shared value blankets a multi-valued dimension', () => {
+    const images = [
+      makeImage({ id: 1, tags: [{ id: 1, name: 'sky', slug: 'sky' }] }),
+      makeImage({ id: 2, tags: [{ id: 1, name: 'sky', slug: 'sky' }] }),
+    ];
+    expect(canFilter(images, img => (img.tags ?? []).map(t => t.name))).toBe(false);
+  });
+
+  it('treats a value present on a subset (others absent) as splitting', () => {
+    // camera Canon on img 1, img 2 has no camera → Canon splits 1-of-2.
+    const images = [
+      makeImage({ id: 1, camera: { id: 1, name: 'Canon' } }),
+      makeImage({ id: 2, camera: null }),
+    ];
+    expect(canFilter(images, img => (img.camera?.name ? [img.camera.name] : []))).toBe(true);
   });
 });

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1026,12 +1026,25 @@ describe('extractCollectionFilterOptions', () => {
     expect(dims.lensTypes.values).toEqual([]);
   });
 
-  it('marks tags and people filterable regardless of count', () => {
-    const dims = extractCollectionFilterOptions([
-      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }], people: [] }),
+  it('marks a dimension filterable only when a value splits the set', () => {
+    // Two images: 'alpine' on both (100% frequency → excluded by 0.9 blanket
+    // threshold in extractFilterOptions, so values is []).  canFilter on an
+    // empty projection returns false → not filterable.
+    const blanketOnly = extractCollectionFilterOptions([
+      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }] }),
+      makeImage({ id: 2, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }] }),
     ]);
-    expect(dims.tags.filterable).toBe(true);
-    expect(dims.people.filterable).toBe(true);
+    expect(blanketOnly.tags.values).toEqual([]);
+    expect(blanketOnly.tags.filterable).toBe(false);
+
+    // 'forest' appears on only one image (50% < 90%) so it survives the threshold.
+    // Now alpine (2/2) is still excluded but forest (1/2) is included. One value
+    // does not cover all items → filterable.
+    const splits = extractCollectionFilterOptions([
+      makeImage({ id: 1, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }, { id: 2, name: 'forest', slug: 'forest' }] }),
+      makeImage({ id: 2, tags: [{ id: 1, name: 'alpine', slug: 'alpine' }] }),
+    ]);
+    expect(splits.tags.filterable).toBe(true);
   });
 
   it('marks single-value cameras/lenses/locations non-filterable (info-mode)', () => {

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/app/types/Content';
 import { type FilterState, INITIAL_FILTER_STATE, type LensType } from '@/app/types/GalleryFilter';
 import {
+  applyActiveOverride,
   applyCollectionFilters,
   buildCollectionCriteria,
   buildLocationCriteria,
@@ -1479,5 +1480,27 @@ describe('canFilter', () => {
       makeImage({ id: 2, camera: null }),
     ];
     expect(canFilter(images, img => (img.camera?.name ? [img.camera.name] : []))).toBe(true);
+  });
+});
+
+describe('applyActiveOverride', () => {
+  const hiddenAll = {
+    dateSort: false, highlyRated: false, film: false, tags: false,
+    people: false, cameras: false, lenses: false, locations: false, lensTypes: false,
+  };
+
+  it('keeps a control visible when its filter is active even if the gate hid it', () => {
+    const result = applyActiveOverride(hiddenAll, makeFilterState({ filmFilter: 'film' }));
+    expect(result.film).toBe(true);
+    expect(result.highlyRated).toBe(false);
+  });
+
+  it('forces an array dimension visible when it has an active selection', () => {
+    const result = applyActiveOverride(hiddenAll, makeFilterState({ selectedTags: ['sunset'] }));
+    expect(result.tags).toBe(true);
+  });
+
+  it('leaves an all-false verdict untouched when no filter is active', () => {
+    expect(applyActiveOverride(hiddenAll, makeFilterState())).toEqual(hiddenAll);
   });
 });

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1086,6 +1086,49 @@ describe('extractCollectionFilterOptions', () => {
     expect(dims.locations.filterable).toBe(true);
   });
 
+  it('keeps a single-value location an info chip even when some images lack it', () => {
+    // 'Dolomites' on only one of two images → canFilter alone would call it
+    // filterable; the >= 2 distinct-value guard keeps it an info chip.
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, locations: [{ id: 1, name: 'Dolomites, Italy', slug: 'dolomites' }] }),
+      makeImage({ id: 2, locations: [] }),
+    ]);
+    expect(dims.locations.values).toEqual(['Dolomites, Italy']);
+    expect(dims.locations.filterable).toBe(false);
+  });
+
+  it('keeps a single-value camera an info chip when only some images have it', () => {
+    const dims = extractCollectionFilterOptions([
+      makeImage({ id: 1, camera: { id: 1, name: 'Hasselblad 500cm' } }),
+      makeImage({ id: 2, camera: null }),
+    ]);
+    expect(dims.cameras.values).toEqual(['Hasselblad 500cm']);
+    expect(dims.cameras.filterable).toBe(false);
+  });
+
+  it('hides a multi-value location dimension where every value blankets all images', () => {
+    // Two images both carry A and B → neither splits → not filterable (the canFilter
+    // half matters here; a bare length>=2 rule would wrongly show a useless dropdown).
+    const dims = extractCollectionFilterOptions([
+      makeImage({
+        id: 1,
+        locations: [
+          { id: 1, name: 'A', slug: 'a' },
+          { id: 2, name: 'B', slug: 'b' },
+        ],
+      }),
+      makeImage({
+        id: 2,
+        locations: [
+          { id: 1, name: 'A', slug: 'a' },
+          { id: 2, name: 'B', slug: 'b' },
+        ],
+      }),
+    ]);
+    expect(dims.locations.values).toEqual(['A', 'B']);
+    expect(dims.locations.filterable).toBe(false);
+  });
+
   it('surfaces lens types only with 2+ distinct categories AND 2+ distinct lenses', () => {
     // wide (24mm) + telephoto (200mm), two distinct lenses → lens types surface, ordered.
     const dims = extractCollectionFilterOptions([

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1500,6 +1500,11 @@ describe('applyActiveOverride', () => {
     expect(result.tags).toBe(true);
   });
 
+  it('forces dateSort and highlyRated visible when those filters are active', () => {
+    expect(applyActiveOverride(hiddenAll, makeFilterState({ dateSortDirection: 'desc' })).dateSort).toBe(true);
+    expect(applyActiveOverride(hiddenAll, makeFilterState({ highlyRatedOnly: true })).highlyRated).toBe(true);
+  });
+
   it('leaves an all-false verdict untouched when no filter is active', () => {
     expect(applyActiveOverride(hiddenAll, makeFilterState())).toEqual(hiddenAll);
   });

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -1289,12 +1289,19 @@ describe('processContentForDisplay', () => {
     });
 
     it('falls back to the pinned mobile slot width when mobileChunkSize is omitted', () => {
-      const omitted = processContentForDisplay(content, 400, 4, { isMobile: true });
-      const explicit = processContentForDisplay(content, 400, 4, {
+      // When mobileChunkSize is omitted the row width pins to LAYOUT.mobileSlotWidth,
+      // independent of the desktop chunkSize arg — so two different chunkSize args
+      // produce identical layouts (the pinned slot ignores them).
+      const pinnedA = processContentForDisplay(content, 400, 4, { isMobile: true });
+      const pinnedB = processContentForDisplay(content, 400, 8, { isMobile: true });
+      expect(pinnedA.length).toBe(pinnedB.length);
+      // And the pinned (narrow) layout is at least as tall as an explicitly dense
+      // mobileChunkSize, confirming it is a fixed narrow slot rather than density-driven.
+      const dense = processContentForDisplay(content, 400, 4, {
         isMobile: true,
-        mobileChunkSize: 1,
+        mobileChunkSize: 5,
       });
-      expect(omitted.length).toBe(explicit.length);
+      expect(pinnedA.length).toBeGreaterThanOrEqual(dense.length);
     });
 
     it('does not affect desktop layout', () => {

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -197,9 +197,42 @@ describe('getComponentValue', () => {
     expect(getComponentValue(0, 1.5)).toBe(1.0);
   });
 
-  it('caps arFactor at 1.0 for wide horizontals (AR > 1.5)', () => {
-    expect(getComponentValue(5, 2.0)).toBe(5.0);
-    expect(getComponentValue(3, 2.5)).toBe(2.5);
+  it('caps arFactor at 1.0 for wide horizontals below the panorama threshold (1.5 <= AR < 2.0)', () => {
+    expect(getComponentValue(5, 1.78)).toBe(5.0);
+    expect(getComponentValue(3, 1.9)).toBe(2.5);
+  });
+
+  describe('panorama scale (AR >= 2:1) — cv climbs with width', () => {
+    it('gives a 2:1 panorama a higher value than a normal 5-star horizontal', () => {
+      // 5★ panorama at 2:1 → arFactor 1.4 → cv 7.0 (vs 5.0 for a normal 5★ horizontal)
+      expect(getComponentValue(5, 2.0)).toBeCloseTo(7.0, 5);
+    });
+
+    it('scales a 5-star panorama 5 → 7 → 10 → 13 across 1.78:1, 2:1, 3:1, 4:1', () => {
+      expect(getComponentValue(5, 1.78)).toBeCloseTo(5.0, 5); // below threshold, capped
+      expect(getComponentValue(5, 2.0)).toBeCloseTo(7.0, 5);
+      expect(getComponentValue(5, 3.0)).toBeCloseTo(10.0, 5);
+      expect(getComponentValue(5, 4.0)).toBeCloseTo(13.0, 5);
+    });
+
+    it('interpolates between anchors (2.5:1 → 8.5 for a 5-star)', () => {
+      expect(getComponentValue(5, 2.5)).toBeCloseTo(8.5, 5);
+    });
+
+    it('scales the panorama boost by rating (a 3-star 3:1 panorama → 5.0)', () => {
+      // 3★ base weight 2.5 × arFactor 2.0 = 5.0
+      expect(getComponentValue(3, 3.0)).toBeCloseTo(5.0, 5);
+    });
+
+    it('keeps the value strictly increasing with width past the threshold', () => {
+      expect(getComponentValue(5, 2.0)).toBeLessThan(getComponentValue(5, 2.5));
+      expect(getComponentValue(5, 2.5)).toBeLessThan(getComponentValue(5, 3.0));
+      expect(getComponentValue(5, 3.0)).toBeLessThan(getComponentValue(5, 4.0));
+    });
+
+    it('does not boost just below the 2:1 threshold (AR 1.99 stays capped)', () => {
+      expect(getComponentValue(5, 1.99)).toBe(5.0);
+    });
   });
 
   it('reduces cv for verticals (AR < 1.0) via sqrt factor', () => {
@@ -254,5 +287,15 @@ describe('getItemComponentValue', () => {
     // Just verify it works with no second arg
     expect(typeof getItemComponentValue(image)).toBe('number');
     expect(getItemComponentValue(image)).toBeGreaterThan(0);
+  });
+
+  it('gives a 5-star 3:1 panorama a much higher cv than a 5-star horizontal', () => {
+    const panorama = createPanorama(1, 5); // AR 3.0
+    const horizontal = createHorizontalImage(2, 5); // AR 1.78
+    // Panorama: er=5, arFactor=1.4+0.6*(3-2)=2.0 → cv 10.0; horizontal capped → cv 5.0
+    expect(getItemComponentValue(panorama)).toBeCloseTo(10.0, 5);
+    expect(getItemComponentValue(panorama)).toBeGreaterThan(
+      getItemComponentValue(horizontal) * 1.9
+    );
   });
 });

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -5,10 +5,8 @@
 
 import {
   getArExtremeness,
-  getComponentValue,
   getEffectiveRating,
   getHeightDemand,
-  getItemComponentValue,
   getProminence,
   getProminenceRating,
   getRating,
@@ -179,8 +177,8 @@ describe('getEffectiveRating', () => {
   });
 
   describe('orientation-only rating (no slotWidth parameter)', () => {
-    // Note: slotWidth does not affect effective rating — slot-width scaling is
-    // handled downstream in getComponentValue().
+    // Note: slotWidth does not affect effective rating — width scaling is handled
+    // downstream by the prominence width-cost Hv = √(P·AR).
     it('should return the same effective rating independent of slot context', () => {
       const image = createHorizontalImage(1, 4);
       expect(getEffectiveRating(image)).toBe(4);
@@ -189,121 +187,7 @@ describe('getEffectiveRating', () => {
 });
 
 // getEffectiveRatingFromAspectRatio deleted — no production callers
-
-// ===================== getComponentValue Tests =====================
-
-describe('getComponentValue', () => {
-  it('returns base weight for standard horizontal (AR=1.5)', () => {
-    expect(getComponentValue(5, 1.5)).toBe(5.0);
-    expect(getComponentValue(4, 1.5)).toBe(3.5);
-    expect(getComponentValue(3, 1.5)).toBe(2.5);
-    expect(getComponentValue(2, 1.5)).toBe(1.75);
-    expect(getComponentValue(1, 1.5)).toBe(1.25);
-    expect(getComponentValue(0, 1.5)).toBe(1.0);
-  });
-
-  it('caps arFactor at 1.0 for wide horizontals below the panorama threshold (1.5 <= AR < 2.0)', () => {
-    expect(getComponentValue(5, 1.78)).toBe(5.0);
-    expect(getComponentValue(3, 1.9)).toBe(2.5);
-  });
-
-  describe('panorama scale (AR >= 2:1) — cv climbs with width', () => {
-    it('gives a 2:1 panorama a higher value than a normal 5-star horizontal', () => {
-      // 5★ panorama at 2:1 → arFactor 1.4 → cv 7.0 (vs 5.0 for a normal 5★ horizontal)
-      expect(getComponentValue(5, 2.0)).toBeCloseTo(7.0, 5);
-    });
-
-    it('scales a 5-star panorama 5 → 7 → 10 → 13 across 1.78:1, 2:1, 3:1, 4:1', () => {
-      expect(getComponentValue(5, 1.78)).toBeCloseTo(5.0, 5); // below threshold, capped
-      expect(getComponentValue(5, 2.0)).toBeCloseTo(7.0, 5);
-      expect(getComponentValue(5, 3.0)).toBeCloseTo(10.0, 5);
-      expect(getComponentValue(5, 4.0)).toBeCloseTo(13.0, 5);
-    });
-
-    it('interpolates between anchors (2.5:1 → 8.5 for a 5-star)', () => {
-      expect(getComponentValue(5, 2.5)).toBeCloseTo(8.5, 5);
-    });
-
-    it('scales the panorama boost by rating (a 3-star 3:1 panorama → 5.0)', () => {
-      // 3★ base weight 2.5 × arFactor 2.0 = 5.0
-      expect(getComponentValue(3, 3.0)).toBeCloseTo(5.0, 5);
-    });
-
-    it('keeps the value strictly increasing with width past the threshold', () => {
-      expect(getComponentValue(5, 2.0)).toBeLessThan(getComponentValue(5, 2.5));
-      expect(getComponentValue(5, 2.5)).toBeLessThan(getComponentValue(5, 3.0));
-      expect(getComponentValue(5, 3.0)).toBeLessThan(getComponentValue(5, 4.0));
-    });
-
-    it('does not boost just below the 2:1 threshold (AR 1.99 stays capped)', () => {
-      expect(getComponentValue(5, 1.99)).toBe(5.0);
-    });
-  });
-
-  it('reduces cv for verticals (AR < 1.0) via sqrt factor', () => {
-    const cv = getComponentValue(4, 0.67);
-    expect(cv).toBeCloseTo(3.5 * Math.sqrt(0.67 / 1.5), 2);
-    expect(cv).toBeLessThan(3.5);
-    expect(cv).toBeGreaterThan(2.0);
-  });
-
-  it('reduces cv for square images (AR=1.0)', () => {
-    const cv = getComponentValue(3, 1.0);
-    expect(cv).toBeCloseTo(2.5 * Math.sqrt(1.0 / 1.5), 2);
-  });
-
-  it('handles effectiveRating > 5 by capping at 5', () => {
-    expect(getComponentValue(6, 1.5)).toBe(5.0);
-    expect(getComponentValue(10, 1.5)).toBe(5.0);
-  });
-
-  it('handles effectiveRating < 0 by flooring at 0', () => {
-    expect(getComponentValue(-1, 1.5)).toBe(1.0);
-  });
-});
-
-// ===================== getItemComponentValue Tests =====================
-
-describe('getItemComponentValue', () => {
-  it('returns full base weight for H5★ (AR ~1.78, capped at reference)', () => {
-    const image = createHorizontalImage(1, 5);
-    // H5★: effectiveRating=5, AR=1.78 (capped at 1.5) → arFactor=1.0 → cv=5.0
-    expect(getItemComponentValue(image)).toBe(5.0);
-  });
-
-  it('applies vertical penalty and AR factor for V5★', () => {
-    const image = createVerticalImage(1, 5);
-    // V5★: effectiveRating=4, AR=0.5625 → arFactor=sqrt(0.5625/1.5)≈0.612 → cv≈2.14
-    const cv = getItemComponentValue(image);
-    expect(cv).toBeGreaterThan(1.5);
-    expect(cv).toBeLessThan(3.5);
-  });
-
-  it('V4★ and H3★ no longer have same cv (AR factor differentiates)', () => {
-    const v4 = createVerticalImage(1, 4);
-    const h3 = createHorizontalImage(2, 3);
-    // V4★: er=3, AR=0.5625, cv = 2.5 * sqrt(0.5625/1.5) ≈ 1.53
-    // H3★: er=3, AR=1.78, cv = 2.5 * 1.0 = 2.5
-    expect(getItemComponentValue(v4)).toBeLessThan(getItemComponentValue(h3));
-  });
-
-  it('does not take slotWidth parameter', () => {
-    const image = createHorizontalImage(1, 3);
-    // Just verify it works with no second arg
-    expect(typeof getItemComponentValue(image)).toBe('number');
-    expect(getItemComponentValue(image)).toBeGreaterThan(0);
-  });
-
-  it('gives a 5-star 3:1 panorama a much higher cv than a 5-star horizontal', () => {
-    const panorama = createPanorama(1, 5); // AR 3.0
-    const horizontal = createHorizontalImage(2, 5); // AR 1.78
-    // Panorama: er=5, arFactor=1.4+0.6*(3-2)=2.0 → cv 10.0; horizontal capped → cv 5.0
-    expect(getItemComponentValue(panorama)).toBeCloseTo(10.0, 5);
-    expect(getItemComponentValue(panorama)).toBeGreaterThan(
-      getItemComponentValue(horizontal) * 1.9
-    );
-  });
-});
+// getComponentValue / getItemComponentValue deleted — retired cv value-model replaced by prominence P / width-cost Hv
 
 // ===================== getArExtremeness Tests =====================
 

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -207,7 +207,7 @@ describe('getProminenceRating', () => {
     expect(getProminenceRating(createHorizontalImage(1, 3))).toBe(3);
   });
 
-  it('returns raw rating for vertical images (no vertical penalty unlike getEffectiveRating)', () => {
+  it('returns raw rating for vertical images (no vertical penalty)', () => {
     expect(getProminenceRating(createVerticalImage(1, 5))).toBe(5);
     expect(getProminenceRating(createVerticalImage(1, 3))).toBe(3);
   });

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -7,10 +7,12 @@ import {
   getArExtremeness,
   getComponentValue,
   getEffectiveRating,
+  getHeightDemand,
   getItemComponentValue,
   getProminence,
   getProminenceRating,
   getRating,
+  getWidthCost,
   isCollectionCard,
 } from '@/app/utils/contentRatingUtils';
 import {
@@ -362,5 +364,21 @@ describe('getProminence (orientation-agnostic P)', () => {
   it('scales 5★ extremeness 5 → 10 across square-ish and 3:1', () => {
     expect(getProminence(createHorizontalImage(1, 5))).toBeCloseTo(5.0, 1);
     expect(getProminence(createPanorama(2, 5))).toBeCloseTo(10.0, 5);
+  });
+});
+
+// ===================== Hv / Vv Decomposition Tests =====================
+
+describe('Hv / Vv decomposition', () => {
+  it('Hv·Vv ≈ P and Hv/Vv = AR', () => {
+    const pano = createPanorama(1, 5);
+    expect(getWidthCost(pano) * getHeightDemand(pano)).toBeCloseTo(getProminence(pano), 4);
+    expect(getWidthCost(pano) / getHeightDemand(pano)).toBeCloseTo(3.0, 4);
+  });
+  it('a panorama is wide-dominant, a portrait is height-dominant, at equal P', () => {
+    const pano = createPanorama(1, 5);
+    const portrait = createVerticalImage(2, 5);
+    expect(getWidthCost(pano)).toBeGreaterThan(getHeightDemand(pano));
+    expect(getHeightDemand(portrait)).toBeGreaterThan(getWidthCost(portrait));
   });
 });

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -4,9 +4,12 @@
  */
 
 import {
+  getArExtremeness,
   getComponentValue,
   getEffectiveRating,
   getItemComponentValue,
+  getProminence,
+  getProminenceRating,
   getRating,
   isCollectionCard,
 } from '@/app/utils/contentRatingUtils';
@@ -297,5 +300,67 @@ describe('getItemComponentValue', () => {
     expect(getItemComponentValue(panorama)).toBeGreaterThan(
       getItemComponentValue(horizontal) * 1.9
     );
+  });
+});
+
+// ===================== getArExtremeness Tests =====================
+
+describe('getArExtremeness', () => {
+  it('is 1 for square, symmetric for wide and tall', () => {
+    expect(getArExtremeness(1.0)).toBeCloseTo(1.0, 5);
+    expect(getArExtremeness(3.0)).toBeCloseTo(3.0, 5);
+    expect(getArExtremeness(1 / 3)).toBeCloseTo(3.0, 5);
+  });
+});
+
+// ===================== getProminenceRating Tests =====================
+
+describe('getProminenceRating', () => {
+  it('returns raw rating for horizontal images (no vertical penalty)', () => {
+    expect(getProminenceRating(createHorizontalImage(1, 5))).toBe(5);
+    expect(getProminenceRating(createHorizontalImage(1, 3))).toBe(3);
+  });
+
+  it('returns raw rating for vertical images (no vertical penalty unlike getEffectiveRating)', () => {
+    expect(getProminenceRating(createVerticalImage(1, 5))).toBe(5);
+    expect(getProminenceRating(createVerticalImage(1, 3))).toBe(3);
+  });
+
+  it('returns 4 for collection cards', () => {
+    const collectionCard = {
+      id: 1,
+      contentType: 'PARALLAX' as const,
+      collectionType: 'TRAVEL',
+    };
+    expect(getProminenceRating(collectionCard as never)).toBe(4);
+  });
+
+  it('returns 1 for non-image content', () => {
+    const textContent = {
+      id: 1,
+      contentType: 'TEXT' as const,
+      textBlock: { title: 'Test' },
+    };
+    expect(getProminenceRating(textContent as never)).toBe(1);
+  });
+});
+
+// ===================== getProminence Tests =====================
+
+describe('getProminence (orientation-agnostic P)', () => {
+  it('gives a 5★ portrait the same P as a 5★ landscape (no vertical penalty)', () => {
+    expect(getProminence(createVerticalImage(1, 5))).toBeCloseTo(
+      getProminence(createHorizontalImage(2, 5)),
+      5
+    );
+  });
+
+  it('gives a 3:1 panorama P=10 at 5★', () => {
+    expect(getProminence(createPanorama(2, 5))).toBeCloseTo(10.0, 5);
+  });
+
+  it('scales 5★ extremeness 5 → 10 across square-ish and 3:1', () => {
+    expect(getProminence(createHorizontalImage(1, 5))).toBeCloseTo(5.0, 1);
+    expect(getProminence(createPanorama(2, 5))).toBeCloseTo(10.0, 5);
   });
 });

--- a/tests/utils/contentRatingUtils.test.ts
+++ b/tests/utils/contentRatingUtils.test.ts
@@ -126,24 +126,24 @@ describe('getEffectiveRating', () => {
     });
   });
 
-  describe('vertical images (penalty -1)', () => {
-    it('should return rating - 1 for vertical images', () => {
-      expect(getEffectiveRating(createVerticalImage(1, 5))).toBe(4); // V5★ → H4★ equivalent
-      expect(getEffectiveRating(createVerticalImage(1, 4))).toBe(3); // V4★ → H3★ equivalent
-      expect(getEffectiveRating(createVerticalImage(1, 3))).toBe(2); // V3★ → H2★ equivalent
-      expect(getEffectiveRating(createVerticalImage(1, 2))).toBe(1); // V2★ → H1★ equivalent
+  describe('vertical images (no penalty — retired in directional prominence)', () => {
+    it('should return the raw rating for vertical images (directionality handled by AR extremeness, not a penalty)', () => {
+      expect(getEffectiveRating(createVerticalImage(1, 5))).toBe(5); // V5★ → 5 (was 4 under the penalty)
+      expect(getEffectiveRating(createVerticalImage(1, 4))).toBe(4); // V4★ → 4 (was 3)
+      expect(getEffectiveRating(createVerticalImage(1, 3))).toBe(3); // V3★ → 3 (was 2)
+      expect(getEffectiveRating(createVerticalImage(1, 2))).toBe(2); // V2★ → 2 (was 1)
     });
 
-    it('should not go below 0 for low-rated verticals', () => {
-      expect(getEffectiveRating(createVerticalImage(1, 1))).toBe(0); // V1★ → 0 (clamped)
-      expect(getEffectiveRating(createVerticalImage(1, 0))).toBe(0); // V0★ → 0 (clamped)
+    it('clamps low-rated verticals to [0, 5] without a penalty', () => {
+      expect(getEffectiveRating(createVerticalImage(1, 1))).toBe(1); // V1★ → 1 (was 0 under the penalty)
+      expect(getEffectiveRating(createVerticalImage(1, 0))).toBe(0); // V0★ → 0
     });
   });
 
-  describe('square images (treated as vertical)', () => {
-    it('should apply vertical penalty to square images', () => {
-      expect(getEffectiveRating(createSquareImage(1, 5))).toBe(4);
-      expect(getEffectiveRating(createSquareImage(1, 3))).toBe(2);
+  describe('square images (no penalty)', () => {
+    it('should return the raw rating for square images (no longer treated as penalised verticals)', () => {
+      expect(getEffectiveRating(createSquareImage(1, 5))).toBe(5); // was 4 under the penalty
+      expect(getEffectiveRating(createSquareImage(1, 3))).toBe(3); // was 2
     });
   });
 

--- a/tests/utils/rowCombination.characterization.test.ts
+++ b/tests/utils/rowCombination.characterization.test.ts
@@ -195,33 +195,30 @@ describe('buildRows characterization', () => {
   });
 
   // ---------------------------------------------------------------
-  // Test 11: 4 verticals (V3★, V1★, V1★, V1★) — 2×2 nested
-  // V3★ eff=2, V1★ eff=0. CVs: 1.25 + 1.0 + 1.0 + 1.0 = 4.25, fill=85%
+  // Test 11: 4 verticals (V3★, V1★, V1★, V1★)
+  // Penalty retired: V3★ eff=3, V1★ eff=1 (was 2 and 0). Penalty-free
+  // point-balance (total 6, half 3) splits exactly after the V3★, so the
+  // top-rated vertical claims its own top-level slot instead of being paired.
   // ---------------------------------------------------------------
-  it('11: V3★ + V1★ + V1★ + V1★ → 2×2 nested', () => {
+  it('11: V3★ + V1★ + V1★ + V1★ → hero V3★ splits off, rest nest', () => {
     const items = [V(1, 3), V(2, 1), V(3, 1), V(4, 1)];
     const rows = buildRows(items, DESKTOP);
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
 
-    // Builds: H( H(V3★,V1★), V(V1★,V1★) ) — an H pair on the left and a
-    // V stack of two leaves on the right.
+    // Builds: H( V3★, H( V1★, V(V1★,V1★) ) ) — the top-rated V3★ takes the left
+    // slot as a single leaf; the three V1★ nest on the right.
     const tree = rows[0]!.boxTree;
     expect(tree.type).toBe('combined');
     if (tree.type === 'combined') {
       expect(tree.direction).toBe('horizontal');
-      // Left side: horizontal pair
-      expect(tree.children[0].type).toBe('combined');
-      if (tree.children[0].type === 'combined') {
-        expect(tree.children[0].direction).toBe('horizontal');
-      }
-      // Right side: vertical stack of two leaves
+      // Left side: the V3★ hero as a single leaf
+      expect(tree.children[0].type).toBe('leaf');
+      // Right side: the remaining three verticals nested under a horizontal pair
       expect(tree.children[1].type).toBe('combined');
       if (tree.children[1].type === 'combined') {
-        expect(tree.children[1].direction).toBe('vertical');
-        expect(tree.children[1].children[0].type).toBe('leaf');
-        expect(tree.children[1].children[1].type).toBe('leaf');
+        expect(tree.children[1].direction).toBe('horizontal');
       }
     }
   });
@@ -454,25 +451,25 @@ describe('architecture types', () => {
       expect(img.componentValue).toBeCloseTo(3.5); // BASE_WEIGHT[4] × 1.0 (arFactor capped)
     });
 
-    it('should convert vertical image with penalty', () => {
+    it('should convert a vertical image with no penalty (retired)', () => {
       const item = V(2, 3);
       const img = toImageType(item, DESKTOP);
 
       expect(img.source).toBe(item);
       expect(img.ar).toBe('V');
       expect(img.numericAR).toBeCloseTo(0.5625);
-      expect(img.effectiveRating).toBe(2); // V3★ → eff 2 (vertical penalty)
-      expect(img.componentValue).toBeCloseTo(1.0717, 3); // BASE_WEIGHT[2] × sqrt(0.5625/1.5)
+      expect(img.effectiveRating).toBe(3); // V3★ → eff 3 (penalty retired; was 2)
+      expect(img.componentValue).toBeCloseTo(1.5309, 3); // BASE_WEIGHT[3] × sqrt(0.5625/1.5)
     });
 
-    it('should handle V1★ → effective 0', () => {
+    it('should handle V1★ → effective 1 (penalty retired)', () => {
       const item = V(3, 1);
       const img = toImageType(item, DESKTOP);
 
       expect(img.ar).toBe('V');
       expect(img.numericAR).toBeCloseTo(0.5625);
-      expect(img.effectiveRating).toBe(0);
-      expect(img.componentValue).toBeCloseTo(0.6124, 3); // BASE_WEIGHT[0] × sqrt(0.5625/1.5)
+      expect(img.effectiveRating).toBe(1); // was 0 under the penalty
+      expect(img.componentValue).toBeCloseTo(0.7655, 3); // BASE_WEIGHT[1] × sqrt(0.5625/1.5)
     });
 
     it('should preserve source reference', () => {

--- a/tests/utils/rowCombination.characterization.test.ts
+++ b/tests/utils/rowCombination.characterization.test.ts
@@ -68,9 +68,10 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 2: V5★ + V5★ — 2 verticals
-  // V5★ effective=4, cv=2.5. 2×2.5=5.0, fill=100%
+  // Penalty retired: V5★ P=5.0, Hv≈1.68. 2×1.68≈3.35, fill≈42% of rw=8 (verticals
+  // cost little horizontal space) — they still pair into the one available row.
   // ---------------------------------------------------------------
-  it('2: V5★ + V5★ → 2 verticals (100% fill)', () => {
+  it('2: V5★ + V5★ → 2 verticals (~42% fill)', () => {
     const items = [V(1, 5), V(2, 5)];
     const rows = buildRows(items, DESKTOP);
 
@@ -81,9 +82,10 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 3: H3★ + H3★ — greedy sequential fill
-  // H3★ cv=1.67, 2×1.67=3.34, fill=67% < 90% → row incomplete with 2 items
+  // H3★ P=2.5, Hv≈2.11. 2×2.11≈4.22, fill≈53% of rw=8 → row incomplete with 2
+  // items (still pairs since there are only two).
   // ---------------------------------------------------------------
-  it('3: H3★ + H3★ → 2 horizontals (67% fill, below 90%)', () => {
+  it('3: H3★ + H3★ → 2 horizontals (~53% fill, below complete)', () => {
     const items = [H(1, 3), H(2, 3)];
     const rows = buildRows(items, DESKTOP);
 
@@ -94,9 +96,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 4: V2★ + V2★ — greedy sequential fill
-  // V2★ effective=1, cv=1.0. 2×1.0=2.0, fill=40% < 90%
+  // Penalty retired: V2★ P=1.75, Hv≈0.99. 2×0.99≈1.98, fill≈25% of rw=8.
   // ---------------------------------------------------------------
-  it('4: V2★ + V2★ → 2 verticals (40% fill)', () => {
+  it('4: V2★ + V2★ → 2 verticals (~25% fill)', () => {
     const items = [V(1, 2), V(2, 2)];
     const rows = buildRows(items, DESKTOP);
 
@@ -107,9 +109,10 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 5: H4★ + V1★ + V1★ — dominant H + stacked V-pair
-  // H4★ cv=2.5, V1★ effective=0 cv=1.0. Total=4.5, fill=90% ✓
+  // Penalty retired: H4★ Hv≈2.49, V1★ P=1.25/Hv≈0.84. Total≈4.17, fill≈52% of
+  // rw=8. The dominant H4★ takes the left slot; the two V1★ stack on the right.
   // ---------------------------------------------------------------
-  it('5: H4★ + V1★ + V1★ → H(leaf, V(leaf,leaf)) (90% fill)', () => {
+  it('5: H4★ + V1★ + V1★ → H(leaf, V(leaf,leaf)) (~52% fill)', () => {
     const items = [H(1, 4), V(2, 1), V(3, 1)];
     const rows = buildRows(items, DESKTOP);
 
@@ -121,9 +124,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 6: H4★ + V2★ — H + V
-  // H4★ cv=2.5, V2★ effective=1 cv=1.0. Total=3.5, fill=70% < 90%
+  // Penalty retired: H4★ Hv≈2.49, V2★ P=1.75/Hv≈0.99. Total≈3.49, fill≈44% of rw=8.
   // ---------------------------------------------------------------
-  it('6: H4★ + V2★ → H + V (70% fill)', () => {
+  it('6: H4★ + V2★ → H + V (~44% fill)', () => {
     const items = [H(1, 4), V(2, 2)];
     const rows = buildRows(items, DESKTOP);
 
@@ -134,9 +137,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 7: H2★ + H2★ + H2★ — 3 horizontals
-  // H2★ cv=1.25, 3×1.25=3.75, fill=75% < 90% → row incomplete
+  // H2★ P=1.75, Hv≈1.76. 3×1.76≈5.29, fill≈66% of rw=8 → row incomplete.
   // ---------------------------------------------------------------
-  it('7: H2★ + H2★ + H2★ → 3 horizontals (75% fill)', () => {
+  it('7: H2★ + H2★ + H2★ → 3 horizontals (~66% fill)', () => {
     const items = [H(1, 2), H(2, 2), H(3, 2)];
     const rows = buildRows(items, DESKTOP);
 
@@ -150,7 +153,7 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 8: H1★ + V1★ + H1★ + V1★ + H1★ — 5-item row (3H + 2V)
-  // H1★ cv=1.0, V1★ effective=0 cv=1.0. 5×1.0=5.0, fill=100% ✓
+  // Penalty retired: H1★ Hv≈1.49, V1★ Hv≈0.84. 3×1.49 + 2×0.84 ≈ 6.15, fill≈77% of rw=8.
   // ---------------------------------------------------------------
   it('8: H1★ + V1★ + H1★ + V1★ + H1★ → 3H + 2V (5-item row)', () => {
     const items = [H(1, 1), V(2, 1), H(3, 1), V(4, 1), H(5, 1)];
@@ -181,8 +184,8 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 10: V1★ + V2★ + H5★ — all in one row at rw=8
-  // V1★ cv≈0.61, V2★ cv≈0.77, H5★ cv=5.0. Total≈6.38, fill≈79.7%
-  // Sequential fill takes all 3, best-fit completes
+  // Penalty retired: V1★ Hv≈0.84, V2★ Hv≈0.99, H5★ Hv≈2.98. Total≈4.81, fill≈60%
+  // of rw=8. Sequential fill takes all 3, best-fit completes.
   // ---------------------------------------------------------------
   it('10: V1★ + V2★ + H5★ → all in one row (no hero skip at rw=8)', () => {
     const items = [V(1, 1), V(2, 2), H(3, 5)];
@@ -225,21 +228,22 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 12: 10 mixed images — realistic collection
-  // With rw=8: H5★ cv=5.0, H4★ cv=3.5, V3★ cv≈1.07, H3★ cv=2.5,
-  //            V1★ cv≈0.61, H2★ cv=1.75, V2★ cv≈0.77
+  // Penalty retired; packing cost is the width-cost Hv against rw=8:
+  // H5★ Hv≈2.98, H4★ Hv≈2.49, V3★ Hv≈1.19, H3★ Hv≈2.11,
+  // V1★ Hv≈0.84, H2★ Hv≈1.76, V2★ Hv≈0.99
   // ---------------------------------------------------------------
   it('12: 10 mixed images — realistic collection end-to-end', () => {
     const items = [
-      H(1, 5), // cv=5.0
-      H(2, 4), // cv=3.5
-      V(3, 3), // eff=2, cv≈1.07
-      V(4, 3), // eff=2, cv≈1.07
-      H(5, 3), // cv=2.5
-      H(6, 3), // cv=2.5
-      H(7, 3), // cv=2.5
-      V(8, 1), // eff=0, cv≈0.61
-      H(9, 2), // cv=1.75
-      V(10, 2), // eff=1, cv≈0.77
+      H(1, 5), // Hv≈2.98
+      H(2, 4), // Hv≈2.49
+      V(3, 3), // eff=3, Hv≈1.19
+      V(4, 3), // eff=3, Hv≈1.19
+      H(5, 3), // Hv≈2.11
+      H(6, 3), // Hv≈2.11
+      H(7, 3), // Hv≈2.11
+      V(8, 1), // eff=1, Hv≈0.84
+      H(9, 2), // Hv≈1.76
+      V(10, 2), // eff=2, Hv≈0.99
     ];
     const rows = buildRows(items, DESKTOP);
 
@@ -287,9 +291,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 15: H4★ + H3★ + V1★ + H2★ + V1★ — with rw=8
-  // H4★ cv=3.5, H3★ cv=2.5, V1★ cv≈0.61, H2★ cv=1.75, V1★ cv≈0.61
-  // Sequential: 3.5(43.8%) + 2.5(75%) + 0.61(82.6%) + 1.75(104.5%✓) → complete at 4
-  // Actual: [1,2,3,4] → 3H + 1V
+  // Penalty retired; width-cost Hv: H4★≈2.49, H3★≈2.11, V1★≈0.84, H2★≈1.76
+  // Cumulative/8: 2.49(31%) + 2.11→4.60(58%) + 0.84→5.44(68%) + 1.76→7.21(90%✓)
+  // → complete at 4. Actual: [1,2,3,4] → 3H + 1V
   // ---------------------------------------------------------------
   it('15: H4★ + H3★ + V1★ + H2★ + V1★ → 3H + 1V first row', () => {
     const items = [H(1, 4), H(2, 3), V(3, 1), H(4, 2), V(5, 1)];
@@ -308,9 +312,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 16: H3★ + V1★ + V1★ + H3★ — sequential fill
-  // H3★ cv=1.67, V1★ cv=1.0
-  // Sequential: 1.67+1.0=2.67 (53%), +1.0=3.67 (73%), +1.67=5.34 (107%) ✓
-  // Sequential completes → 2H + 2V
+  // Penalty retired; width-cost Hv: H3★≈2.11, V1★≈0.84
+  // Cumulative/8: 2.11(26%) + 0.84→2.95(37%) + 0.84→3.79(47%) + 2.11→5.89(74%)
+  // These are the only four items, so they all land in the one row → 2H + 2V.
   // ---------------------------------------------------------------
   it('16: H3★ + V1★ + V1★ + H3★ → sequential fill (no best-fit needed)', () => {
     const items = [H(1, 3), V(2, 1), V(3, 1), H(4, 3)];
@@ -338,7 +342,7 @@ describe('buildRows characterization', () => {
   // ---------------------------------------------------------------
   // Test 18: H4★ + H4★ — 2 horizontals (100% fill)
   // ---------------------------------------------------------------
-  it('18: H4★ + H4★ → 2 horizontals (100% fill)', () => {
+  it('18: H4★ + H4★ → 2 horizontals (~62% fill)', () => {
     const items = [H(1, 4), H(2, 4)];
     const rows = buildRows(items, DESKTOP);
 
@@ -350,7 +354,7 @@ describe('buildRows characterization', () => {
   // ---------------------------------------------------------------
   // Test 19: H4★ + V3★ + V3★ — dominant H + stacked V-pair (100% fill)
   // ---------------------------------------------------------------
-  it('19: H4★ + V3★ + V3★ → H(leaf, V(leaf,leaf)) (100% fill)', () => {
+  it('19: H4★ + V3★ + V3★ → H(leaf, V(leaf,leaf)) (~61% fill)', () => {
     const items = [H(1, 4), V(2, 3), V(3, 3)];
     const rows = buildRows(items, DESKTOP);
 
@@ -361,9 +365,9 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 20: 5 H1★ images — single-row fallback
-  // H1★ cv=1.0, all same rating (eff=1)
-  // 3×1.0=3.0, fill=60% < 90% → isRowComplete fails for 3
-  // 5×1.0=5.0, fill=100% → all 5 fill into one row
+  // H1★ P=1.25, Hv≈1.49, all same rating (eff=1)
+  // 3×1.49≈4.47, fill≈56% of rw=8 → isRowComplete fails for 3
+  // 5×1.49≈7.46, fill≈93% → all 5 fill into one row
   // ---------------------------------------------------------------
   it('20: 5 H1★ images → single-row fallback', () => {
     const items = [H(1, 1), H(2, 1), H(3, 1), H(4, 1), H(5, 1)];
@@ -380,15 +384,15 @@ describe('buildRows characterization', () => {
   // ---------------------------------------------------------------
   it('21: large mixed collection (15 images) — all items consumed', () => {
     const items = [
-      H(1, 5), // cv=5.0
-      H(2, 4),
+      H(1, 5), // Hv≈2.98
+      H(2, 4), // Hv≈2.49
       V(3, 3),
-      V(4, 3), // cv=3.5, 1.07, 1.07
+      V(4, 3), // V3★ eff=3, Hv≈1.19 each (penalty retired)
       H(5, 3),
       H(6, 3),
-      H(7, 3), // cv=2.5 each
+      H(7, 3), // Hv≈2.11 each
       V(8, 2),
-      V(9, 2), // cv≈0.77 each
+      V(9, 2), // V2★ eff=2, Hv≈0.99 each
       H(10, 1),
       V(11, 1),
       H(12, 1),
@@ -448,7 +452,6 @@ describe('architecture types', () => {
       expect(img.ar).toBe('H');
       expect(img.numericAR).toBeCloseTo(1.7778, 3);
       expect(img.effectiveRating).toBe(4); // horizontal, no penalty
-      expect(img.componentValue).toBeCloseTo(3.5); // BASE_WEIGHT[4] × 1.0 (arFactor capped)
     });
 
     it('should convert a vertical image with no penalty (retired)', () => {
@@ -459,7 +462,6 @@ describe('architecture types', () => {
       expect(img.ar).toBe('V');
       expect(img.numericAR).toBeCloseTo(0.5625);
       expect(img.effectiveRating).toBe(3); // V3★ → eff 3 (penalty retired; was 2)
-      expect(img.componentValue).toBeCloseTo(1.5309, 3); // BASE_WEIGHT[3] × sqrt(0.5625/1.5)
     });
 
     it('should handle V1★ → effective 1 (penalty retired)', () => {
@@ -469,7 +471,6 @@ describe('architecture types', () => {
       expect(img.ar).toBe('V');
       expect(img.numericAR).toBeCloseTo(0.5625);
       expect(img.effectiveRating).toBe(1); // was 0 under the penalty
-      expect(img.componentValue).toBeCloseTo(0.7655, 3); // BASE_WEIGHT[1] × sqrt(0.5625/1.5)
     });
 
     it('should preserve source reference', () => {

--- a/tests/utils/rowCombination.characterization.test.ts
+++ b/tests/utils/rowCombination.characterization.test.ts
@@ -165,22 +165,18 @@ describe('buildRows characterization', () => {
   });
 
   // ---------------------------------------------------------------
-  // Test 9: V1★ + H5★ + H3★ + H3★ — no hero skip at rw=8
-  // V1★ cv≈0.61, H5★ cv=5.0, H3★ cv=2.5
-  // Sequential: 0.61+5.0=5.61 (70.2%), +2.5=8.11 (101.4%✓) → complete at 3 items
-  // Row 1: V1★+H5★+H3★ (ids [1,2,3]), remaining H3★ in row 2
+  // Test 9: V1★ + H5★ + H3★ + H3★ — width-cost (Hv) packing at rw=8
+  // Hv: V1≈0.84, H5≈2.98, H3≈2.11. Sum of all four ≈ 8.04 (fill≈100.5%), so
+  // under the cheaper Hv scale all four pack into ONE balanced 2×2 row at AR
+  // 1.316 — vs the old cv scale which closed at 3 and orphaned the last H3★.
   // ---------------------------------------------------------------
-  it('9: V1★ + H5★ + H3★ + H3★ → sequential fill, 3 in first row', () => {
+  it('9: V1★ + H5★ + H3★ + H3★ → one 2×2 row under Hv packing', () => {
     const items = [V(1, 1), H(2, 5), H(3, 3), H(4, 3)];
     const rows = buildRows(items, DESKTOP);
 
-    // Row 1: V1★+H5★+H3★ → H(V-pair, leaf)
-    expect(rows).toHaveLength(2);
-    expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(V(L(1),L(2)),L(3))');
-
-    // Row 2: remaining H3★
-    expect(rowIds(rows[1]!)).toEqual([4]);
+    expect(rows).toHaveLength(1);
+    expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
+    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(V(L(1),L(2)),V(L(3),L(4)))');
   });
 
   // ---------------------------------------------------------------
@@ -254,15 +250,13 @@ describe('buildRows characterization', () => {
     const allIds = rows.flatMap(r => rowIds(r)).sort((a, b) => a - b);
     expect(allIds).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-    // Row 1: H5★(5.0) + H4★(3.5) = 8.5, fill≈106% (≤ MAX). The AR estimate for
-    // {H5,H4} already meets the AR floor, so the row closes at 2 items.
-    expect(rowIds(rows[0]!)).toEqual([1, 2]);
-
-    // Row 2: V3★ + V3★ + H3★ + H3★ + H3★ → 3H + 2V
-    expect(rowIds(rows[1]!)).toEqual([3, 4, 5, 6, 7]);
-
-    // Row 3: V1★ + H2★ + V2★ → 1H + 2V
-    expect(rowIds(rows[2]!)).toEqual([8, 9, 10]);
+    // Hv packs cheaper than cv, so each row holds more. Row 1 now takes 4 items
+    // (H5★+H4★ + the two V3★) at AR 2.02; Row 2 takes the three H3★ plus V1★+H2★
+    // (5 items, AR 1.90). That leaves the trailing V2★ as a lone leftover row —
+    // a low-rated vertical orphan, the expected leftover of the denser packing.
+    expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
+    expect(rowIds(rows[1]!)).toEqual([5, 6, 7, 8, 9]);
+    expect(rowIds(rows[2]!)).toEqual([10]);
 
     expect(rows).toHaveLength(3);
   });
@@ -274,11 +268,12 @@ describe('buildRows characterization', () => {
     const items = [H(1, 3), H(2, 3), H(3, 3), H(4, 3), H(5, 3), H(6, 3)];
     const rows = buildRows(items, DESKTOP);
 
-    // H3★ cv=1.67. 3×1.67=5.0 → 100% → row complete
-    // 3 H3★ per row
+    // Hv(H3)≈2.108. 4×2.108=8.43 → 105% fills the rw=8 budget, so the first row
+    // takes 4 (a balanced 2×2 at AR 1.778) and the remaining 2 pair off — vs the
+    // old cv scale (cv 2.5) which fit only 3 per row.
     expect(rows).toHaveLength(2);
-    expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
-    expect(rowIds(rows[1]!)).toEqual([4, 5, 6]);
+    expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
+    expect(rowIds(rows[1]!)).toEqual([5, 6]);
   });
 
   // ---------------------------------------------------------------
@@ -329,24 +324,18 @@ describe('buildRows characterization', () => {
   });
 
   // ---------------------------------------------------------------
-  // Test 17: V4★ + H3★ + H4★ + H1★ — with rw=8
-  // V4★ eff=3 cv≈1.53, H3★ cv=2.5, H4★ cv=3.5, H1★ cv=1.25
-  // Sequential: 1.53(19.1%) + 2.5(50.4%) + 3.5(94.1%✓) → complete at 3
-  // Actual: [1,2,3] → 2H + 1V, remaining [4] alone
+  // Test 17: V4★ + H3★ + H4★ + H1★ — width-cost (Hv) packing at rw=8
+  // Hv: V4≈2.05, H3≈2.11, H4≈2.49, H1≈1.49. Sum ≈ 8.14 (fill≈102%), so under
+  // the cheaper Hv scale all four pack into ONE balanced 2×2 row at AR 1.316 —
+  // vs the old cv scale which closed at 3 and orphaned the trailing H1★.
   // ---------------------------------------------------------------
-  it('17: sequential fill — V4★ + H3★ + H4★ + H1★', () => {
+  it('17: sequential fill — V4★ + H3★ + H4★ + H1★ → one 2×2 row', () => {
     const items = [V(1, 4), H(2, 3), H(3, 4), H(4, 1)];
     const rows = buildRows(items, DESKTOP);
 
-    // Row 1: V4★ + H3★ + H4★ → 2H + 1V
-    expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
-    expect(rows[0]!.components).toHaveLength(3);
-
-    // Row 2: H1★ alone
-    expect(rowIds(rows[1]!)).toEqual([4]);
-
-    const allIds = rows.flatMap(r => rowIds(r)).sort((a, b) => a - b);
-    expect(allIds).toEqual([1, 2, 3, 4]);
+    expect(rows).toHaveLength(1);
+    expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
+    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(V(L(1),L(2)),V(L(3),L(4)))');
   });
 
   // ---------------------------------------------------------------
@@ -389,7 +378,8 @@ describe('buildRows characterization', () => {
 
   // ---------------------------------------------------------------
   // Test 21: Large mixed collection — 15 images
-  // With rw=8, H5★ is no longer standalone (cv=5.0, fill=62.5% < 95%)
+  // With rw=8, a normal H5★ never solos: Hv≈2.98, fraction≈0.37 < the 0.5
+  // HERO_SOLO_WIDTH_FRACTION bar (only a wide panorama would clear it).
   // ---------------------------------------------------------------
   it('21: large mixed collection (15 images) — all items consumed', () => {
     const items = [
@@ -415,9 +405,10 @@ describe('buildRows characterization', () => {
     const allIds = rows.flatMap(r => rowIds(r)).sort((a, b) => a - b);
     expect(allIds).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
 
-    // First row: H5★+H4★ (5.0+3.5=8.5, 106% ≤ MAX). The AR estimate for {H5,H4}
-    // meets the AR floor, so the row closes at 2 items → [1,2].
-    expect(rowIds(rows[0]!)).toEqual([1, 2]);
+    // First row under Hv: H5★+H4★ (Hv 2.98+2.49=5.48, only 68%) doesn't fill the
+    // budget, so the two trailing V3★ join → [1,2,3,4] at AR 2.02. (Under the old
+    // cv scale H5+H4 = 8.5 = 106% closed the row at 2.)
+    expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
   });
 
   // ---------------------------------------------------------------

--- a/tests/utils/rowCombination.composition.test.ts
+++ b/tests/utils/rowCombination.composition.test.ts
@@ -451,8 +451,8 @@ describe('buildAtomic — directional prominence (Task 1.1)', () => {
   //   - NEW prominence: V5★ P=5.0 ≫ H3★ P=2.5, so the prominence-equity-optimal
   //     tree pairs the verticals side by side → the 5★ vertical out-sizes the 3★s.
   // This assertion FLIPS RED→GREEN on the cv→prominence swap in leafShares:
-  // revert the leaf value to `ac.img.componentValue` and it fails (V5★ ≈ 0.12
-  // < H3★ ≈ 0.22). Larger sizing wins compound downstream (Phase 2 per-row
+  // under the retired cv value-model the leaf value put V5★ ≈ 0.12 < H3★ ≈ 0.22
+  // and this failed. Larger sizing wins compound downstream (Phase 2 per-row
   // targetAR + the Hv width-cost packing in later phases).
   it('sizes a 5★ vertical larger than its 3★ horizontal row-mates (equity tiebreak picks prominence)', () => {
     const imgs = [H(1, 3), H(2, 3), createVerticalImage(3, 3), createVerticalImage(4, 5)].map(i =>

--- a/tests/utils/rowCombination.composition.test.ts
+++ b/tests/utils/rowCombination.composition.test.ts
@@ -13,6 +13,8 @@ import {
   type AtomicComponent,
   type BoxTree,
   buildAtomic,
+  buildRows,
+  rowTargetAR,
   toImageType,
 } from '@/app/utils/rowCombination';
 import {
@@ -461,6 +463,33 @@ describe('buildAtomic — directional prominence (Task 1.1)', () => {
     // V5★ (id=4) must claim more area than either H3★ (id=1 or id=2).
     expect(shares.get(4)).toBeGreaterThan(shares.get(1)!);
     expect(shares.get(4)).toBeGreaterThan(shares.get(2)!);
+  });
+});
+
+describe('rowTargetAR — per-row target AR from peak height-demand (Task 2.1)', () => {
+  // The per-row target AR pulls toward a taller (lower-AR) shape in proportion to
+  // the row's peak Vv ABOVE the wide-image ceiling (ROW_TARGET_AR_VV_LOW). A bland
+  // all-horizontal row (peak Vv ≈ 1.19, below the ceiling) keeps the baseline; a row
+  // holding a 5★ vertical (peak Vv ≈ 2.98) is pulled below it so the hero sizes taller.
+  // A single-anchor pull (Vv / REF) pulled even bland rows off baseline — see the
+  // 2026-06-10 plan revision — hence the wide-image Vv ceiling gates the pull.
+  it('pulls a hero row toward a taller target than a bland row, leaving bland at baseline', () => {
+    const bland = [H(1, 3), H(2, 3)].map(i => toImageType(i, 10));
+    const hero = [H(1, 3), createVerticalImage(2, 5)].map(i => toImageType(i, 10));
+    expect(rowTargetAR(hero, 2.0)).toBeLessThan(rowTargetAR(bland, 2.0));
+    expect(rowTargetAR(bland, 2.0)).toBeCloseTo(2.0, 5); // bland row keeps the baseline
+  });
+
+  it('buildRows composes a hero row taller via the per-row target (end-to-end wiring)', () => {
+    // [H3,H3,V3,V5] land in one row at rowWidth 10. With the neutral baseline target the row
+    // composes wide (AR ≈ 2.0) and the 5★ vertical renders short; buildRows derives a per-row
+    // target from the row's peak Vv (≈2.98) and composes it much taller (AR ≈ 1.17), giving the
+    // hero full height. Reverting the buildRows→rowTargetAR wiring snaps this back toward ≈2.0.
+    const items = [H(1, 3), H(2, 3), createVerticalImage(3, 3), createVerticalImage(4, 5)];
+    const rows = buildRows(items, 10, 1.457);
+    const heroRow = rows.find(r => r.components.some(c => (c as { id?: number }).id === 4))!;
+    const heroRowAR = calculateBoxTreeAspectRatio(heroRow.boxTree, 10);
+    expect(heroRowAR).toBeLessThan(1.5); // pulled well below the baseline-target composition (~2.0)
   });
 });
 

--- a/tests/utils/rowCombination.composition.test.ts
+++ b/tests/utils/rowCombination.composition.test.ts
@@ -11,6 +11,7 @@ import { LAYOUT } from '@/app/constants';
 import {
   acToBoxTree,
   type AtomicComponent,
+  type BoxTree,
   buildAtomic,
   toImageType,
 } from '@/app/utils/rowCombination';
@@ -22,7 +23,52 @@ import {
   createHorizontalImage,
   createImageContent,
   createVerticalImage,
+  H,
 } from '@/tests/fixtures/contentFixtures';
+
+// ---------------------------------------------------------------------------
+// Area-share walker — mirrors leafShares geometry in rowCombination.ts:
+//   leaf → 1; hPair → split ∝ child AR; vStack → split ∝ 1/child AR
+// Returns a map from content.id to fractional area [0, 1].
+// ---------------------------------------------------------------------------
+function areaShares(tree: BoxTree, parentShare = 1): Map<number, number> {
+  if (tree.type === 'leaf') {
+    const result = new Map<number, number>();
+    const id = (tree.content as { id?: number }).id;
+    if (id !== undefined) result.set(id, parentShare);
+    return result;
+  }
+  const [left, right] = tree.children;
+  const leftAR = aspectOf(left);
+  const rightAR = aspectOf(right);
+  const sum = leftAR + rightAR;
+  const isH = tree.direction === 'horizontal';
+  const leftFactor = isH ? leftAR / sum : rightAR / sum; // vStack: area ∝ 1/AR → left gets rightAR/sum
+  const rightFactor = isH ? rightAR / sum : leftAR / sum;
+  const leftShares = areaShares(left, parentShare * leftFactor);
+  const rightShares = areaShares(right, parentShare * rightFactor);
+  return new Map([...leftShares, ...rightShares]);
+}
+
+/** Intrinsic AR of a BoxTree node (assuming all leaf children have fixed AR). */
+function aspectOf(tree: BoxTree): number {
+  if (tree.type === 'leaf') {
+    const item = tree.content as {
+      aspectRatio?: number;
+      imageWidth?: number;
+      imageHeight?: number;
+    };
+    if (item.aspectRatio !== undefined) return item.aspectRatio;
+    if (item.imageWidth !== undefined && item.imageHeight !== undefined && item.imageHeight > 0) {
+      return item.imageWidth / item.imageHeight;
+    }
+    return 1;
+  }
+  const [l, r] = tree.children;
+  const lAR = aspectOf(l);
+  const rAR = aspectOf(r);
+  return tree.direction === 'horizontal' ? lAR + rAR : (lAR * rAR) / (lAR + rAR);
+}
 
 const DESKTOP = LAYOUT.desktopSlotWidth;
 const TARGET_AR = 1.5;
@@ -389,6 +435,32 @@ describe('buildAtomic — AR fitness', () => {
     // more evenly — so the upper bound allows a little above target.
     expect(ar).toBeGreaterThanOrEqual(1.0);
     expect(ar).toBeLessThan(1.4);
+  });
+});
+
+describe('buildAtomic — directional prominence (Task 1.1)', () => {
+  // The equity tiebreak (within AR_EQUITY_BAND of the AR-optimal candidate)
+  // is what actually decides this row. Two candidates tie on row AR:
+  //   h(v(H3,H3), v(V3,V5))  — the verticals STACKED (each ~0.12 of the row)
+  //   h(v(H3,H3), h(V3,V5))  — the verticals SIDE BY SIDE (each ~0.28 of the row)
+  // The leaf value fed to equitySpread decides which wins:
+  //   - OLD cv value:  V5★ cv≈2.14 < H3★ cv 2.50, so the cv-equity-optimal tree
+  //     STACKS the verticals → the 5★ vertical renders SMALLER than each 3★ H.
+  //   - NEW prominence: V5★ P=5.0 ≫ H3★ P=2.5, so the prominence-equity-optimal
+  //     tree pairs the verticals side by side → the 5★ vertical out-sizes the 3★s.
+  // This assertion FLIPS RED→GREEN on the cv→prominence swap in leafShares:
+  // revert the leaf value to `ac.img.componentValue` and it fails (V5★ ≈ 0.12
+  // < H3★ ≈ 0.22). Larger sizing wins compound downstream (Phase 2 per-row
+  // targetAR + the Hv width-cost packing in later phases).
+  it('sizes a 5★ vertical larger than its 3★ horizontal row-mates (equity tiebreak picks prominence)', () => {
+    const imgs = [H(1, 3), H(2, 3), createVerticalImage(3, 3), createVerticalImage(4, 5)].map(i =>
+      toImageType(i, 10)
+    );
+    const tree = acToBoxTree(buildAtomic(imgs, 1.457, 10));
+    const shares = areaShares(tree);
+    // V5★ (id=4) must claim more area than either H3★ (id=1 or id=2).
+    expect(shares.get(4)).toBeGreaterThan(shares.get(1)!);
+    expect(shares.get(4)).toBeGreaterThan(shares.get(2)!);
   });
 });
 

--- a/tests/utils/rowCombination.heroAcceptance.test.ts
+++ b/tests/utils/rowCombination.heroAcceptance.test.ts
@@ -1,0 +1,15 @@
+import { buildRows } from '@/app/utils/rowCombination';
+import { createPanorama,H } from '@/tests/fixtures/contentFixtures';
+
+describe('acceptance: wide 5★ panorama prominence (was isFullWidthHero on 0180)', () => {
+  it('gives a wide 5★ panorama its own row at medium density', () => {
+    const rows = buildRows([H(1, 3), H(2, 3), createPanorama(3, 5), H(4, 3)], 10, 1.5);
+    const solo = rows.find(r => r.components.length === 1 && r.components[0]!.id === 3);
+    expect(solo).toBeDefined();
+  });
+  it('lets a wide 5★ panorama share at high density', () => {
+    const rows = buildRows([H(1, 3), H(2, 3), createPanorama(3, 5), H(4, 3)], 20, 1.5);
+    const soloPano = rows.find(r => r.components.length === 1 && r.components[0]!.id === 3);
+    expect(soloPano).toBeUndefined();
+  });
+});

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -5,7 +5,7 @@
 
 import { DENSITY_ROW_WIDTH_MULTIPLIER, LAYOUT } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
-import { getItemComponentValue } from '@/app/utils/contentRatingUtils';
+import { getItemComponentValue, getWidthCost } from '@/app/utils/contentRatingUtils';
 import type { ImageType, RowResult } from '@/app/utils/rowCombination';
 import {
   acToBoxTree,
@@ -519,8 +519,11 @@ describe('buildRows', () => {
       ];
       const rows = buildRows(items, DESKTOP);
       for (const row of rows) {
+        // Fill is measured with the actual Stage-1 packing cost (width-cost Hv),
+        // which is what buildRows fills against — not the legacy cv. (Summing cv
+        // here would over-count verticals now that the vertical penalty is gone.)
         const totalCV = row.components.reduce(
-          (sum: number, item: AnyContentModel) => sum + getItemComponentValue(item),
+          (sum: number, item: AnyContentModel) => sum + getWidthCost(item),
           0
         );
         const fill = totalCV / DESKTOP;
@@ -581,12 +584,12 @@ describe('buildRows', () => {
   });
 
   describe('2×2 nested layout', () => {
-    it('should build a 2×2 nested boxTree for a 4-item row with dominant vertical', () => {
-      // Real Row 15 scenario: V1★, V2★, V4★, H3★
-      // V4★ base rating 4 → effective rating 3 (vertical penalty)
+    it('builds a balanced two-pair boxTree for a 4-item mixed row (penalty-free ratings)', () => {
+      // Real Row 15 scenario: V1★, V2★, V4★, H3★. Vertical penalty retired, so
+      // V4★ now balances at its true rating 4 (was effective 3 under the penalty).
       const v1 = createVerticalImage(1, 1); // V1★ → effective 1
       const v2 = createVerticalImage(2, 2); // V2★ → effective 2
-      const v4 = createVerticalImage(3, 4); // V4★ → effective 3
+      const v4 = createVerticalImage(3, 4); // V4★ → effective 4
       const h3 = createHorizontalImage(4, 3); // H3★ → effective 3
 
       const items = [v1, v2, v4, h3];
@@ -594,21 +597,22 @@ describe('buildRows', () => {
 
       expect(rows).toHaveLength(1);
 
-      // Builds: H[ V[ H[v1,v2], v4 ], h3 ] — a vertical-stack column on the
-      // left and the H3★ as the right leaf.
+      // Penalty-free point-balance splits [V1,V2 | V4,H3] (points 1+2 | 4+3 → halves
+      // 3 | 7) giving H( H(v1,v2), V(v4,h3) ): a horizontal pair on the left, a
+      // vertical stack on the right.
       const boxTree = rows[0]?.boxTree;
       expect(boxTree?.type).toBe('combined');
       if (boxTree?.type === 'combined') {
         expect(boxTree.direction).toBe('horizontal');
-        // Left child is the vertical stack column
+        // Left child: horizontal pair of the two low-rated verticals
         expect(boxTree.children[0].type).toBe('combined');
         if (boxTree.children[0].type === 'combined') {
-          expect(boxTree.children[0].direction).toBe('vertical');
+          expect(boxTree.children[0].direction).toBe('horizontal');
         }
-        // Right child is the H3★ leaf
-        expect(boxTree.children[1].type).toBe('leaf');
-        if (boxTree.children[1].type === 'leaf') {
-          expect(boxTree.children[1].content).toEqual(h3);
+        // Right child: vertical stack of V4★ + H3★
+        expect(boxTree.children[1].type).toBe('combined');
+        if (boxTree.children[1].type === 'combined') {
+          expect(boxTree.children[1].direction).toBe('vertical');
         }
       }
     });
@@ -810,12 +814,12 @@ describe('toImageType', () => {
     expect(result.ar).toBe('V');
   });
 
-  it('should apply vertical penalty to effective rating', () => {
-    // V3*: rating=3, effectiveRating=2 (penalty -1)
+  it('applies no vertical penalty — a V3★ and an H3★ have equal effective rating', () => {
+    // Vertical penalty retired (directional prominence): directionality is now
+    // expressed by AR extremeness downstream, not by demoting the rating.
     const v3 = createVerticalImage(1, 3);
-    expect(toImageType(v3, DESKTOP).effectiveRating).toBe(2);
+    expect(toImageType(v3, DESKTOP).effectiveRating).toBe(3); // was 2 under the penalty
 
-    // H3*: no penalty
     const h3 = createHorizontalImage(2, 3);
     expect(toImageType(h3, DESKTOP).effectiveRating).toBe(3);
   });

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -3,7 +3,7 @@
  * Tests isRowComplete, buildRows, and the row composition helpers.
  */
 
-import { LAYOUT } from '@/app/constants';
+import { DENSITY_ROW_WIDTH_MULTIPLIER, LAYOUT } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import { getItemComponentValue } from '@/app/utils/contentRatingUtils';
 import type { ImageType, RowResult } from '@/app/utils/rowCombination';
@@ -13,9 +13,7 @@ import {
   buildRows,
   estimateRowAR,
   hChain,
-  HERO_FULLWIDTH_MAX_ROWWIDTH,
   hPair,
-  isFullWidthHero,
   isRowComplete,
   MAX_FILL_RATIO,
   MAX_ROW_IMAGES,
@@ -32,9 +30,7 @@ import {
   createCollectionContent,
   createGifContent,
   createHorizontalImage,
-  createImageContent,
   createPanorama,
-  createSquareImage,
   createTextContent,
   createVerticalImage,
 } from '@/tests/fixtures/contentFixtures';
@@ -83,59 +79,62 @@ describe('isRowComplete', () => {
       expect(isRowComplete([], DESKTOP)).toBe(false);
     });
 
-    it('should return true for three H3* images (3 × 2.5 = 7.5, fill=93.8%)', () => {
+    it('should return false for three H3* images (3 × Hv 2.108 = 6.32, fill=79.1%)', () => {
       const items = [
         createHorizontalImage(1, 3),
         createHorizontalImage(2, 3),
         createHorizontalImage(3, 3),
       ];
-      // 7.5/8=93.8% — above 90% threshold
+      // Hv: 6.32/8=79.1% — below 90% threshold (under cv it was 93.8%; Hv < cv so
+      // a third H3 no longer completes the row — four are needed, see below).
+      expect(isRowComplete(items, DESKTOP)).toBe(false);
+    });
+
+    it('should return true for four H3* images (4 × Hv 2.108 = 8.43, fill=105.4%)', () => {
+      const items = Array.from({ length: 4 }, (_, i) => createHorizontalImage(i + 1, 3));
+      // Hv: 8.43/8=105.4% — within the 90-115% band.
       expect(isRowComplete(items, DESKTOP)).toBe(true);
     });
 
-    it('should return false for five H1* images (5 × 1.25 = 6.25, fill=78.1%)', () => {
-      // 6.25/8=78.1% — below 90% threshold
+    it('should return true for five H1* images (5 × Hv 1.491 = 7.45, fill=93.2%)', () => {
+      // Hv: 7.45/8=93.2% — above 90% threshold (under cv it was 78.1%, incomplete).
       const items = Array.from({ length: 5 }, (_, i) => createHorizontalImage(i + 1, 1));
-      expect(isRowComplete(items, DESKTOP)).toBe(false);
+      expect(isRowComplete(items, DESKTOP)).toBe(true);
     });
   });
 
   describe('threshold behavior', () => {
-    it('should return true at ~91% fill (H4*+H3*+H1*)', () => {
-      // H4*(3.5) + H3*(2.5) + H1*(1.25) = 7.25 → 90.6% ✓
-      const items = [
-        createHorizontalImage(1, 4),
-        createHorizontalImage(2, 3),
-        createHorizontalImage(3, 1),
-      ];
+    it('should return true at ~93% fill (5×H1*)', () => {
+      // Hv: 5 × 1.491 = 7.45 → 93.2% ✓ (within the 90-115% band)
+      const items = Array.from({ length: 5 }, (_, i) => createHorizontalImage(i + 1, 1));
       expect(isRowComplete(items, DESKTOP)).toBe(true);
     });
 
-    it('should return true at ~94% fill (H5*+H3*)', () => {
-      // H5*(5.0) + H3*(2.5) = 7.5 → 93.8% ✓
-      const items = [createHorizontalImage(1, 5), createHorizontalImage(2, 3)];
-      expect(isRowComplete(items, DESKTOP)).toBe(true);
-    });
-
-    it('should return true at ~106% fill (H5*+H4*, within 115% cap)', () => {
-      // H5*(5.0) + H4*(3.5) = 8.5 → 106.3% ✓
-      const items = [createHorizontalImage(1, 5), createHorizontalImage(2, 4)];
-      expect(isRowComplete(items, DESKTOP)).toBe(true);
-    });
-
-    it('should return false when fill exceeds 115% (overfill cap)', () => {
-      // H5*(5.0) + H5*(5.0) = 10.0 → 125% — exceeds cap
-      const items = [createHorizontalImage(1, 5), createHorizontalImage(2, 5)];
-      expect(isRowComplete(items, DESKTOP)).toBe(false);
-    });
-
-    it('should return false for catastrophic overfill like 150%+', () => {
-      // H5*(5.0) + H5*(5.0) + H3*(2.5) = 12.5 → 156%
+    it('should return true at ~101% fill (H5*+H5*+H3*)', () => {
+      // Hv: 2.981 + 2.981 + 2.108 = 8.07 → 100.9% ✓
       const items = [
         createHorizontalImage(1, 5),
         createHorizontalImage(2, 5),
         createHorizontalImage(3, 3),
       ];
+      expect(isRowComplete(items, DESKTOP)).toBe(true);
+    });
+
+    it('should return true at ~112% fill (3×H5*, within 115% cap)', () => {
+      // Hv: 3 × 2.981 = 8.94 → 111.8% ✓
+      const items = Array.from({ length: 3 }, (_, i) => createHorizontalImage(i + 1, 5));
+      expect(isRowComplete(items, DESKTOP)).toBe(true);
+    });
+
+    it('should return false when fill exceeds 115% (overfill cap)', () => {
+      // Hv: 4×H4* = 4 × 2.494 = 9.98 → 124.7% — exceeds cap
+      const items = Array.from({ length: 4 }, (_, i) => createHorizontalImage(i + 1, 4));
+      expect(isRowComplete(items, DESKTOP)).toBe(false);
+    });
+
+    it('should return false for catastrophic overfill like 150%+', () => {
+      // Hv: 6×H3* = 6 × 2.108 = 12.65 → 158%
+      const items = Array.from({ length: 6 }, (_, i) => createHorizontalImage(i + 1, 3));
       expect(isRowComplete(items, DESKTOP)).toBe(false);
     });
 
@@ -257,26 +256,28 @@ describe('buildRows', () => {
   });
 
   it('should work with rowWidth=4 (tablet)', () => {
-    // H4* cv=3.5, fill=3.5/4=87.5% < 90% — not complete as a pair
-    // Each H4* fills 87.5% alone — two H4* go to separate rows (each hero)
+    // Two normal H4★ landscapes (AR 1.78, extremeness < 2) are NOT solo-eligible,
+    // so they pair into one row rather than each claiming a full-width row. (Only
+    // extreme-AR panoramas solo; a normal landscape never does — see isSoloHero.)
     const items = [createHorizontalImage(1, 4), createHorizontalImage(2, 4)];
     const rows = buildRows(items, 4);
-    expect(rows).toHaveLength(2);
-    expect(rows[0]?.components).toHaveLength(1);
-    expect(rows[1]?.components).toHaveLength(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.components).toHaveLength(2);
   });
 
   it('should work with rowWidth=3 (small tablet)', () => {
-    // H1* cv=1.25, 2×1.25=2.5/3=83.3% < MIN_FILL, 3×1.25=3.75/3=125% > MAX
-    // Overfill accepted (125% ≤ 135%) to avoid underfilled row
+    // Hv(H1)≈1.491. Two H1★ = 2.98/3 = 99.4% — within the fill band, so the row
+    // closes cleanly at 2 and the third H1★ forms a second row (under cv the row
+    // needed all 3 at 125% overfill). All items preserved.
     const items = [
       createHorizontalImage(1, 1),
       createHorizontalImage(2, 1),
       createHorizontalImage(3, 1),
     ];
     const rows = buildRows(items, 3);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.components).toHaveLength(3);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.components.map(c => c.id)).toEqual([1, 2]);
+    expect(rows[1]?.components.map(c => c.id)).toEqual([3]);
   });
 
   it('should put H4* + V3* + V3* in one row', () => {
@@ -380,10 +381,11 @@ describe('buildRows', () => {
   });
 
   describe('standalone promotion in greedy fill', () => {
-    it('should split H3★+H5★ | H3★+H3★ across two rows with rw=8', () => {
-      // H3★(2.5) + H5★(5.0) = 7.5, fill=93.8% ✓. The V3 estimate for {H3,H5}
-      // meets the AR floor at 2 items, so the row closes there (was 3 under V1).
-      // Remaining H3★+H3★ form the second row.
+    it('should pack H3★+H5★+H3★+H3★ into one 2×2 row with rw=8', () => {
+      // Hv: H3≈2.11, H5≈2.98. Sum of all four ≈ 9.31 (116%) overshoots, but the
+      // first three (2.11+2.98+2.11=7.20, 90%) close the row — the fourth H3★ then
+      // joins via AR-floor expansion into a single balanced row. Under the cheaper
+      // Hv scale these no longer split (cv split them 2+2).
       const items = [
         createHorizontalImage(1, 3),
         createHorizontalImage(2, 5),
@@ -391,28 +393,22 @@ describe('buildRows', () => {
         createHorizontalImage(4, 3),
       ];
       const rows = buildRows(items, DESKTOP);
-      expect(rows).toHaveLength(2);
-      // First row: H3★+H5★ (fill=93.8%)
-      const row0Ids = rows[0]?.components.map(c => c.id);
-      expect(row0Ids).toEqual([1, 2]);
-      // Second row: remaining H3★+H3★
-      const row1Ids = rows[1]?.components.map(c => c.id);
-      expect(row1Ids).toEqual([3, 4]);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.components.map(c => c.id)).toEqual([1, 2, 3, 4]);
     });
 
-    it('should split H4★+H5★ | H3★ across two rows with rw=8', () => {
-      // H4★(3.5) + H5★(5.0) = 8.5, fill=106% ≤ MAX. The V3 estimate for {H4,H5}
-      // meets the AR floor at 2 items, so the row closes there (was all 3 under
-      // V1). The trailing H3★ becomes its own row.
+    it('should pack H4★+H5★+H3★ into one row with rw=8', () => {
+      // Hv: H4≈2.49 + H5≈2.98 = 5.48 (68%) doesn't fill, so the trailing H3★
+      // (2.11) joins → one 3-item row at 95% fill (under cv, H4+H5 = 8.5 = 106%
+      // closed the row at 2 and orphaned the H3★).
       const items = [
         createHorizontalImage(1, 4),
         createHorizontalImage(2, 5),
         createHorizontalImage(3, 3),
       ];
       const rows = buildRows(items, DESKTOP);
-      expect(rows).toHaveLength(2);
-      expect(rows[0]?.components.map(c => c.id)).toEqual([1, 2]);
-      expect(rows[1]?.components.map(c => c.id)).toEqual([3]);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.components.map(c => c.id)).toEqual([1, 2, 3]);
     });
 
     it('should NOT skip non-standalone items that overfill', () => {
@@ -618,17 +614,18 @@ describe('buildRows', () => {
     });
 
     it('should keep a 4-item row horizontal at the root with only 1 vertical', () => {
-      // 4 items but only 1 vertical - can't form top pair
+      // 4 items, only 1 vertical. Sized at rw=8 so Hv packs all four into one row
+      // (at rw=5 the cheaper Hv scale closes the row at 3 and orphans the V1★).
       const h1a = createHorizontalImage(1, 1);
       const h1b = createHorizontalImage(2, 1);
-      const h2 = createHorizontalImage(3, 2);
+      const h1c = createHorizontalImage(3, 1);
       const v1 = createVerticalImage(4, 1);
 
-      const items = [h1a, h1b, h2, v1];
-      const rows = buildRows(items, 5);
+      const items = [h1a, h1b, h1c, v1];
+      const rows = buildRows(items, 8);
 
       expect(rows).toHaveLength(1);
-      // BoxTree should be flat horizontal (no vertical stacking)
+      // Row root is horizontal (rows are horizontal by definition).
       const boxTree = rows[0]?.boxTree;
       expect(boxTree?.type).toBe('combined');
       if (boxTree?.type === 'combined') {
@@ -1055,11 +1052,12 @@ describe('buildRows AR-aware fill', () => {
 // ===================== buildRows fill at constant MIN_FILL =====================
 
 describe('buildRows fill at constant MIN_FILL', () => {
-  it('rowWidth=12 packs 4 H items per row at the constant 0.9 fill bar', () => {
-    // The fill bar is a constant MIN_FILL (0.9), no longer rowWidth-scaled:
-    // 3×r3 + 1×r4 = cv 11/12 = 92% ≥ 0.9 completes the row after 4 items.
-    // Density itself now comes from the rowWidth = chunkSize×2.5 mapping rather
-    // than a scaled fill bar.
+  it('rowWidth=12 packs 5 H items per row at the constant 0.9 fill bar', () => {
+    // The fill bar is a constant MIN_FILL (0.9), no longer rowWidth-scaled.
+    // Under the width-cost (Hv) scale a 3★ landscape costs ≈2.108 (was cv 2.5),
+    // so a rw=12 row reaches the 90% bar after 5 items (≈4×2.108 + 2.494 = 10.93,
+    // 91%) instead of 4. Density itself comes from rowWidth = chunkSize ×
+    // DENSITY_ROW_WIDTH_MULTIPLIER (calibrated so default density is unchanged).
     const items = [
       createHorizontalImage(1, 3),
       createHorizontalImage(2, 3),
@@ -1069,10 +1067,13 @@ describe('buildRows fill at constant MIN_FILL', () => {
       createHorizontalImage(6, 3),
     ];
     const rows = buildRows(items, 12);
-    expect(rows[0]!.components.length).toBe(4);
+    expect(rows[0]!.components.length).toBe(5);
   });
 
-  it('rowWidth=8 (default) — 3 H items per row at cv 7.5 hits 94% fill', () => {
+  it('rowWidth=8 — 4 H3★ per row under Hv (4 × 2.108 = 8.43, 105% fill)', () => {
+    // Under cv (2.5) only 3 fit per rw=8 row; under the cheaper Hv (2.108) four
+    // pack to 105% — the K calibration in contentLayout.ts compensates at the
+    // density level so a DEFAULT-density collection keeps its old per-row count.
     const items = [
       createHorizontalImage(1, 3),
       createHorizontalImage(2, 3),
@@ -1080,7 +1081,73 @@ describe('buildRows fill at constant MIN_FILL', () => {
       createHorizontalImage(4, 3),
     ];
     const rows = buildRows(items, 8);
-    expect(rows[0]!.components.length).toBe(3);
+    expect(rows[0]!.components.length).toBe(4);
+  });
+});
+
+// ===================== Density calibration (Hv vs cv) =====================
+// Locks the DENSITY_ROW_WIDTH_MULTIPLIER (K) so the switch from the cv packing
+// scale to the width-cost Hv scale does NOT change how many normal 3★ landscapes
+// pack per row at default density. Recorded baseline on the OLD cv code:
+//   buildRows(12×H3, Math.round(4 × 2.5) = 10, 1.5) → row 0 holds 4 items.
+// After switching packing to Hv (H3 cost 2.5 → 2.108, ~30% cheaper) K was retuned
+// from 2.5 to DENSITY_ROW_WIDTH_MULTIPLIER so row 0 still holds 4. The test reads
+// the shared constant so code and calibration can never drift apart.
+
+describe('density calibration: default density packs the same per-row count', () => {
+  it('default density packs the same count of normal 3★ landscapes per row (unchanged)', () => {
+    const rows = buildRows(
+      Array.from({ length: 12 }, (_, i) => createHorizontalImage(i + 1, 3)),
+      Math.round(4 * DENSITY_ROW_WIDTH_MULTIPLIER),
+      1.5
+    );
+    // Recorded baseline (cv code at K=2.5, rowWidth 10): exactly 4 per row.
+    expect(rows[0]!.components.length).toBeGreaterThanOrEqual(4);
+    expect(rows[0]!.components.length).toBeLessThanOrEqual(4);
+  });
+
+  // Regression: the hero-solo check is gated on aspect-ratio extremeness, so a
+  // NORMAL landscape (AR 1.78, extremeness < 2) never claims its own row — even
+  // at a small rowWidth where its width-cost fraction alone would exceed
+  // HERO_SOLO_WIDTH_FRACTION. Without the gate, a 3★ landscape at rowWidth 4
+  // (Hv 2.108 / 4 = 0.527 ≥ 0.5) degenerated to one-per-row, collapsing the
+  // chunk-2 density step into full-width singles.
+  it('a normal 3★ landscape never solos at small rowWidth (rw=4 → 2 per row)', () => {
+    const rows = buildRows(
+      Array.from({ length: 12 }, (_, i) => createHorizontalImage(i + 1, 3)),
+      4,
+      1.5
+    );
+    expect(rows[0]!.components.length).toBe(2);
+  });
+
+  it('a normal 5★ landscape never solos at small rowWidth either (AR 1.78, ext<2)', () => {
+    // The retired isFullWidthHero required AR≥2; a normal 5★ (AR 1.78) must not
+    // qualify regardless of rating. Hv(H5)=2.981, frac at rw=4 = 0.745 ≥ 0.5,
+    // so only the extremeness gate keeps it sharing.
+    const rows = buildRows(
+      [createHorizontalImage(1, 5), createHorizontalImage(2, 3), createHorizontalImage(3, 3)],
+      4,
+      1.5
+    );
+    expect(rows[0]!.components.length).toBeGreaterThan(1);
+  });
+
+  it('per-row count is non-decreasing as rowWidth grows for normal 3★ landscapes', () => {
+    // No degenerate all-singles step anywhere across the density range.
+    const counts = [4, 6, 8, 11, 13].map(
+      rw =>
+        buildRows(
+          Array.from({ length: 12 }, (_, i) => createHorizontalImage(i + 1, 3)),
+          rw,
+          1.5
+        )[0]!.components.length
+    );
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]!).toBeGreaterThanOrEqual(counts[i - 1]!);
+    }
+    // And the first step must be a real 2 (not a collapsed 1).
+    expect(counts[0]).toBe(2);
   });
 });
 
@@ -1348,41 +1415,13 @@ describe('row density packing', () => {
   });
 });
 
-// ===================== Full-width hero promotion =====================
+// ===================== Emergent full-width hero (Hv width-cost) =====================
+// isFullWidthHero (the AR+rating special-case) was retired in the directional-
+// prominence rewrite. A wide top-rated panorama now claims its own row purely
+// because its width-cost Hv = √(P·AR) clears HERO_SOLO_WIDTH_FRACTION of the row
+// budget — emergent, not a hard-coded rule. These exercise that emergent behavior.
 
-describe('full-width hero promotion', () => {
-  describe('isFullWidthHero predicate', () => {
-    it('promotes a wide 5★ horizontal panorama at low/medium density', () => {
-      expect(isFullWidthHero(createPanorama(1, 5), 10)).toBe(true);
-    });
-
-    it('honours the AR floor (2.0) at the boundary', () => {
-      // getAspectRatio reads imageWidth/imageHeight, not the aspectRatio field.
-      const ar2 = createImageContent(1, { imageWidth: 2000, imageHeight: 1000, rating: 5 });
-      const ar199 = createImageContent(2, { imageWidth: 1990, imageHeight: 1000, rating: 5 });
-      expect(isFullWidthHero(ar2, 10)).toBe(true);
-      expect(isFullWidthHero(ar199, 10)).toBe(false);
-    });
-
-    it('rejects a normal-AR (1.78) 5★ horizontal — not a panorama', () => {
-      expect(isFullWidthHero(createHorizontalImage(1, 5), 10)).toBe(false);
-    });
-
-    it('rejects a wide panorama below the rating floor (5)', () => {
-      expect(isFullWidthHero(createPanorama(1, 4), 10)).toBe(false);
-    });
-
-    it('rejects vertical and square images regardless of rating', () => {
-      expect(isFullWidthHero(createVerticalImage(1, 5), 10)).toBe(false);
-      expect(isFullWidthHero(createSquareImage(2, 5), 10)).toBe(false);
-    });
-
-    it('applies the density ceiling at HERO_FULLWIDTH_MAX_ROWWIDTH', () => {
-      expect(isFullWidthHero(createPanorama(1, 5), HERO_FULLWIDTH_MAX_ROWWIDTH)).toBe(true);
-      expect(isFullWidthHero(createPanorama(1, 5), HERO_FULLWIDTH_MAX_ROWWIDTH + 1)).toBe(false);
-    });
-  });
-
+describe('emergent full-width hero (width-cost driven)', () => {
   describe('buildRows promotion', () => {
     const soloPanoRow = (rows: RowResult[], panoId: number): RowResult | undefined =>
       rows.find(
@@ -1436,14 +1475,16 @@ describe('full-width hero promotion', () => {
       expect(totalItems(rows)).toBe(items.length);
     });
 
-    it('does NOT promote at high density (rowWidth above the ceiling)', () => {
+    it('does NOT promote at high density (Hv fraction falls below the bar)', () => {
+      // At rowWidth 20 the pano's Hv (≈5.48) is only ~0.27 of the budget, below
+      // HERO_SOLO_WIDTH_FRACTION (0.5), so it shares instead of soloing.
       const items = [
         createHorizontalImage(1, 3),
         createPanorama(2, 5),
         createHorizontalImage(3, 3),
         createHorizontalImage(4, 3),
       ];
-      const rows = buildRows(items, HERO_FULLWIDTH_MAX_ROWWIDTH + 5, 1.4);
+      const rows = buildRows(items, 20, 1.4);
       expect(soloPanoRow(rows, 2)).toBeUndefined();
       expect(totalItems(rows)).toBe(items.length);
     });

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -5,7 +5,7 @@
 
 import { DENSITY_ROW_WIDTH_MULTIPLIER, LAYOUT } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
-import { getItemComponentValue, getWidthCost } from '@/app/utils/contentRatingUtils';
+import { getWidthCost } from '@/app/utils/contentRatingUtils';
 import type { ImageType, RowResult } from '@/app/utils/rowCombination';
 import {
   acToBoxTree,
@@ -248,8 +248,8 @@ describe('buildRows', () => {
     for (let i = 0; i < rows.length - 1; i++) {
       const row = rows[i];
       if (row) {
-        const totalCV = row.components.reduce((sum, item) => sum + getItemComponentValue(item), 0);
-        const fill = totalCV / DESKTOP;
+        const totalHv = row.components.reduce((sum, item) => sum + getWidthCost(item), 0);
+        const fill = totalHv / DESKTOP;
         expect(fill).toBeGreaterThanOrEqual(0.5);
       }
     }
@@ -842,13 +842,6 @@ describe('toImageType', () => {
 
     const h3 = createHorizontalImage(2, 3);
     expect(toImageType(h3, DESKTOP).effectiveRating).toBe(3);
-  });
-
-  it('should set componentValue from getItemComponentValue', () => {
-    const img = createHorizontalImage(1, 5);
-    const result = toImageType(img, DESKTOP);
-    expect(result.componentValue).toBeGreaterThan(0);
-    expect(result.componentValue).toBe(getItemComponentValue(img));
   });
 
   it('should back-reference the source item', () => {

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -583,6 +583,26 @@ describe('buildRows', () => {
     });
   });
 
+  describe('vertical overpacking guard (Phase 3.3)', () => {
+    // Penalty-free verticals have a cheap width-cost Hv (a V3★ ≈ 1.19), so a long
+    // run of portraits could pack many-per-row. MAX_ROW_IMAGES bounds the COUNT and
+    // the targetAR-closeness composer nests the run into a 2D grid rather than a
+    // single thin filmstrip (a flat 12-wide strip of verticals would be AR ≈ 6.75).
+    it('tiles a long run of cheap verticals into bounded, sane-AR grids — never a thin filmstrip', () => {
+      const items = Array.from({ length: 24 }, (_, i) => createVerticalImage(i + 1, 3));
+      // High density (rw=20) is where cheap Hv could overpack a flat strip.
+      const rows = buildRows(items, 20, 1.5);
+      for (const row of rows) {
+        expect(row.components.length).toBeLessThanOrEqual(MAX_ROW_IMAGES);
+        const ar = calculateBoxTreeAspectRatio(row.boxTree, 20);
+        // A degenerate wide filmstrip would have AR well above the target band;
+        // the composer keeps even a 12-vertical row near-square (observed ≤ 1.7).
+        expect(ar).toBeLessThanOrEqual(2.5);
+        expect(ar).toBeGreaterThan(0.5);
+      }
+    });
+  });
+
   describe('2×2 nested layout', () => {
     it('builds a balanced two-pair boxTree for a 4-item mixed row (penalty-free ratings)', () => {
       // Real Row 15 scenario: V1★, V2★, V4★, H3★. Vertical penalty retired, so

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -13,7 +13,9 @@ import {
   buildRows,
   estimateRowAR,
   hChain,
+  HERO_FULLWIDTH_MAX_ROWWIDTH,
   hPair,
+  isFullWidthHero,
   isRowComplete,
   MAX_FILL_RATIO,
   MAX_ROW_IMAGES,
@@ -30,6 +32,9 @@ import {
   createCollectionContent,
   createGifContent,
   createHorizontalImage,
+  createImageContent,
+  createPanorama,
+  createSquareImage,
   createTextContent,
   createVerticalImage,
 } from '@/tests/fixtures/contentFixtures';
@@ -1340,5 +1345,125 @@ describe('row density packing', () => {
     const items = Array.from({ length: 30 }, (_, i) => createHorizontalImage(i + 1, 1));
     const rows = buildRows(items, 25, 1.0);
     for (const r of rows) expect(r.components.length).toBeLessThanOrEqual(MAX_ROW_IMAGES);
+  });
+});
+
+// ===================== Full-width hero promotion =====================
+
+describe('full-width hero promotion', () => {
+  describe('isFullWidthHero predicate', () => {
+    it('promotes a wide 5★ horizontal panorama at low/medium density', () => {
+      expect(isFullWidthHero(createPanorama(1, 5), 10)).toBe(true);
+    });
+
+    it('honours the AR floor (2.0) at the boundary', () => {
+      // getAspectRatio reads imageWidth/imageHeight, not the aspectRatio field.
+      const ar2 = createImageContent(1, { imageWidth: 2000, imageHeight: 1000, rating: 5 });
+      const ar199 = createImageContent(2, { imageWidth: 1990, imageHeight: 1000, rating: 5 });
+      expect(isFullWidthHero(ar2, 10)).toBe(true);
+      expect(isFullWidthHero(ar199, 10)).toBe(false);
+    });
+
+    it('rejects a normal-AR (1.78) 5★ horizontal — not a panorama', () => {
+      expect(isFullWidthHero(createHorizontalImage(1, 5), 10)).toBe(false);
+    });
+
+    it('rejects a wide panorama below the rating floor (5)', () => {
+      expect(isFullWidthHero(createPanorama(1, 4), 10)).toBe(false);
+    });
+
+    it('rejects vertical and square images regardless of rating', () => {
+      expect(isFullWidthHero(createVerticalImage(1, 5), 10)).toBe(false);
+      expect(isFullWidthHero(createSquareImage(2, 5), 10)).toBe(false);
+    });
+
+    it('applies the density ceiling at HERO_FULLWIDTH_MAX_ROWWIDTH', () => {
+      expect(isFullWidthHero(createPanorama(1, 5), HERO_FULLWIDTH_MAX_ROWWIDTH)).toBe(true);
+      expect(isFullWidthHero(createPanorama(1, 5), HERO_FULLWIDTH_MAX_ROWWIDTH + 1)).toBe(false);
+    });
+  });
+
+  describe('buildRows promotion', () => {
+    const soloPanoRow = (rows: RowResult[], panoId: number): RowResult | undefined =>
+      rows.find(
+        r =>
+          r.components.length === 1 &&
+          (r.components[0] as { id: number }).id === panoId &&
+          r.boxTree.type === 'leaf'
+      );
+    const totalItems = (rows: RowResult[]): number =>
+      rows.reduce((n, r) => n + r.components.length, 0);
+
+    it('gives a mid-stream wide 5★ panorama its own full-width row (gorge regression)', () => {
+      // Mirrors the real /gorge-climbing row: V3, H3, V3, then the wide 5★ pano.
+      const items = [
+        createVerticalImage(1, 3),
+        createHorizontalImage(2, 3),
+        createVerticalImage(3, 3),
+        createPanorama(4, 5),
+        createHorizontalImage(5, 4),
+      ];
+      const rows = buildRows(items, 10, 1.4);
+      // The pano is its own leaf row — never nested as a vStack sliver.
+      expect(soloPanoRow(rows, 4)).toBeDefined();
+      const panoRow = rows.find(r => r.components.some(c => (c as { id: number }).id === 4));
+      expect(panoRow!.boxTree.type).toBe('leaf');
+      expect(totalItems(rows)).toBe(items.length); // nothing dropped
+    });
+
+    it('gives a leading wide 5★ panorama its own full-width row', () => {
+      const items = [
+        createPanorama(1, 5),
+        createHorizontalImage(2, 3),
+        createHorizontalImage(3, 3),
+        createHorizontalImage(4, 4),
+      ];
+      const rows = buildRows(items, 10, 1.4);
+      expect(rows[0]!.components).toHaveLength(1);
+      expect((rows[0]!.components[0] as { id: number }).id).toBe(1);
+      expect(rows[0]!.boxTree.type).toBe('leaf');
+      expect(totalItems(rows)).toBe(items.length);
+    });
+
+    it('does NOT promote a wide panorama below 5★ — it shares a row', () => {
+      const items = [
+        createHorizontalImage(1, 3),
+        createPanorama(2, 4),
+        createHorizontalImage(3, 3),
+      ];
+      const rows = buildRows(items, 10, 1.4);
+      expect(soloPanoRow(rows, 2)).toBeUndefined();
+      expect(totalItems(rows)).toBe(items.length);
+    });
+
+    it('does NOT promote at high density (rowWidth above the ceiling)', () => {
+      const items = [
+        createHorizontalImage(1, 3),
+        createPanorama(2, 5),
+        createHorizontalImage(3, 3),
+        createHorizontalImage(4, 3),
+      ];
+      const rows = buildRows(items, HERO_FULLWIDTH_MAX_ROWWIDTH + 5, 1.4);
+      expect(soloPanoRow(rows, 2)).toBeUndefined();
+      expect(totalItems(rows)).toBe(items.length);
+    });
+
+    it('does NOT promote a normal 5★ horizontal (AR 1.78)', () => {
+      const items = [
+        createHorizontalImage(1, 5),
+        createHorizontalImage(2, 3),
+        createHorizontalImage(3, 3),
+      ];
+      const rows = buildRows(items, 10, 1.4);
+      expect(soloPanoRow(rows, 1)).toBeUndefined();
+    });
+
+    it('promotes multiple wide 5★ panoramas each to their own row', () => {
+      const items = [createPanorama(1, 5), createPanorama(2, 5), createHorizontalImage(3, 3)];
+      const rows = buildRows(items, 10, 1.4);
+      expect(soloPanoRow(rows, 1)).toBeDefined();
+      expect(soloPanoRow(rows, 2)).toBeDefined();
+      expect(totalItems(rows)).toBe(items.length);
+    });
   });
 });


### PR DESCRIPTION
Three independent threads landed on this branch (kept together because the `ce58de0` docblock cleanup touches files in all three).

**Status:** 2109 tests green · `tsc`/eslint clean · critically reviewed (no blockers).

---

## 1. Directional-prominence layout rewrite

**Problem:** the layout value model penalized verticals (a `−1` rating penalty), boosted only *wide* panoramas (one-sided arFactor ramp), and carried two competing hard-coded panorama mechanisms. A 5★ portrait was sized like a lesser image.

**Solution:** one orientation-agnostic prominence `P`, decomposed onto the engine's two geometric axes:
```
P  = BASE_WEIGHT[rating] × prominenceFactor(extremeness)   // extremeness = max(AR, 1/AR)
Hv = √(P·AR)    // width-cost   → Stage-1 packing
Vv = √(P/AR)    // height-demand → per-row target AR
```
- Equity metric targets area ∝ `P` (verticals sized by value within a row).
- Per-row `targetAR` pulled toward a taller shape in proportion to peak `Vv`.
- Stage-1 packs by `Hv`; the `isFullWidthHero` special-case becomes the emergent, extremeness-gated `isSoloHero`.
- Vertical penalty retired; the dead `cv` value-model (`getComponentValue`/`getItemComponentValue`/`PANORAMA_*`) removed.
- Density `K` recalibrated 2.5 → 2.1 so normal collections keep their items-per-row.

See `app/utils/rowCombination.md` for the full model.

## 2. Unified filter-visibility gate

**Problem:** filter visibility used scattered per-dimension heuristics; the location toolbar showed controls that couldn't filter anything (the Film bug); single-value dimensions rendered as useless 1-option dropdowns.

**Solution:** one `canFilter` gate — a dimension is filterable iff some value covers a proper non-empty subset (`0 < count < total`, `total ≥ 2`). `computeFilterVisibility` runs it across every dimension; `applyActiveOverride` keeps deep-linked filters visible.

**Intentional user-visible changes:**
- `highlyRated` now hides when *all* images are ≥4★ (previously a variance proxy).
- Single-value-covers-all dropdowns hide; single-value dimensions render as info chips, not 1-option dropdowns.
- Single-image pages show no filter controls.

## 3. Edit sheet
Desktop edit sheet shows Info + Structure side-by-side; mobile layout unchanged.

---

## Deferred (follow-ups — not in this PR)
- **Phase 4 — AR-floor relaxation** (let tall-portrait heroes render taller-than-wide): a taste change to the "never taller than wide" guarantee; needs live-preview calibration.
- Consolidate `getEffectiveRating`/`getProminenceRating` (now identical).
- Remove the self-marked unused params (`_rowWidth` / `void rowWidth` / `chunkSize`).

## Known limitation
The oval-lakes `[V4,H3,V4,V5,V5]` row (Issue #4) still renders the two 5★ verticals smallest — a structural point-balance limitation none of these phases fix (needs hero-vertical isolation). Documented in `app/utils/rowCombination.md`.

## Verification
- 2109/2109 jest · `tsc --noEmit` clean · eslint clean.
- Layout verified analytically + by tests (no preview/backend available in this environment). **Recommend a visual eyeball before merge** — trailing-row packing shifted slightly under denser `Hv` (a lone low-rated vertical can orphan to its own row; documented).
