### PR TITLE
Collection-page UX fixes: image-unavailable, cover Update shortcut, related cards, chronological Date default

### DIFF
--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -320,6 +320,7 @@ export default function CollectionContentRenderer({
                     : null
                 }
                 showDateSort={collectionFilter.filterOptions.showDateSort}
+                dateTwoState={collectionFilter.dateTwoState}
                 showHighlyRated={collectionFilter.filterOptions.showHighlyRated}
                 density={collectionFilter.density}
                 densityMax={collectionFilter.densityMax}

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -29,8 +29,16 @@ import {
   buildWrapperClassName,
   resolveValidDimensions,
 } from '@/app/utils/contentRendererUtils';
+import { isLocalEnvironment } from '@/app/utils/environment';
 import { slugify } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
+import { manageHref } from '@/app/utils/manageUrl';
+
+/**
+ * Sentinel content id used by createCoverImageBlock (app/utils/contentLayout.ts) for the
+ * header cover image. Lets the renderer single out the cover without a new prop.
+ */
+const COVER_IMAGE_CONTENT_ID = -1;
 
 import { getClickEligibility, toCollectionDimensions } from './collectionContentRendererUtils';
 import cbStyles from './ContentComponent.module.scss';
@@ -156,6 +164,26 @@ export default function CollectionContentRenderer({
 
   const collectionFilter = useCollectionFilter();
   const inlineEdit = useInlineEdit();
+
+  // Localhost-only shortcut into manage mode, pinned to the header cover image. Shown only on the
+  // public view (manage path sets currentCollectionId) for the cover block (contentId === -1).
+  const showCoverUpdateShortcut =
+    contentType === 'IMAGE' &&
+    contentId === COVER_IMAGE_CONTENT_ID &&
+    currentCollectionId == null &&
+    !!collectionSlug &&
+    isLocalEnvironment();
+
+  const handleCoverUpdateClick = useCallback(
+    (event: { stopPropagation: () => void }) => {
+      // Stop the click from bubbling to the parallax wrapper (which opens fullscreen).
+      event.stopPropagation();
+      if (collectionSlug) {
+        router.push(manageHref(collectionSlug));
+      }
+    },
+    [collectionSlug, router]
+  );
 
   if (contentType === 'TEXT') {
     if (!textItems || textItems.length === 0) {
@@ -628,6 +656,15 @@ export default function CollectionContentRenderer({
       <div className={cbStyles.imageWrapper} onClick={handleClick}>
         {imageWrapperContent}
       </div>
+      {showCoverUpdateShortcut && (
+        <button
+          type="button"
+          className={cbStyles.coverUpdateShortcut}
+          onClick={handleCoverUpdateClick}
+        >
+          Update
+        </button>
+      )}
       {!enableParallax && (
         <ImageOverlays
           contentType={contentType}

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -309,22 +309,63 @@ export default function CollectionContentRenderer({
                 </div>
               </div>
             )}
-            {collectionItems.length > 0 && (
-              <div className={cbStyles.metadataSiblingsContainer}>
-                <span className={cbStyles.metadataSiblingLabel}>Related:</span>
-                <div className={cbStyles.metadataSiblingsRow}>
-                  {collectionItems.map(item => (
-                    <Link
-                      key={`sibling-${contentId}-${item.slug}`}
-                      href={item.slug!}
-                      className={cbStyles.metadataSiblingCollection}
-                    >
-                      {item.value}
-                    </Link>
-                  ))}
+            {collectionItems.length > 0 &&
+              (collectionItems.some(item => item.coverImageUrl) ? (
+                // Card path: at least one sibling has a cover image. Render a wrapping
+                // row of ~2:1 cover cards; siblings still lacking a cover fall back to a
+                // text-link chip inside the same row (no blank placeholder).
+                <div className={cbStyles.metadataSiblingsContainer}>
+                  <span className={cbStyles.metadataSiblingLabel}>Related:</span>
+                  <div className={cbStyles.metadataSiblingCardRow}>
+                    {collectionItems.map(item =>
+                      item.coverImageUrl ? (
+                        <Link
+                          key={`sibling-${contentId}-${item.slug}`}
+                          href={item.slug!}
+                          className={cbStyles.metadataSiblingCard}
+                          aria-label={item.value}
+                        >
+                          <Image
+                            src={item.coverImageUrl}
+                            alt={item.value}
+                            fill
+                            sizes="(max-width: 768px) 140px, 200px"
+                            className={cbStyles.metadataSiblingCardImage}
+                          />
+                          <span className={cbStyles.metadataSiblingCardOverlay}>
+                            <span className={cbStyles.metadataSiblingCardTitle}>{item.value}</span>
+                          </span>
+                        </Link>
+                      ) : (
+                        <Link
+                          key={`sibling-${contentId}-${item.slug}`}
+                          href={item.slug!}
+                          className={cbStyles.metadataSiblingChip}
+                        >
+                          {item.value}
+                        </Link>
+                      )
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              ) : (
+                // Fallback path: no sibling has a cover image (e.g. backend not yet
+                // deployed). Keep the original plain text-link row.
+                <div className={cbStyles.metadataSiblingsContainer}>
+                  <span className={cbStyles.metadataSiblingLabel}>Related:</span>
+                  <div className={cbStyles.metadataSiblingsRow}>
+                    {collectionItems.map(item => (
+                      <Link
+                        key={`sibling-${contentId}-${item.slug}`}
+                        href={item.slug!}
+                        className={cbStyles.metadataSiblingCollection}
+                      >
+                        {item.value}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              ))}
             {isClientGallery && collectionSlug && (
               <ClientGalleryDownload collectionSlug={collectionSlug} />
             )}

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -441,22 +441,51 @@ export default function CollectionContentRenderer({
   }
 
   if (failedImageIds.has(contentId)) {
+    // currentCollectionId is only threaded down on the manage path (EditModeLayer);
+    // the public CollectionPageClient grid, TaxonomyPage, and LocationPage never set it.
+    const isManage = currentCollectionId != null;
+
+    // Public view: a URL that 404s/fails to load has nothing renderable, so drop it.
+    // We intentionally leave the already-allocated grid slot empty (a small gap)
+    // rather than re-flowing the BoxTree layout.
+    if (!isManage) {
+      return null;
+    }
+
     const placeholderWidth = width || 300;
     const placeholderHeight = height || (placeholderWidth * 2) / 3;
+    const placeholderClassName = `${buildWrapperClassName(className, cbStyles, {
+      includeDragContainer: false,
+      enableParallax: false,
+      isMobile,
+      hasClickHandler,
+      isSelected: false,
+    })} ${cbStyles.contentBox}`;
 
+    // Manage view: keep the "Image unavailable" box and make it clickable so the admin
+    // can open the edit/delete modal and remove the broken image. Mirrors the click
+    // wiring of the empty-URL ("No Image") placeholder above.
     return (
       <div
         key={contentId}
-        className={`${buildWrapperClassName(className, cbStyles, {
-          includeDragContainer: false,
-          enableParallax: false,
-          isMobile,
-          hasClickHandler: false,
-          isSelected: false,
-        })} ${cbStyles.contentBox}`}
+        className={placeholderClassName}
+        onClick={hasClickHandler ? handleClick : undefined}
+        role={hasClickHandler ? 'button' : undefined}
+        tabIndex={hasClickHandler ? 0 : undefined}
+        onKeyDown={
+          hasClickHandler
+            ? e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleClick();
+                }
+              }
+            : undefined
+        }
         style={{
           width: placeholderWidth,
           height: placeholderHeight,
+          cursor: hasClickHandler ? 'pointer' : 'default',
         }}
       >
         <div

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -596,6 +596,100 @@
   }
 }
 
+/* Card path: ~2:1 cover-image cards for related collections.
+   Wrapping row of small thumbnails; whole card is a link with the title overlaid. */
+.metadataSiblingCardRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.metadataSiblingCard {
+  position: relative;
+  display: block;
+  flex-shrink: 0;
+  width: 140px;
+  aspect-ratio: 2 / 1;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  text-decoration: none;
+  transition: opacity var(--duration-fast) var(--ease-standard);
+
+  @media (width >= 768px) {
+    width: 200px;
+  }
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+.metadataSiblingCardImage {
+  object-fit: cover;
+}
+
+.metadataSiblingCardOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  background: linear-gradient(to top, rgb(0 0 0 / 55%), rgb(0 0 0 / 0%) 60%);
+  transition: background var(--duration-fast) var(--ease-standard);
+
+  .metadataSiblingCard:hover & {
+    background: linear-gradient(to top, rgb(0 0 0 / 65%), rgb(0 0 0 / 10%) 60%);
+  }
+}
+
+.metadataSiblingCardTitle {
+  padding: var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: 1.3;
+  color: #fff;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+
+  @media (width >= 768px) {
+    font-size: var(--text-sm);
+  }
+}
+
+/* Cover-less sibling inside the card row: a text-link chip, vertically centered
+   so it sits alongside the cover cards instead of leaving a blank placeholder. */
+.metadataSiblingChip {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-fg);
+  text-decoration: none;
+  background-color: rgb(0 0 0 / 6%);
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: var(--radius-round);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background-color: rgb(0 0 0 / 12%);
+    border-color: rgb(0 0 0 / 25%);
+  }
+}
+
+[data-surface='dark'] .metadataSiblingChip {
+  background-color: rgb(255 255 255 / 6%);
+  border-color: rgb(255 255 255 / 12%);
+
+  &:hover {
+    background-color: rgb(255 255 255 / 12%);
+    border-color: rgb(255 255 255 / 25%);
+  }
+}
+
 /* Generic text block item styles (for non-metadata text blocks) */
 .textItem {
   margin-bottom: var(--space-2);

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -354,6 +354,50 @@
   }
 }
 
+/* Localhost-only "Update" shortcut pinned to the header cover image's bottom-right corner.
+   Hidden until the cover is hovered (or the button is keyboard-focused). Height matches the
+   EditBar/FilterToolbar control row (.barCell min-height: 44px). */
+.coverUpdateShortcut {
+  position: absolute;
+  right: var(--space-2);
+  bottom: var(--space-2);
+  z-index: var(--z-content);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 var(--space-4);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-bg);
+  background: var(--color-fg);
+  border: none;
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    background: var(--color-fg);
+    opacity: 0.95;
+  }
+
+  &:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+}
+
+/* Reveal the shortcut when the cover wrapper is hovered. The cover renders in the parallax
+   wrapper div, which carries the data-parallax-container attribute. */
+[data-parallax-container]:hover .coverUpdateShortcut {
+  opacity: 0.95;
+}
+
 /* ===================== Metadata Block ===================== */
 
 /* Metadata block inner container — professional information panel */

--- a/app/components/ContentCollection/CollectionFilterContext.tsx
+++ b/app/components/ContentCollection/CollectionFilterContext.tsx
@@ -39,6 +39,12 @@ interface CollectionFilterContextValue {
   filterOptions: CollectionInfoOptions;
   filteredAvailable: FilteredAvailableOptions;
   onFilterChange: (update: Partial<FilterState>) => void;
+  /**
+   * When true, the Date filter is always engaged and toggles only between directions
+   * (asc <-> desc, never `off`) — used for CHRONOLOGICAL collections, which are inherently
+   * date-ordered. Other views keep the neutral off/asc/desc tri-state.
+   */
+  dateTwoState: boolean;
   /** Density value in the active viewport's scale (desktop 1-10, mobile 1-5). */
   density: number;
   /** Upper bound of the density slider for the active viewport (10 or 5). */

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -9,7 +9,12 @@ import { useFilterUrlState } from '@/app/hooks/useFilterUrlState';
 import { useViewport } from '@/app/hooks/useViewport';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
 import { type AnyContentModel } from '@/app/types/Content';
-import { type FilterState, INITIAL_FILTER_STATE, type LensType } from '@/app/types/GalleryFilter';
+import {
+  type FilterState,
+  INITIAL_FILTER_STATE,
+  initialDateSortDirection,
+  type LensType,
+} from '@/app/types/GalleryFilter';
 import {
   applyCollectionFilters,
   buildCollectionCriteria,
@@ -75,8 +80,15 @@ export default function CollectionPageClient({
 
   const { initialCriteria, syncToUrl } = useFilterUrlState();
 
+  // CHRONOLOGICAL collections are inherently date-ordered, so on the PUBLIC view their Date
+  // filter defaults ON (oldest-first) and toggles only between directions. Edit mode is excluded:
+  // an admin manages order against the LIVE displayMode (which may have been converted away from
+  // CHRONOLOGICAL), so auto-engaging date sort there would revert saved manual reorders.
+  const isChronological = !editMode && collection.displayMode === 'CHRONOLOGICAL';
+
   const [filterState, setFilterState] = useState<FilterState>(() => ({
     ...INITIAL_FILTER_STATE,
+    dateSortDirection: editMode ? 'off' : initialDateSortDirection(collection.displayMode),
     highlyRatedOnly: initialCriteria.minRating !== undefined && initialCriteria.minRating >= 4,
     selectedTags: initialCriteria.tags ?? [],
     selectedPeople: initialCriteria.people ?? [],
@@ -221,6 +233,7 @@ export default function CollectionPageClient({
       filterOptions: availableOptions,
       filteredAvailable: filteredAvailableOptions,
       onFilterChange: handleFilterChange,
+      dateTwoState: isChronological,
       density: displayDensity,
       densityMax,
       onDensityChange: handleDensityChange,
@@ -230,6 +243,7 @@ export default function CollectionPageClient({
       availableOptions,
       filteredAvailableOptions,
       handleFilterChange,
+      isChronological,
       displayDensity,
       densityMax,
       handleDensityChange,

--- a/app/components/ui/FilterToolbar/FilterToolbar.tsx
+++ b/app/components/ui/FilterToolbar/FilterToolbar.tsx
@@ -8,6 +8,7 @@ import {
   ARRAY_FILTER_KEYS,
   type ArrayFilterKey,
   cycleDateSort,
+  cycleDateSortTwoState,
   cycleFilmFilter,
   type FilterState,
   INITIAL_FILTER_STATE,
@@ -44,6 +45,12 @@ export interface FilterToolbarProps {
   /** Aggregate counts for the highly-rated / film / digital toggles. */
   counts?: ToolbarCounts;
   showDateSort?: boolean;
+  /**
+   * When true, the Date chip is always active and toggles only between directions
+   * (asc <-> desc, never `off`) — for views that are inherently date-ordered (CHRONOLOGICAL
+   * collections). Defaults to false (the neutral off/asc/desc tri-state).
+   */
+  dateTwoState?: boolean;
   showHighlyRated?: boolean;
   showFilm?: boolean;
   /** When provided, renders the row-density slider (min 1, max {@link densityMax}). */
@@ -70,6 +77,7 @@ export function FilterToolbar({
   filteredAvailable,
   counts,
   showDateSort = false,
+  dateTwoState = false,
   showHighlyRated = false,
   showFilm = false,
   density,
@@ -99,9 +107,14 @@ export function FilterToolbar({
       {showDateSort && (
         <FilterChip
           label={DATE_LABELS[filterState.dateSortDirection]}
-          active={filterState.dateSortDirection !== 'off'}
+          // In two-state mode the date sort is always engaged, so the chip stays active.
+          active={dateTwoState || filterState.dateSortDirection !== 'off'}
           onToggle={() =>
-            onFilterChange({ dateSortDirection: cycleDateSort(filterState.dateSortDirection) })
+            onFilterChange({
+              dateSortDirection: dateTwoState
+                ? cycleDateSortTwoState(filterState.dateSortDirection)
+                : cycleDateSort(filterState.dateSortDirection),
+            })
           }
         />
       )}

--- a/app/types/Collection.ts
+++ b/app/types/Collection.ts
@@ -108,6 +108,13 @@ export interface CollectionListModel {
   type?: string;
   /** ISO date — used to sort BLOG group rows on the manage page. */
   collectionDate?: string | null;
+  /**
+   * Cover image URL (CloudFront). Populated by the backend on the public
+   * sibling/related payload to render related collections as cover-image cards.
+   * Absent until that backend change deploys — renderers must fall back to text
+   * links when missing.
+   */
+  coverImageUrl?: string;
 }
 
 /**

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -127,6 +127,7 @@ export interface TextBlockItem {
   value: string;
   slug?: string; // URL slug for navigation (location, tag, and sibling-collection items)
   label?: string; // Optional display label (e.g., "Date:", "Location:")
+  coverImageUrl?: string; // Cover image (CloudFront) for sibling-collection items — renders as a card; absent => text link
 }
 
 /**

--- a/app/types/GalleryFilter.ts
+++ b/app/types/GalleryFilter.ts
@@ -72,6 +72,25 @@ export function cycleDateSort(current: DateSortDirection): DateSortDirection {
 }
 
 /**
+ * Two-state date-sort cycle for views where the date filter is always engaged
+ * (e.g. CHRONOLOGICAL collections, which are inherently date-ordered): asc <-> desc,
+ * never `off`. `off` is not reachable here, but is mapped to `asc` defensively so the
+ * collection stays oldest-first if it ever lands there.
+ */
+export function cycleDateSortTwoState(current: DateSortDirection): DateSortDirection {
+  return current === 'asc' ? 'desc' : 'asc';
+}
+
+/**
+ * Initial date-sort direction for a collection. CHRONOLOGICAL collections are already
+ * stored oldest-first (see contentLayout `sortContentByCreatedAt`), so their Date filter
+ * defaults ON at `asc` to match that order; every other view starts neutral (`off`).
+ */
+export function initialDateSortDirection(displayMode?: string): DateSortDirection {
+  return displayMode === 'CHRONOLOGICAL' ? 'asc' : 'off';
+}
+
+/**
  * The single canonical film-filter cycle: off -> film -> digital -> off.
  */
 export function cycleFilmFilter(current: FilmFilter): FilmFilter {

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -277,10 +277,19 @@ export function isContentVisibleInCollection(
 ): boolean {
   if (block.visible === false) return false;
 
-  if (block.contentType === 'IMAGE' && collectionId) {
+  if (block.contentType === 'IMAGE') {
     const imageBlock = block as ContentImageModel;
-    const entry = imageBlock.collections?.find(c => c.collectionId === collectionId);
-    if (entry?.visible === false) return false;
+
+    // Images with an empty/blank imageUrl have no renderable content. On the public
+    // view they would otherwise occupy a layout slot with a "No Image" placeholder,
+    // so exclude them here. Manage uses processContentBlocks(..., filterVisible=false),
+    // which skips this filter, so admins still see + can delete these blocks.
+    if (!imageBlock.imageUrl || imageBlock.imageUrl.trim() === '') return false;
+
+    if (collectionId) {
+      const entry = imageBlock.collections?.find(c => c.collectionId === collectionId);
+      if (entry?.visible === false) return false;
+    }
   }
 
   return true;

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -482,7 +482,17 @@ function buildMetadataItems(collection: CollectionModel): TextBlockItem[] {
   if (collection.siblings && collection.siblings.length > 0) {
     for (const sib of collection.siblings) {
       if (sib.slug) {
-        items.push({ type: 'collection', value: sib.name, slug: `/${sib.slug}` });
+        const siblingItem: TextBlockItem = {
+          type: 'collection',
+          value: sib.name,
+          slug: `/${sib.slug}`,
+        };
+        // Cover image (CloudFront) — present once the backend ships it. Renders the
+        // sibling as a cover card; absent siblings stay plain text links.
+        if (sib.coverImageUrl) {
+          siblingItem.coverImageUrl = sib.coverImageUrl;
+        }
+        items.push(siblingItem);
       }
     }
   }

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -9,11 +9,19 @@ import {
 } from '@/app/components/ContentCollection/edit/InlineEditContext';
 import type { TextBlockItem } from '@/app/types/Content';
 
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+const pushMock = jest.fn();
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
 jest.mock('@/app/hooks/useParallax', () => ({ useParallax: () => ({ current: null }) }));
 jest.mock('@/app/components/ContentCollection/CollectionFilterContext', () => ({
   useCollectionFilter: () => null,
 }));
+jest.mock('@/app/utils/environment', () => ({
+  isLocalEnvironment: jest.fn(() => false),
+}));
+
+import { isLocalEnvironment } from '@/app/utils/environment';
+
+const mockIsLocalEnvironment = isLocalEnvironment as jest.MockedFunction<typeof isLocalEnvironment>;
 
 const baseProps = {
   contentId: 42,
@@ -131,5 +139,62 @@ describe('CollectionContentRenderer — coverless collection tile (regression)',
     render(<CollectionContentRenderer {...coverlessCollectionProps} />);
     expect(screen.getByText('Lisbon')).toBeInTheDocument();
     expect(screen.queryByText('No Image')).not.toBeInTheDocument();
+  });
+});
+
+describe('CollectionContentRenderer — cover "Update" shortcut (localhost public view)', () => {
+  // The header cover image is the parallax IMAGE block with the sentinel id -1.
+  const coverProps = {
+    contentId: -1,
+    className: 'imageSingle',
+    width: 600,
+    height: 400,
+    isMobile: false,
+    imageUrl: 'https://cdn.example.com/cover.jpg',
+    imageWidth: 600,
+    imageHeight: 400,
+    alt: 'Cover',
+    enableParallax: true,
+    contentType: 'IMAGE' as const,
+    overlayText: 'My Gallery',
+    collectionSlug: 'my-gallery',
+  };
+
+  beforeEach(() => {
+    pushMock.mockClear();
+    mockIsLocalEnvironment.mockReturnValue(false);
+  });
+
+  it('shows the shortcut and navigates to ?manage=1 on localhost public view', () => {
+    mockIsLocalEnvironment.mockReturnValue(true);
+    render(<CollectionContentRenderer {...coverProps} />);
+
+    const button = screen.getByRole('button', { name: 'Update' });
+    fireEvent.click(button);
+    expect(pushMock).toHaveBeenCalledWith('/my-gallery?manage=1');
+  });
+
+  it('does not show the shortcut in production (non-localhost)', () => {
+    mockIsLocalEnvironment.mockReturnValue(false);
+    render(<CollectionContentRenderer {...coverProps} />);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the shortcut in manage mode (currentCollectionId set)', () => {
+    mockIsLocalEnvironment.mockReturnValue(true);
+    render(<CollectionContentRenderer {...coverProps} currentCollectionId={7} />);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the shortcut on a non-cover image (contentId !== -1)', () => {
+    mockIsLocalEnvironment.mockReturnValue(true);
+    render(<CollectionContentRenderer {...coverProps} contentId={123} enableParallax={false} />);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the shortcut when no collectionSlug is available', () => {
+    mockIsLocalEnvironment.mockReturnValue(true);
+    render(<CollectionContentRenderer {...coverProps} collectionSlug={undefined} />);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 });

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -62,6 +62,82 @@ describe('CollectionContentRenderer — TEXT branch sibling collections', () => 
   });
 });
 
+describe('CollectionContentRenderer — sibling collections as cover cards', () => {
+  it('renders a cover-image card per sibling when coverImageUrl is present', () => {
+    const textItems: TextBlockItem[] = [
+      {
+        type: 'collection',
+        value: 'Dolomites Film',
+        slug: '/dolomites-film',
+        coverImageUrl: 'https://cdn.example.com/dolomites-film.jpg',
+      },
+      {
+        type: 'collection',
+        value: 'Dolomites 2025',
+        slug: '/dolomites-2025',
+        coverImageUrl: 'https://cdn.example.com/dolomites-2025.jpg',
+      },
+    ];
+    render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
+
+    // Related: context preserved
+    expect(screen.getByText('Related:')).toBeInTheDocument();
+
+    // Each card is a link to /{slug} with an accessible name (the collection title)
+    const filmLink = screen.getByRole('link', { name: /Dolomites Film/ });
+    expect(filmLink).toHaveAttribute('href', '/dolomites-film');
+    const link2025 = screen.getByRole('link', { name: /Dolomites 2025/ });
+    expect(link2025).toHaveAttribute('href', '/dolomites-2025');
+
+    // Cover images render with alt text = collection name
+    const filmImage = screen.getByRole('img', { name: 'Dolomites Film' });
+    expect(filmImage).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Dolomites 2025' })).toBeInTheDocument();
+  });
+
+  it('renders a sibling without coverImageUrl as a text-link chip inside the card row', () => {
+    const textItems: TextBlockItem[] = [
+      {
+        type: 'collection',
+        value: 'Has Cover',
+        slug: '/has-cover',
+        coverImageUrl: 'https://cdn.example.com/has-cover.jpg',
+      },
+      { type: 'collection', value: 'No Cover', slug: '/no-cover' },
+    ];
+    render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
+
+    // Card path is active (one sibling has a cover) so we still see the cover image
+    expect(screen.getByRole('img', { name: 'Has Cover' })).toBeInTheDocument();
+
+    // The cover-less sibling is still a navigable link (rendered as a text chip)
+    const noCoverLink = screen.getByRole('link', { name: 'No Cover' });
+    expect(noCoverLink).toHaveAttribute('href', '/no-cover');
+    // No image rendered for the cover-less sibling
+    expect(screen.queryByRole('img', { name: 'No Cover' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to plain text links when NO sibling has a coverImageUrl', () => {
+    const textItems: TextBlockItem[] = [
+      { type: 'collection', value: 'Dolomites Film', slug: '/dolomites-film' },
+      { type: 'collection', value: 'Dolomites 2025', slug: '/dolomites-2025' },
+    ];
+    render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
+
+    expect(screen.getByText('Related:')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Dolomites Film' })).toHaveAttribute(
+      'href',
+      '/dolomites-film'
+    );
+    expect(screen.getByRole('link', { name: 'Dolomites 2025' })).toHaveAttribute(
+      'href',
+      '/dolomites-2025'
+    );
+    // No images in the pure-fallback path
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});
+
 describe('CollectionContentRenderer — TEXT branch inline edit context', () => {
   const textItems: TextBlockItem[] = [
     { type: 'date', value: '2026-01-01' },

--- a/tests/components/ui/FilterToolbar.test.tsx
+++ b/tests/components/ui/FilterToolbar.test.tsx
@@ -29,6 +29,29 @@ describe('FilterToolbar', () => {
     expect(onFilterChange).toHaveBeenCalledWith({ dateSortDirection: 'asc' });
   });
 
+  it('two-state date toggle cycles asc <-> desc and never shows the off label', () => {
+    const { onFilterChange } = renderToolbar({
+      showDateSort: true,
+      dateTwoState: true,
+      filterState: { ...INITIAL_FILTER_STATE, dateSortDirection: 'asc' },
+    });
+    // Shows the directional label, not the neutral "Date".
+    const chip = screen.getByRole('button', { name: /date ↑/i });
+    expect(screen.queryByRole('button', { name: /^date$/i })).toBeNull();
+    fireEvent.click(chip);
+    expect(onFilterChange).toHaveBeenCalledWith({ dateSortDirection: 'desc' });
+  });
+
+  it('two-state date toggle from desc cycles back to asc (never off)', () => {
+    const { onFilterChange } = renderToolbar({
+      showDateSort: true,
+      dateTwoState: true,
+      filterState: { ...INITIAL_FILTER_STATE, dateSortDirection: 'desc' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /date ↓/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ dateSortDirection: 'asc' });
+  });
+
   it('renders a highly-rated toggle with its count badge', () => {
     const { onFilterChange } = renderToolbar({
       showHighlyRated: true,

--- a/tests/types/GalleryFilter.test.ts
+++ b/tests/types/GalleryFilter.test.ts
@@ -1,9 +1,11 @@
 import {
   ARRAY_FILTER_KEYS,
   cycleDateSort,
+  cycleDateSortTwoState,
   cycleFilmFilter,
   type FilterState,
   INITIAL_FILTER_STATE,
+  initialDateSortDirection,
   toggleArrayFilter,
 } from '@/app/types/GalleryFilter';
 
@@ -28,6 +30,21 @@ describe('FilterState helpers', () => {
     expect(cycleDateSort('off')).toBe('asc');
     expect(cycleDateSort('asc')).toBe('desc');
     expect(cycleDateSort('desc')).toBe('off');
+  });
+
+  it('cycleDateSortTwoState toggles only between asc and desc (never off)', () => {
+    expect(cycleDateSortTwoState('asc')).toBe('desc');
+    expect(cycleDateSortTwoState('desc')).toBe('asc');
+    // 'off' is not a reachable state in the two-state cycle; defaulting to asc
+    // keeps a chronological collection sorted oldest-first if it somehow lands there.
+    expect(cycleDateSortTwoState('off')).toBe('asc');
+  });
+
+  it('initialDateSortDirection defaults to asc for CHRONOLOGICAL, off otherwise', () => {
+    expect(initialDateSortDirection('CHRONOLOGICAL')).toBe('asc');
+    expect(initialDateSortDirection('ORDERED')).toBe('off');
+    expect(initialDateSortDirection('FIXED')).toBe('off');
+    expect(initialDateSortDirection()).toBe('off');
   });
 
   it('cycleFilmFilter uses one canonical order: off -> film -> digital -> off', () => {

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -1063,6 +1063,37 @@ describe('createHeaderRow', () => {
       expect(collectionItems[0]?.value).toBe('Has Slug');
       expect(collectionItems[0]?.slug).toBe('/has-slug');
     });
+
+    it('should thread coverImageUrl onto the collection item when present', () => {
+      const collection = createCollectionModel(1, {
+        siblings: [
+          {
+            id: 70,
+            name: 'With Cover',
+            slug: 'with-cover',
+            coverImageUrl: 'https://cdn.example.com/with-cover.jpg',
+          },
+          { id: 71, name: 'No Cover', slug: 'no-cover' },
+        ],
+      });
+      const result = asSingleRow(createHeaderRow(collection, componentWidth, chunkSize));
+      const metadataBlock = result?.items[1]?.content as ContentTextModel;
+      const collectionItems = metadataBlock.items.filter(item => item.type === 'collection');
+      expect(collectionItems).toHaveLength(2);
+      expect(collectionItems[0]).toEqual({
+        type: 'collection',
+        value: 'With Cover',
+        slug: '/with-cover',
+        coverImageUrl: 'https://cdn.example.com/with-cover.jpg',
+      });
+      // No coverImageUrl => key omitted entirely (stays a plain text-link item).
+      expect(collectionItems[1]).toEqual({
+        type: 'collection',
+        value: 'No Cover',
+        slug: '/no-cover',
+      });
+      expect(collectionItems[1]).not.toHaveProperty('coverImageUrl');
+    });
   });
 
   describe('Height-constrained sizing', () => {

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -759,6 +759,33 @@ describe('isContentVisibleInCollection', () => {
     // collectionId 42 not in collections array — should default to visible
     expect(isContentVisibleInCollection(block, 42)).toBe(true);
   });
+
+  it('should return false for an IMAGE with an empty imageUrl', () => {
+    const block = createImageContent(1, { visible: true, imageUrl: '' });
+    expect(isContentVisibleInCollection(block)).toBe(false);
+  });
+
+  it('should return false for an IMAGE with a blank (whitespace-only) imageUrl', () => {
+    const block = createImageContent(1, { visible: true, imageUrl: '   ' });
+    expect(isContentVisibleInCollection(block)).toBe(false);
+  });
+
+  it('should return true for an IMAGE with a valid imageUrl', () => {
+    const block = createImageContent(1, {
+      visible: true,
+      imageUrl: 'https://example.com/image-1.jpg',
+    });
+    expect(isContentVisibleInCollection(block)).toBe(true);
+  });
+
+  it('should return false for an IMAGE with empty imageUrl even when its collection entry is visible', () => {
+    const block = createImageContent(1, {
+      visible: true,
+      imageUrl: '',
+      collections: [{ collectionId: 42, visible: true, orderIndex: 0 }],
+    });
+    expect(isContentVisibleInCollection(block, 42)).toBe(false);
+  });
 });
 
 describe('convertCollectionContentToImage', () => {


### PR DESCRIPTION
Four collection-page fixes. **2126 jest green · tsc/eslint clean** · key flows browser-verified on the local preview.

## 1. "Image unavailable" handling
- **Manage:** a broken image (valid-looking URL that fails to load) is now clickable → opens the edit/delete modal. The runtime-failure placeholder previously hardcoded `hasClickHandler: false`.
- **Production:** images with an empty `imageUrl` are excluded pre-layout (`isContentVisibleInCollection`); runtime-broken images render nothing on the public view instead of an "Image unavailable" box. (Caveat: a runtime-broken image leaves its allocated grid slot empty until deleted — no BoxTree re-flow.)

## 2. On-hover "Update" shortcut on the cover image (localhost)
On a localhost collection page in the public view, hovering the cover image reveals a bottom-right "Update" button that enters manage mode (`?manage=1`) — same action as the menu-dropdown "Update" (which stays). Hidden in production / in manage / on non-cover images.

## 3. Related collections as cover-image cards
Related ("sibling") collections render as a row of clickable ~2:1 cover-image cards. **Cross-repo:** needs `coverImageUrl` on the siblings DTO from `edens.zac.backend` (branch `0167-sibling-cover-images`). Until that deploys, the frontend gracefully **falls back to the existing text links** (byte-identical). Per-sibling missing cover → text chip.

## 4. Chronological collections: Date filter default
When `displayMode === 'CHRONOLOGICAL'`, the Date filter defaults to `↑` (asc, oldest-first) and toggles 2-state (↑↔↓, no off). Public-view only (gated behind `!editMode` so it doesn't revert saved manual reorders). Other collections + location/tag pages keep the off/↑/↓ tri-state.

## Notes
- Plan: `docs/superpowers/plans/2026-06-15-collection-fixes.md` (gitignored local artifact).
- Bug 3 cards activate once the backend PR deploys; `next/image` `remotePatterns` already allows `*.cloudfront.net`.
