### PR TITLE
feat(content): redesign related-collections row + fix chronological f…

### DIFF
--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -318,7 +318,7 @@ export default function CollectionContentRenderer({
                 // row of ~2:1 cover cards; siblings still lacking a cover fall back to a
                 // text-link chip inside the same row (no blank placeholder).
                 <div className={cbStyles.metadataSiblingsContainer}>
-                  <span className={cbStyles.metadataSiblingLabel}>Related:</span>
+                  <span className={cbStyles.metadataSiblingLabel}>Related</span>
                   <div className={cbStyles.metadataSiblingCardRow}>
                     {collectionItems.map(item =>
                       item.coverImageUrl ? (
@@ -355,7 +355,7 @@ export default function CollectionContentRenderer({
                 // Fallback path: no sibling has a cover image (e.g. backend not yet
                 // deployed). Keep the original plain text-link row.
                 <div className={cbStyles.metadataSiblingsContainer}>
-                  <span className={cbStyles.metadataSiblingLabel}>Related:</span>
+                  <span className={cbStyles.metadataSiblingLabel}>Related</span>
                   <div className={cbStyles.metadataSiblingsRow}>
                     {collectionItems.map(item => (
                       <Link

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -563,19 +563,22 @@
   --tag-bg-active: rgb(255 255 255 / 18%);
 }
 
-/* Related sibling collections — link row mirroring the location link treatment */
+/* Related sibling collections — small heading stacked above the card row,
+   left-aligned to the metadata column edge (matching the Date filter chip). */
 .metadataSiblingsContainer {
   display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-2);
   padding-top: var(--space-2);
 }
 
 .metadataSiblingLabel {
   font-weight: 600;
-  font-size: var(--text-sm);
-  color: var(--color-fg);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-on-surface-muted);
 }
 
 .metadataSiblingsRow {
@@ -608,15 +611,17 @@
   position: relative;
   display: block;
   flex-shrink: 0;
-  width: 140px;
+  width: 110px;
   aspect-ratio: 2 / 1;
   border-radius: var(--radius-sm);
   overflow: hidden;
   text-decoration: none;
+  /* Container for the title's container-query font sizing (mirrors the cover image). */
+  container-type: inline-size;
   transition: opacity var(--duration-fast) var(--ease-standard);
 
   @media (width >= 768px) {
-    width: 200px;
+    width: 150px;
   }
 
   &:hover {
@@ -628,30 +633,31 @@
   object-fit: cover;
 }
 
+/* Full-cover overlay reusing the cover image's overlay token so the related
+   card reads like a miniature cover (centered title, same scrim). */
 .metadataSiblingCardOverlay {
   position: absolute;
   inset: 0;
   display: flex;
-  align-items: flex-end;
-  background: linear-gradient(to top, rgb(0 0 0 / 55%), rgb(0 0 0 / 0%) 60%);
+  align-items: center;
+  justify-content: center;
+  background: var(--color-text-overlay-bg);
   transition: background var(--duration-fast) var(--ease-standard);
 
   .metadataSiblingCard:hover & {
-    background: linear-gradient(to top, rgb(0 0 0 / 65%), rgb(0 0 0 / 10%) 60%);
+    background: var(--color-overlay-strong);
   }
 }
 
 .metadataSiblingCardTitle {
-  padding: var(--space-2);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  line-height: 1.3;
-  color: #fff;
+  padding: var(--space-1);
+  font-family: var(--font-serif), serif;
+  font-weight: 700;
+  font-size: clamp(0.7rem, 12cqi, 1.1rem);
+  line-height: 1.2;
+  text-align: center;
+  color: var(--color-white);
   text-shadow: 0 1px 3px rgb(0 0 0 / 50%);
-
-  @media (width >= 768px) {
-    font-size: var(--text-sm);
-  }
 }
 
 /* Cover-less sibling inside the card row: a text-link chip, vertically centered

--- a/app/components/ui/FilterToolbar/FilterToolbar.tsx
+++ b/app/components/ui/FilterToolbar/FilterToolbar.tsx
@@ -95,10 +95,15 @@ export function FilterToolbar({
 
   const filmCount = filterState.filmFilter === 'off' ? undefined : counts?.[filterState.filmFilter];
 
-  const hasActiveFilters = computeHasActiveFilters(filterState, ARRAY_FILTER_KEYS);
+  const hasActiveFilters = computeHasActiveFilters(filterState, ARRAY_FILTER_KEYS, dateTwoState);
 
   const resetAll = () => {
-    onFilterChange({ ...INITIAL_FILTER_STATE });
+    onFilterChange({
+      ...INITIAL_FILTER_STATE,
+      // Two-state views are inherently date-ordered, so `off` is invalid there:
+      // preserve the current direction and only clear the other filters.
+      ...(dateTwoState ? { dateSortDirection: filterState.dateSortDirection } : {}),
+    });
     closeAll();
   };
 

--- a/app/components/ui/FilterToolbar/filterToolbarUtils.ts
+++ b/app/components/ui/FilterToolbar/filterToolbarUtils.ts
@@ -25,13 +25,19 @@ export function isOptionAvailable(
 /**
  * Whether any filter is active: a date sort, the highly-rated toggle, the film/digital filter, or
  * any non-empty array dimension. Drives the reset (×) button's visibility.
+ *
+ * In two-state mode ({@link FilterToolbarProps.dateTwoState}) the date sort is structurally
+ * always engaged (CHRONOLOGICAL collections, asc <-> desc, never `off`), so it is NOT counted as
+ * an active filter — otherwise the reset button would show on load for every chronological view.
  */
 export function computeHasActiveFilters(
   filterState: FilterState,
-  arrayKeys: readonly ArrayFilterKey[]
+  arrayKeys: readonly ArrayFilterKey[],
+  dateTwoState = false
 ): boolean {
+  const dateActive = !dateTwoState && filterState.dateSortDirection !== 'off';
   return (
-    filterState.dateSortDirection !== 'off' ||
+    dateActive ||
     filterState.highlyRatedOnly ||
     filterState.filmFilter !== 'off' ||
     arrayKeys.some(k => (filterState[k] as readonly string[]).length > 0)

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -38,13 +38,13 @@ const baseProps = {
 };
 
 describe('CollectionContentRenderer — TEXT branch sibling collections', () => {
-  it('renders a Related: label and a link per collection item', () => {
+  it('renders a Related label and a link per collection item', () => {
     const textItems: TextBlockItem[] = [
       { type: 'collection', value: 'Dolomites Film', slug: '/dolomites-film' },
       { type: 'collection', value: 'Dolomites 2025', slug: '/dolomites-2025' },
     ];
     render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
-    expect(screen.getByText('Related:')).toBeInTheDocument();
+    expect(screen.getByText('Related')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dolomites Film' })).toHaveAttribute(
       'href',
       '/dolomites-film'
@@ -55,10 +55,10 @@ describe('CollectionContentRenderer — TEXT branch sibling collections', () => 
     );
   });
 
-  it('renders no Related: label when there are no collection items', () => {
+  it('renders no Related label when there are no collection items', () => {
     const textItems: TextBlockItem[] = [{ type: 'description', value: 'Just a description' }];
     render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
-    expect(screen.queryByText('Related:')).not.toBeInTheDocument();
+    expect(screen.queryByText('Related')).not.toBeInTheDocument();
   });
 });
 
@@ -80,8 +80,8 @@ describe('CollectionContentRenderer — sibling collections as cover cards', () 
     ];
     render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
 
-    // Related: context preserved
-    expect(screen.getByText('Related:')).toBeInTheDocument();
+    // Related context preserved
+    expect(screen.getByText('Related')).toBeInTheDocument();
 
     // Each card is a link to /{slug} with an accessible name (the collection title)
     const filmLink = screen.getByRole('link', { name: /Dolomites Film/ });
@@ -124,7 +124,7 @@ describe('CollectionContentRenderer — sibling collections as cover cards', () 
     ];
     render(<CollectionContentRenderer {...baseProps} textItems={textItems} />);
 
-    expect(screen.getByText('Related:')).toBeInTheDocument();
+    expect(screen.getByText('Related')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dolomites Film' })).toHaveAttribute(
       'href',
       '/dolomites-film'

--- a/tests/components/ui/FilterToolbar.test.tsx
+++ b/tests/components/ui/FilterToolbar.test.tsx
@@ -122,4 +122,31 @@ describe('FilterToolbar', () => {
     );
     expect(screen.getByRole('button', { name: /reset all filters/i })).toBeInTheDocument();
   });
+
+  it('hides the reset button for a two-state date sort with no other filters', () => {
+    // The always-on chronological Date sort must not surface the reset (×) on load.
+    renderToolbar({
+      showDateSort: true,
+      dateTwoState: true,
+      filterState: { ...INITIAL_FILTER_STATE, dateSortDirection: 'asc' },
+    });
+    expect(screen.queryByRole('button', { name: /reset all filters/i })).toBeNull();
+  });
+
+  it('preserves the date direction when resetting in two-state mode', () => {
+    const { onFilterChange } = renderToolbar({
+      showDateSort: true,
+      showHighlyRated: true,
+      dateTwoState: true,
+      filterState: {
+        ...INITIAL_FILTER_STATE,
+        dateSortDirection: 'desc',
+        highlyRatedOnly: true,
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /reset all filters/i }));
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({ dateSortDirection: 'desc', highlyRatedOnly: false })
+    );
+  });
 });

--- a/tests/components/ui/filterToolbarUtils.test.ts
+++ b/tests/components/ui/filterToolbarUtils.test.ts
@@ -68,4 +68,20 @@ describe('computeHasActiveFilters', () => {
     // selectedTags is non-empty but excluded from the scanned keys -> still no active filter.
     expect(computeHasActiveFilters(state, ['selectedPeople'])).toBe(false);
   });
+
+  it('ignores the always-on date sort in two-state mode', () => {
+    // CHRONOLOGICAL collections run with the Date sort always engaged (asc/desc, never off);
+    // that structural sort must not count as an active filter or the reset button shows on load.
+    const state: FilterState = { ...INITIAL_FILTER_STATE, dateSortDirection: 'asc' };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS, true)).toBe(false);
+  });
+
+  it('still reports other filters as active in two-state mode', () => {
+    const state: FilterState = {
+      ...INITIAL_FILTER_STATE,
+      dateSortDirection: 'desc',
+      highlyRatedOnly: true,
+    };
+    expect(computeHasActiveFilters(state, ARRAY_FILTER_KEYS, true)).toBe(true);
+  });
 });


### PR DESCRIPTION
…ilter reset

Related sibling-collection cards on the collection detail page:
- "Related" is now a small heading stacked above the card row, left-aligned to the metadata column edge (matching the Date filter chip)
- cards smaller (110px mobile / 150px desktop, was 140/200)
- card title centered like the cover image, reusing the cover overlay token (--color-text-overlay-bg + --color-white + --font-serif) with a container-query font, replacing the bottom gradient

FilterToolbar reset (×) button:
- no longer shows on load for CHRONOLOGICAL collections, where the always-on two-state Date sort previously counted as an active filter
- resetAll preserves the chronological date direction instead of resetting it to the invalid `off`

Tests: dateTwoState cases in filterToolbarUtils + FilterToolbar; updated the "Related" label assertions in CollectionContentRenderer.