### PR TITLE
feat(auth): Auth Foundation (Phase F) — auth.ts BFF client

### DIFF
--- a/app/lib/api/auth.ts
+++ b/app/lib/api/auth.ts
@@ -1,0 +1,265 @@
+/**
+ * Auth API — mirrors backend Phase F `/api/auth/*` endpoints through the BFF proxy.
+ *
+ * Every call is a raw `fetch` to `/api/proxy/api/auth/...` with
+ * `credentials: 'same-origin'` (so the same-origin proxy response's `Set-Cookie`
+ * is accepted/sent) and `cache: 'no-store'`. Mirrors the raw-fetch idiom of
+ * `validateClientGalleryAccess` in `app/lib/api/collections.ts`. Non-OK responses
+ * throw `ApiError` from `core.ts`; the sole exception is `me()`, which returns
+ * `null` on 401 so "logged out" is data, not an error.
+ */
+
+import { ApiError } from '@/app/lib/api/core';
+import { type MeResponse } from '@/app/types/Auth';
+
+/**
+ * Throw an `ApiError` carrying the backend message (or a status fallback) for a
+ * non-OK response. Mirrors the error extraction in `validateClientGalleryAccess`.
+ */
+async function throwFromResponse(res: Response): Promise<never> {
+  let detail: unknown;
+  const contentType = res.headers.get('content-type') || '';
+  try {
+    detail = contentType.includes('application/json') ? await res.json() : await res.text();
+  } catch {
+    detail = '';
+  }
+  const message =
+    typeof detail === 'string' && detail
+      ? detail
+      : (detail && typeof detail === 'object'
+        ? ((detail as { message?: string }).message ?? JSON.stringify(detail))
+        : `API error: ${res.status}`);
+  throw new ApiError(message, res.status);
+}
+
+/**
+ * Break-glass / bootstrap password login. POSTs `{email, password}` to
+ * `/api/proxy/api/auth/login`. Resolves on `204` (the backend sets the
+ * `ezac_session` cookie, forwarded by the proxy). Throws `ApiError(401)` on bad
+ * credentials and `ApiError(429)` when rate-limited.
+ */
+export async function login(email: string, password: string): Promise<void> {
+  if (!email) throw new Error('email is required');
+  if (!password) throw new Error('password is required');
+  const res = await fetch('/api/proxy/api/auth/login', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+}
+
+/**
+ * Revoke the current session. POSTs to `/api/proxy/api/auth/logout`; the backend
+ * returns `204` and clears the `ezac_session` cookie (forwarded by the proxy).
+ * Throws `ApiError` on any non-OK status.
+ */
+export async function logout(): Promise<void> {
+  const res = await fetch('/api/proxy/api/auth/logout', {
+    method: 'POST',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+}
+
+/**
+ * Resolve the current principal. GETs `/api/proxy/api/auth/me`. Returns the
+ * parsed `MeResponse` on `200`, `null` on `401` (anonymous — "logged out" is
+ * data, not an error), and throws `ApiError` on any other non-OK status.
+ */
+export async function me(): Promise<MeResponse | null> {
+  const res = await fetch('/api/proxy/api/auth/me', {
+    method: 'GET',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (res.status === 401) return null;
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+  return (await res.json()) as MeResponse;
+}
+
+/**
+ * Decode a base64url string (no padding, `-`/`_` alphabet) into an `ArrayBuffer`.
+ * WebAuthn ceremony JSON delivers all binary fields (challenge, user handle,
+ * credential id, attestation/assertion blobs) as base64url.
+ */
+function base64urlToArrayBuffer(value: string): ArrayBuffer {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * Encode an `ArrayBuffer` (or `ArrayBufferView`) into an unpadded base64url
+ * string for posting WebAuthn results back to the `/webauthn/*` endpoints.
+ */
+function arrayBufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * The base64url-encoded creation options the backend returns from
+ * `/webauthn/register/start`. Only the fields we decode to `ArrayBuffer` are
+ * typed precisely; the rest pass through to `navigator.credentials.create`.
+ */
+interface CreationOptionsJSON {
+  challenge: string;
+  user: { id: string; name: string; displayName: string };
+  excludeCredentials?: Array<{ id: string; type: string; transports?: AuthenticatorTransport[] }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Register a passkey for the logged-in user (session required). Drives the
+ * WebAuthn registration ceremony: fetch creation options, decode the base64url
+ * binary fields to `ArrayBuffer`, call `navigator.credentials.create()`, encode
+ * the attestation back to base64url, and POST it to `/webauthn/register/finish`.
+ * Throws `ApiError` if either round-trip is non-OK.
+ */
+export async function registerPasskey(): Promise<void> {
+  const startRes = await fetch('/api/proxy/api/auth/webauthn/register/start', {
+    method: 'POST',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!startRes.ok) {
+    await throwFromResponse(startRes);
+  }
+  const options = (await startRes.json()) as CreationOptionsJSON;
+
+  const publicKey: PublicKeyCredentialCreationOptions = {
+    ...(options as unknown as PublicKeyCredentialCreationOptions),
+    challenge: base64urlToArrayBuffer(options.challenge),
+    user: {
+      ...options.user,
+      id: base64urlToArrayBuffer(options.user.id),
+    },
+    excludeCredentials: options.excludeCredentials?.map(cred => ({
+      ...cred,
+      id: base64urlToArrayBuffer(cred.id),
+      type: 'public-key' as const,
+    })),
+  };
+
+  const credential = (await navigator.credentials.create({ publicKey })) as PublicKeyCredential;
+  const response = credential.response as AuthenticatorAttestationResponse;
+
+  const finishBody = {
+    id: credential.id,
+    rawId: arrayBufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: arrayBufferToBase64url(response.clientDataJSON),
+      attestationObject: arrayBufferToBase64url(response.attestationObject),
+    },
+  };
+
+  const finishRes = await fetch('/api/proxy/api/auth/webauthn/register/finish', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(finishBody),
+    cache: 'no-store',
+  });
+  if (!finishRes.ok) {
+    await throwFromResponse(finishRes);
+  }
+}
+
+/**
+ * The base64url-encoded request options the backend returns from
+ * `/webauthn/login/start`. Only the binary fields we decode are typed precisely.
+ */
+interface RequestOptionsJSON {
+  challenge: string;
+  allowCredentials?: Array<{ id: string; type: string; transports?: AuthenticatorTransport[] }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Log in with a passkey (public, no session required). Drives the WebAuthn
+ * assertion ceremony: fetch request options for `email`, decode the base64url
+ * binary fields, call `navigator.credentials.get()`, encode the assertion back
+ * to base64url, and POST it to `/webauthn/login/finish` (the backend sets the
+ * session cookie on `204`). Throws `ApiError` (e.g. `429`) on a non-OK round-trip.
+ */
+export async function loginWithPasskey(email: string): Promise<void> {
+  if (!email) throw new Error('email is required');
+
+  const startRes = await fetch('/api/proxy/api/auth/webauthn/login/start', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+    cache: 'no-store',
+  });
+  if (!startRes.ok) {
+    await throwFromResponse(startRes);
+  }
+  const options = (await startRes.json()) as RequestOptionsJSON;
+
+  const publicKey: PublicKeyCredentialRequestOptions = {
+    ...(options as unknown as PublicKeyCredentialRequestOptions),
+    challenge: base64urlToArrayBuffer(options.challenge),
+    allowCredentials: options.allowCredentials?.map(cred => ({
+      ...cred,
+      id: base64urlToArrayBuffer(cred.id),
+      type: 'public-key' as const,
+    })),
+  };
+
+  const credential = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential;
+  const response = credential.response as AuthenticatorAssertionResponse;
+
+  const finishBody = {
+    id: credential.id,
+    rawId: arrayBufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {
+      clientDataJSON: arrayBufferToBase64url(response.clientDataJSON),
+      authenticatorData: arrayBufferToBase64url(response.authenticatorData),
+      signature: arrayBufferToBase64url(response.signature),
+      userHandle: response.userHandle ? arrayBufferToBase64url(response.userHandle) : null,
+    },
+  };
+
+  const finishRes = await fetch('/api/proxy/api/auth/webauthn/login/finish', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(finishBody),
+    cache: 'no-store',
+  });
+  if (!finishRes.ok) {
+    await throwFromResponse(finishRes);
+  }
+}
+
+/**
+ * Internal helpers exposed ONLY for unit tests (base64url round-trip). Not part
+ * of the public auth API surface — do not import in application code.
+ */
+export const __authTestInternals = {
+  base64urlToArrayBuffer,
+  arrayBufferToBase64url,
+};

--- a/app/types/Auth.ts
+++ b/app/types/Auth.ts
@@ -1,0 +1,23 @@
+/**
+ * Auth API types — mirror the backend Phase F contract exactly.
+ *
+ * Source of truth: edens.zac.backend Auth Foundation build contract
+ * (`MeResponse`, `GalleryAccessSummary`, `Role`). The `galleries` array is
+ * always empty in Phase F (admin is all-access; client scope is Phase C) but
+ * ships now so the frontend contract is stable.
+ */
+
+export type Role = 'ADMIN' | 'CLIENT';
+
+export interface GalleryAccessSummary {
+  collectionId: number;
+  canDownload: boolean;
+  canTag: boolean;
+}
+
+export interface MeResponse {
+  email: string;
+  role: Role;
+  mfaSatisfied: boolean;
+  galleries: GalleryAccessSummary[];
+}

--- a/tests/lib/api/auth.test.ts
+++ b/tests/lib/api/auth.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for auth.ts
+ * Mirrors the fetch-mock idiom of tests/lib/api/collections.test.ts.
+ */
+
+import { login, loginWithPasskey, logout, me, registerPasskey } from '@/app/lib/api/auth';
+import { ApiError } from '@/app/lib/api/core';
+import { type MeResponse } from '@/app/types/Auth';
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+// Mock navigator.credentials (jsdom does not implement WebAuthn).
+const mockCredentialsCreate = jest.fn();
+const mockCredentialsGet = jest.fn();
+Object.defineProperty(global.navigator, 'credentials', {
+  value: { create: mockCredentialsCreate, get: mockCredentialsGet },
+  writable: true,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('login', () => {
+  it('throws when email is missing', async () => {
+    await expect(login('', 'pw')).rejects.toThrow('email is required');
+  });
+
+  it('throws when password is missing', async () => {
+    await expect(login('admin@example.com', '')).rejects.toThrow('password is required');
+  });
+
+  it('POSTs through the BFF proxy with credentials and JSON body, resolves on 204', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+    });
+
+    await expect(login('admin@example.com', 'super-secret')).resolves.toBeUndefined();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/proxy/api/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'admin@example.com', password: 'super-secret' }),
+        cache: 'no-store',
+      })
+    );
+  });
+
+  it('throws ApiError with status 401 on bad credentials', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Unauthorized' }),
+    });
+
+    const caught = await login('admin@example.com', 'wrong').catch(error => error);
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBe(401);
+  });
+
+  it('throws ApiError with status 429 when rate-limited', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Too Many Requests' }),
+    });
+
+    await expect(login('admin@example.com', 'pw')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 429,
+    });
+  });
+});
+
+describe('logout', () => {
+  it('POSTs through the BFF proxy and resolves on 204', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+    });
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/proxy/api/auth/logout',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      })
+    );
+  });
+
+  it('throws ApiError on a non-OK status', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Server error' }),
+    });
+
+    await expect(logout()).rejects.toMatchObject({ name: 'ApiError', status: 500 });
+  });
+});
+
+describe('me', () => {
+  const meBody: MeResponse = {
+    email: 'admin@example.com',
+    role: 'ADMIN',
+    mfaSatisfied: true,
+    galleries: [],
+  };
+
+  it('GETs through the BFF proxy and returns the parsed MeResponse on 200', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue(meBody),
+    });
+
+    const result = await me();
+
+    expect(result).toEqual(meBody);
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/proxy/api/auth/me',
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      })
+    );
+  });
+
+  it('returns null on 401 (anonymous), not an error', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+    });
+
+    await expect(me()).resolves.toBeNull();
+  });
+
+  it('throws ApiError on a non-401 non-OK status', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Server error' }),
+    });
+
+    await expect(me()).rejects.toMatchObject({ name: 'ApiError', status: 500 });
+  });
+});
+
+import { __authTestInternals } from '@/app/lib/api/auth';
+
+describe('base64url helpers', () => {
+  const { base64urlToArrayBuffer, arrayBufferToBase64url } = __authTestInternals;
+
+  it('round-trips arbitrary bytes through base64url without padding', () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+    const b64url = arrayBufferToBase64url(bytes.buffer);
+
+    // base64url uses -/_ and strips '=' padding
+    expect(b64url).not.toContain('+');
+    expect(b64url).not.toContain('/');
+    expect(b64url).not.toContain('=');
+
+    const restored = new Uint8Array(base64urlToArrayBuffer(b64url));
+    expect(Array.from(restored)).toEqual(Array.from(bytes));
+  });
+
+  it('decodes a known base64url string to the expected bytes', () => {
+    // "Aa-_" base64url => bytes 0x01 0xAF 0xBF
+    const restored = new Uint8Array(base64urlToArrayBuffer('Aa-_'));
+    expect(Array.from(restored)).toEqual([0x01, 0xaf, 0xbf]);
+  });
+
+  it('encodes bytes that produce - and _ in base64url', () => {
+    const bytes = new Uint8Array([0x01, 0xaf, 0xbf]);
+    expect(arrayBufferToBase64url(bytes.buffer)).toBe('Aa-_');
+  });
+});
+
+describe('registerPasskey', () => {
+  it('runs the registration ceremony: start -> create -> finish', async () => {
+    // start: backend creation options (binary fields are base64url)
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({
+          challenge: 'Aa-_', // bytes 0x01 0xAF 0xBF
+          rp: { id: 'localhost', name: 'Zac Edens Photography' },
+          user: { id: 'Aa-_', name: 'admin@example.com', displayName: 'Admin' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          excludeCredentials: [{ type: 'public-key', id: 'Aa-_' }],
+        }),
+      })
+      // finish: 204
+      .mockResolvedValueOnce({ ok: true, status: 204, headers: new Headers() });
+
+    // navigator.credentials.create returns a PublicKeyCredential-shaped object
+    mockCredentialsCreate.mockResolvedValue({
+      id: 'cred-id',
+      rawId: new Uint8Array([0x01, 0xaf, 0xbf]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: new Uint8Array([0x01]).buffer,
+        attestationObject: new Uint8Array([0xaf]).buffer,
+      },
+    });
+
+    await expect(registerPasskey()).resolves.toBeUndefined();
+
+    // start called
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/proxy/api/auth/webauthn/register/start',
+      expect.objectContaining({ method: 'POST', credentials: 'same-origin', cache: 'no-store' })
+    );
+
+    // create() received decoded ArrayBuffers
+    const createArg = mockCredentialsCreate.mock.calls[0][0];
+    expect(createArg.publicKey.challenge).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(createArg.publicKey.challenge))).toEqual([0x01, 0xaf, 0xbf]);
+    expect(createArg.publicKey.user.id).toBeInstanceOf(ArrayBuffer);
+    expect(createArg.publicKey.excludeCredentials[0].id).toBeInstanceOf(ArrayBuffer);
+
+    // finish posted base64url-encoded attestation
+    const finishCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(finishCall[0]).toBe('/api/proxy/api/auth/webauthn/register/finish');
+    const finishBody = JSON.parse(finishCall[1].body as string);
+    expect(finishBody.id).toBe('cred-id');
+    expect(finishBody.rawId).toBe('Aa-_');
+    expect(finishBody.type).toBe('public-key');
+    expect(finishBody.response.clientDataJSON).toBe('AQ'); // byte 0x01 -> base64url 'AQ'
+    expect(finishBody.response.attestationObject).toBe('rw'); // byte 0xAF -> 'rw'
+  });
+
+  it('throws ApiError when start fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Unauthorized' }),
+    });
+
+    await expect(registerPasskey()).rejects.toMatchObject({ name: 'ApiError', status: 401 });
+    expect(mockCredentialsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('loginWithPasskey', () => {
+  it('throws when email is missing', async () => {
+    await expect(loginWithPasskey('')).rejects.toThrow('email is required');
+  });
+
+  it('runs the assertion ceremony: start -> get -> finish', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({
+          challenge: 'Aa-_',
+          allowCredentials: [{ type: 'public-key', id: 'Aa-_' }],
+          rpId: 'localhost',
+          userVerification: 'required',
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 204, headers: new Headers() });
+
+    mockCredentialsGet.mockResolvedValue({
+      id: 'cred-id',
+      rawId: new Uint8Array([0x01, 0xaf, 0xbf]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: new Uint8Array([0x01]).buffer,
+        authenticatorData: new Uint8Array([0xaf]).buffer,
+        signature: new Uint8Array([0xbf]).buffer,
+        userHandle: new Uint8Array([0x01]).buffer,
+      },
+    });
+
+    await expect(loginWithPasskey('admin@example.com')).resolves.toBeUndefined();
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      '/api/proxy/api/auth/webauthn/login/start',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'admin@example.com' }),
+        cache: 'no-store',
+      })
+    );
+
+    const getArg = mockCredentialsGet.mock.calls[0][0];
+    expect(getArg.publicKey.challenge).toBeInstanceOf(ArrayBuffer);
+    expect(getArg.publicKey.allowCredentials[0].id).toBeInstanceOf(ArrayBuffer);
+
+    const finishCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(finishCall[0]).toBe('/api/proxy/api/auth/webauthn/login/finish');
+    const finishBody = JSON.parse(finishCall[1].body as string);
+    expect(finishBody.id).toBe('cred-id');
+    expect(finishBody.rawId).toBe('Aa-_');
+    expect(finishBody.response.authenticatorData).toBe('rw'); // 0xAF
+    expect(finishBody.response.signature).toBe('vw'); // 0xBF
+    expect(finishBody.response.userHandle).toBe('AQ'); // 0x01
+  });
+
+  it('throws ApiError 429 when login/start is rate-limited', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: jest.fn().mockResolvedValue({ message: 'Too Many Requests' }),
+    });
+
+    await expect(loginWithPasskey('admin@example.com')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 429,
+    });
+    expect(mockCredentialsGet).not.toHaveBeenCalled();
+  });
+
+  it('omits userHandle from the finish body when the authenticator returns none', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({
+          challenge: 'Aa-_',
+          allowCredentials: [],
+          rpId: 'localhost',
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 204, headers: new Headers() });
+
+    mockCredentialsGet.mockResolvedValue({
+      id: 'cred-id',
+      rawId: new Uint8Array([0x01]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: new Uint8Array([0x01]).buffer,
+        authenticatorData: new Uint8Array([0xaf]).buffer,
+        signature: new Uint8Array([0xbf]).buffer,
+        userHandle: null,
+      },
+    });
+
+    await loginWithPasskey('admin@example.com');
+
+    const finishBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body as string);
+    expect(finishBody.response.userHandle).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The thin frontend slice of **Phase F** (the auth spine lives in the backend — see themancalledzac/edens.zac.backend#105). Adds the BFF-routed auth client; **no BFF / proxy / admin changes**.

- `app/lib/api/auth.ts`: `login` / `logout` / `me` (password) + `registerPasskey` / `loginWithPasskey` (WebAuthn) — raw `fetch` through `/api/proxy/api/auth/*` with `credentials: 'same-origin'` + `cache: 'no-store'`, mirroring `validateClientGalleryAccess`. `me()` returns `null` on `401`.
- `app/types/Auth.ts`: `Role`, `GalleryAccessSummary`, `MeResponse` mirroring the backend records.
- base64url ↔ ArrayBuffer plumbing for the WebAuthn `navigator.credentials` ceremonies (the challenge rides a backend HttpOnly cookie — the client sends no custom header).

## Test plan

- [x] `jest tests/lib/api/auth.test.ts` — **19 tests** (URL / method / credentials / body, `401`/`429` handling, `me()` null-on-401, base64url round-trip, mocked `navigator.credentials`).
- [x] Full suite **2158 passed, 0 regressions**; `tsc --noEmit` clean; eslint clean.
- [x] BFF proxy (`app/api/proxy/[...path]/route.ts`), `app/utils/admin.ts`, and `app/(admin)/layout.tsx` confirmed **untouched** — no proxy change is needed (cookies + `Set-Cookie` already forwarded).

Depends on the backend PR: themancalledzac/edens.zac.backend#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
