### PR TITLE
fix(admin): render user detail page read-only (synthetic /user 404)

### DIFF
--- a/app/(admin)/admin/users/[id]/page.tsx
+++ b/app/(admin)/admin/users/[id]/page.tsx
@@ -55,11 +55,13 @@ export default async function AdminUserDetailPage({ params }: { params: Promise<
         <GenerateInviteButton userId={user.id} email={user.email} status={user.status} />
       </div>
 
-      {page ? (
-        <CollectionPage collection={page} editMode />
-      ) : (
-        <p>This user has no galleries yet.</p>
-      )}
+      {/*
+        Read-only. The user page is a synthetic aggregation (slug "user", no backing
+        collection row), so it is not editable: editMode mounts the edit layer, which
+        loads /api/admin/collections/user/update and 404s ("Collection not found with
+        slug: user"). The admin edits the user's real collections by drilling into a tile.
+      */}
+      {page ? <CollectionPage collection={page} /> : <p>This user has no galleries yet.</p>}
     </PageShell>
   );
 }

--- a/tests/app/admin-user-detail-page.test.tsx
+++ b/tests/app/admin-user-detail-page.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import AdminUserDetailPage from '@/app/(admin)/admin/users/[id]/page';
+import CollectionPage from '@/app/components/ContentCollection/CollectionPage';
+import { getAdminUser, getUserPageById } from '@/app/lib/api/users';
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock('@/app/components/ui/PageShell/PageShell', () => ({
+  PageShell: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock('@/app/(admin)/admin/users/GenerateInviteButton', () => ({
+  GenerateInviteButton: () => null,
+}));
+
+jest.mock('@/app/components/ContentCollection/CollectionPage', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('@/app/lib/api/users', () => ({
+  getAdminUser: jest.fn(),
+  getUserPageById: jest.fn(),
+}));
+
+const mockCollectionPage = CollectionPage as unknown as jest.Mock;
+const mockGetAdminUser = getAdminUser as jest.Mock;
+const mockGetUserPageById = getUserPageById as jest.Mock;
+
+const adminUser = { id: 5, email: 'c@x.com', displayName: 'Cara', status: 'ACTIVE' };
+
+async function renderPage() {
+  const element = await AdminUserDetailPage({ params: Promise.resolve({ id: '5' }) });
+  render(element);
+}
+
+describe('app/(admin)/admin/users/[id] — user page is rendered read-only', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAdminUser.mockResolvedValue(adminUser);
+  });
+
+  // Regression: the user page is a synthetic aggregation (slug "user", no backing collection
+  // row). editMode would mount the edit layer, which loads /api/admin/collections/user/update
+  // and 404s ("Collection not found with slug: user"). It must render read-only.
+  it('renders the synthetic user page WITHOUT editMode', async () => {
+    mockGetUserPageById.mockResolvedValue({ slug: 'user', type: 'PARENT', content: [] });
+
+    await renderPage();
+
+    expect(mockCollectionPage).toHaveBeenCalledTimes(1);
+    const props = mockCollectionPage.mock.calls[0][0];
+    expect(props.collection).toMatchObject({ slug: 'user' });
+    expect(props.editMode).toBeFalsy();
+  });
+
+  it('shows an empty state and renders no CollectionPage when the user has no galleries', async () => {
+    mockGetUserPageById.mockResolvedValue(null);
+
+    await renderPage();
+
+    expect(mockCollectionPage).not.toHaveBeenCalled();
+    expect(screen.getByText('This user has no galleries yet.')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

The admin user-detail page (`/admin/users/[id]`) surfaced a 404:

```json
{"status":404,"error":"Not Found","message":"Collection not found with slug: user"}
```

## Root cause

The page rendered the user's page with `<CollectionPage collection={page} editMode />`. The `page` is a **synthetic aggregation** the backend builds in-memory with a hardcoded `slug: "user"` (`UserPageAssembler`) — there is no `user` row in the DB.

`editMode` mounts the edit layer → `useCollectionEdit`, which on mount loads the editable DTO **by slug** → `GET /api/admin/collections/user/update` → `CollectionService.findBySlug("user")` is empty → `ResourceNotFoundException("Collection not found with slug: user")`.

Verified by curl: both `/api/read/collections/user` and `/api/admin/collections/user/update` return the exact error. The public `/user` page renders the same synthetic collection **without** `editMode`, which is why it works.

`editMode` was a regression: commit 695f755 shipped this page read-only; 68ef43e changed it to "edit-capable mode". A computed aggregation has no save target and isn't editable.

## Fix

Drop `editMode` so the admin views the user's page read-only (matching the public page and the original design). Admins still edit the user's **real** collections by drilling into a tile.

## Test plan

- Adds `tests/app/admin-user-detail-page.test.tsx` asserting `editMode` is never passed and the empty state renders when the user has no galleries.
- `eslint` clean, `tsc --noEmit` clean, 158 related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)