### PR TITLE
feat(admin): hard-delete a collection from the edit Structure tab

### DIFF
--- a/app/components/ContentCollection/edit/sections/StructureTab.module.scss
+++ b/app/components/ContentCollection/edit/sections/StructureTab.module.scss
@@ -96,3 +96,18 @@
   justify-content: space-between;
   gap: var(--space-3);
 }
+
+.dangerZone {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-danger-subtle);
+}
+
+.dangerHint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}

--- a/app/components/ContentCollection/edit/sections/StructureTab.tsx
+++ b/app/components/ContentCollection/edit/sections/StructureTab.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 
 import CollectionListSelector from '@/app/components/CollectionListSelector/CollectionListSelector';
 import RatingStars from '@/app/components/RatingStars/RatingStars';
+import { Button } from '@/app/components/ui/Button/Button';
 import { Field } from '@/app/components/ui/Field/Field';
 import { Select } from '@/app/components/ui/Field/Select';
 import { type DisplayMode } from '@/app/types/Collection';
@@ -37,6 +38,8 @@ export function StructureTab({ edit }: StructureTabProps) {
     parentIds,
     handleParentToggle,
     updateCollectionRating,
+    deleting,
+    handleDeleteCollection,
   } = edit;
 
   const collection = currentState?.collection;
@@ -155,6 +158,25 @@ export function StructureTab({ edit }: StructureTabProps) {
               </li>
             ))}
           </ul>
+        </section>
+      )}
+
+      {!isHomeCollection && (
+        <section aria-labelledby="edit-sheet-danger-heading" className={styles.dangerZone}>
+          <h3 id="edit-sheet-danger-heading" className={styles.sectionTitle}>
+            Danger zone
+          </h3>
+          <p className={styles.dangerHint}>
+            Permanently delete this collection. Its images remain in the system.
+          </p>
+          <Button
+            variant="danger"
+            loading={deleting}
+            disabled={deleting}
+            onClick={() => void handleDeleteCollection()}
+          >
+            Delete collection
+          </Button>
         </section>
       )}
     </div>

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -8,6 +8,7 @@ import { type EditableContent, useMetadataEditor } from '@/app/hooks/useMetadata
 import { useToggleTriple } from '@/app/hooks/useToggleTriple';
 import {
   createChildCollection,
+  deleteCollection,
   getCollectionUpdateMetadata,
   getMetadata,
   regenerateCollectionPeople,
@@ -131,6 +132,8 @@ export interface UseCollectionEditResult {
   isUpdateDirty: boolean;
   saving: boolean;
   handleUpdate: (patch?: Partial<CollectionUpdateRequest>) => Promise<void>;
+  deleting: boolean;
+  handleDeleteCollection: () => Promise<void>;
 
   collectionPeople: ContentPersonModel[];
   setCollectionPeople: (people: ContentPersonModel[]) => void;
@@ -210,6 +213,7 @@ export function useCollectionEdit({
 }: UseCollectionEditParams): UseCollectionEditResult {
   const router = useRouter();
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const [currentState, setCurrentState] = useState<CollectionUpdateResponseDTO | null>(null);
 
@@ -680,7 +684,8 @@ export function useCollectionEdit({
         const response = await refreshCollectionAfterOperation(
           collection.slug,
           async () => {
-            for (const file of imageFiles) { // one POST per file to stay under the proxy's multipart cap
+            for (const file of imageFiles) {
+              // one POST per file to stay under the proxy's multipart cap
               try {
                 const formData = new FormData();
                 formData.append('files', file);
@@ -922,6 +927,43 @@ export function useCollectionEdit({
       setOperationLoading(false);
     }
   }, [selectedIds, collection, currentState?.filmTypes, handleDeleteSuccess]);
+
+  const handleDeleteCollection = useCallback(async () => {
+    if (!collection) return;
+    // Safety: the home system collection must never be deletable.
+    if (collection.slug === 'home') {
+      setError('The home collection cannot be deleted.');
+      return;
+    }
+    const confirmed = window.confirm(
+      `Delete "${collection.title || collection.slug}"? This permanently removes the collection. ` +
+        'Its images and their metadata remain in the system.'
+    );
+    if (!confirmed) return;
+
+    try {
+      setDeleting(true);
+      setError(null);
+      await deleteCollection(collection.id); // throws on failure
+
+      collectionStorage.clear(collection.slug);
+      collectionStorage.clearFull(collection.slug);
+
+      const parentSlugs = (collection.parents ?? [])
+        .map(parent => parent.slug)
+        .filter((parentSlug): parentSlug is string => Boolean(parentSlug));
+      await Promise.all([
+        revalidateCollectionCache(collection.slug),
+        ...parentSlugs.map(parentSlug => revalidateCollectionCache(parentSlug)),
+      ]);
+      void revalidateMetadataCache();
+
+      router.push('/');
+    } catch (error_) {
+      setError(handleApiError(error_, 'Failed to delete collection'));
+      setDeleting(false); // stay on the page to retry; success navigates away (unmounts)
+    }
+  }, [collection, router]);
 
   const originalChildIds = useMemo(
     () =>
@@ -1359,6 +1401,8 @@ export function useCollectionEdit({
     isUpdateDirty,
     saving,
     handleUpdate,
+    deleting,
+    handleDeleteCollection,
 
     collectionPeople,
     setCollectionPeople: setCollectionPeopleState,

--- a/app/lib/api/collections.ts
+++ b/app/lib/api/collections.ts
@@ -261,10 +261,12 @@ export async function saveGalleryAccess(
 
 /**
  * DELETE /api/admin/collections/{id}
- * Delete a collection
+ * Hard-delete a collection. The backend cleans up association rows
+ * (parents/siblings/people/tags/locations) and orphans the content.
+ * Resolves to `{ success: true }` (HTTP 200) on success; throws ApiError on failure.
  */
-export async function deleteCollection(id: number): Promise<void | null> {
-  return fetchAdminDeleteApi<void>(`/collections/${id}`);
+export async function deleteCollection(id: number): Promise<{ success: boolean } | null> {
+  return fetchAdminDeleteApi<{ success: boolean }>(`/collections/${id}`);
 }
 
 /**

--- a/tests/components/ContentCollection/CollectionEditSheet.test.tsx
+++ b/tests/components/ContentCollection/CollectionEditSheet.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { CollectionEditSheet } from '@/app/components/ContentCollection/edit/CollectionEditSheet';
 import { type UseCollectionEditResult } from '@/app/components/ContentCollection/edit/useCollectionEdit';
@@ -96,6 +96,8 @@ function makeEdit(overrides: Partial<UseCollectionEditResult> = {}): UseCollecti
     isUpdateDirty: false,
     saving: false,
     handleUpdate: jest.fn(),
+    deleting: false,
+    handleDeleteCollection: jest.fn(),
 
     isParent: false,
 
@@ -366,5 +368,30 @@ describe('CollectionEditSheet — desktop two-column layout', () => {
     expect(screen.getByRole('region', { name: 'Info' })).toBeInTheDocument();
     expect(screen.getByRole('region', { name: 'Structure' })).toBeInTheDocument();
     expect(screen.queryByRole('tabpanel')).not.toBeInTheDocument();
+  });
+});
+
+describe('CollectionEditSheet — StructureTab danger zone', () => {
+  it('renders a Delete collection button on the Structure tab for a normal collection', () => {
+    render(<CollectionEditSheet edit={makeEdit({ editTab: 'structure' })} />);
+    expect(screen.getByRole('button', { name: 'Delete collection' })).toBeInTheDocument();
+  });
+
+  it('hides the Delete collection button for the home collection', () => {
+    render(
+      <CollectionEditSheet
+        edit={makeEdit({ editTab: 'structure', currentState: makeState({ slug: 'home' }) })}
+      />
+    );
+    expect(screen.queryByRole('button', { name: 'Delete collection' })).not.toBeInTheDocument();
+  });
+
+  it('invokes handleDeleteCollection when the Delete collection button is clicked', () => {
+    const handleDeleteCollection = jest.fn();
+    render(
+      <CollectionEditSheet edit={makeEdit({ editTab: 'structure', handleDeleteCollection })} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete collection' }));
+    expect(handleDeleteCollection).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/components/ContentCollection/useCollectionEdit.delete.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.delete.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Focused test for useCollectionEdit's handleDeleteCollection path — the hard
+ * delete of an entire collection (admin Danger zone). On success it calls
+ * deleteCollection(id), evicts the slug's storage, revalidates caches, and
+ * navigates home. The home system collection is guarded.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { revalidateCollectionCache } from '@/app/components/ContentCollection/edit/collectionEditUtils';
+import { useCollectionEdit } from '@/app/components/ContentCollection/edit/useCollectionEdit';
+import {
+  deleteCollection,
+  getCollectionUpdateMetadata,
+  getMetadata,
+  updateCollection,
+  updateCollectionRating,
+} from '@/app/lib/api/collections';
+import { collectionStorage } from '@/app/lib/storage/collectionStorage';
+import {
+  type CollectionModel,
+  CollectionType,
+  type CollectionUpdateResponseDTO,
+  type GeneralMetadataDTO,
+} from '@/app/types/Collection';
+import { CollectionVisibility } from '@/app/types/CollectionVisibility';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('@/app/lib/api/collections');
+jest.mock('@/app/lib/api/content');
+jest.mock('@/app/lib/storage/collectionStorage');
+
+jest.mock('@/app/utils/contentLayout', () => ({
+  processContentBlocks: (content: unknown[]) => content,
+}));
+
+jest.mock('@/app/components/ContentCollection/edit/collectionEditUtils', () => {
+  const actual = jest.requireActual(
+    '@/app/components/ContentCollection/edit/collectionEditUtils'
+  ) as Record<string, unknown>;
+  return {
+    ...actual,
+    revalidateCollectionCache: jest.fn(async () => {}),
+    revalidateMetadataCache: jest.fn(async () => {}),
+  };
+});
+
+const mockDeleteCollection = deleteCollection as jest.MockedFunction<typeof deleteCollection>;
+const mockGetCollectionUpdateMetadata = getCollectionUpdateMetadata as jest.MockedFunction<
+  typeof getCollectionUpdateMetadata
+>;
+const mockGetMetadata = getMetadata as jest.MockedFunction<typeof getMetadata>;
+const mockRevalidateCollectionCache = revalidateCollectionCache as jest.MockedFunction<
+  typeof revalidateCollectionCache
+>;
+const mockStorageGetFull = collectionStorage.getFull as jest.MockedFunction<
+  typeof collectionStorage.getFull
+>;
+const mockStorageClear = collectionStorage.clear as jest.MockedFunction<
+  typeof collectionStorage.clear
+>;
+const mockStorageClearFull = collectionStorage.clearFull as jest.MockedFunction<
+  typeof collectionStorage.clearFull
+>;
+
+function makeMetadata(overrides: Partial<GeneralMetadataDTO> = {}): GeneralMetadataDTO {
+  return {
+    tags: [],
+    people: [],
+    locations: [],
+    cameras: [],
+    lenses: [],
+    filmTypes: [],
+    filmFormats: [],
+    collections: [],
+    ...overrides,
+  };
+}
+
+function makeCollection(overrides: Partial<CollectionModel> = {}): CollectionModel {
+  return {
+    id: 42,
+    slug: 'smith-wedding',
+    title: 'Smith Wedding',
+    description: 'A description',
+    type: CollectionType.PORTFOLIO,
+    locations: [],
+    visibility: CollectionVisibility.LISTED,
+    displayMode: 'ORDERED',
+    collectionDate: '2026-01-01',
+    rowsWide: 4,
+    content: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<CollectionModel> = {}): CollectionUpdateResponseDTO {
+  return {
+    collection: makeCollection(overrides),
+    tags: [],
+    people: [],
+    locations: [],
+    cameras: [],
+    lenses: [],
+    filmTypes: [],
+    filmFormats: [],
+    collections: [],
+  };
+}
+
+function renderEdit(opts: { collection?: CollectionModel } = {}) {
+  const collection = opts.collection ?? makeCollection();
+  return renderHook(() =>
+    useCollectionEdit({
+      collection,
+      slug: collection.slug,
+      enabled: true,
+    })
+  );
+}
+
+describe('useCollectionEdit — handleDeleteCollection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouterPush.mockReset();
+    mockStorageGetFull.mockReturnValue(null);
+    mockGetCollectionUpdateMetadata.mockResolvedValue(makeResponse());
+    mockGetMetadata.mockResolvedValue(makeMetadata());
+    (updateCollection as jest.MockedFunction<typeof updateCollection>).mockResolvedValue(
+      makeResponse()
+    );
+    (
+      updateCollectionRating as jest.MockedFunction<typeof updateCollectionRating>
+    ).mockResolvedValue();
+    mockDeleteCollection.mockResolvedValue({ success: true });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('deletes, evicts storage, revalidates, and navigates home on confirm', async () => {
+    const { result } = renderEdit();
+    await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+    await act(async () => {
+      await result.current.handleDeleteCollection();
+    });
+
+    expect(mockDeleteCollection).toHaveBeenCalledWith(42);
+    expect(mockStorageClear).toHaveBeenCalledWith('smith-wedding');
+    expect(mockStorageClearFull).toHaveBeenCalledWith('smith-wedding');
+    expect(mockRevalidateCollectionCache).toHaveBeenCalledWith('smith-wedding');
+    expect(mockRouterPush).toHaveBeenCalledWith('/');
+  });
+
+  it('also revalidates each parent collection slug', async () => {
+    mockGetCollectionUpdateMetadata.mockResolvedValue(
+      makeResponse({
+        parents: [
+          { id: 7, name: 'Weddings', slug: 'weddings' },
+          { id: 8, name: 'Featured', slug: 'featured' },
+        ],
+      })
+    );
+    const { result } = renderEdit();
+    await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+    await act(async () => {
+      await result.current.handleDeleteCollection();
+    });
+
+    expect(mockRevalidateCollectionCache).toHaveBeenCalledWith('smith-wedding');
+    expect(mockRevalidateCollectionCache).toHaveBeenCalledWith('weddings');
+    expect(mockRevalidateCollectionCache).toHaveBeenCalledWith('featured');
+  });
+
+  it('does nothing when the confirm is cancelled', async () => {
+    (window.confirm as jest.Mock).mockReturnValue(false);
+    const { result } = renderEdit();
+    await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+    await act(async () => {
+      await result.current.handleDeleteCollection();
+    });
+
+    expect(mockDeleteCollection).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error and does not navigate when the delete fails', async () => {
+    mockDeleteCollection.mockRejectedValue(new Error('boom'));
+    const { result } = renderEdit();
+    await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+    await act(async () => {
+      await result.current.handleDeleteCollection();
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(result.current.deleting).toBe(false);
+  });
+
+  it('guards the home collection — never deletes', async () => {
+    mockGetCollectionUpdateMetadata.mockResolvedValue(
+      makeResponse({ id: 1, slug: 'home', title: 'Home' })
+    );
+    const { result } = renderEdit({
+      collection: makeCollection({ id: 1, slug: 'home', title: 'Home' }),
+    });
+    await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+    await act(async () => {
+      await result.current.handleDeleteCollection();
+    });
+
+    expect(mockDeleteCollection).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(result.current.error).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Delete collection** control to the admin in-place edit UI's **Structure tab** (a "Danger zone" section), hidden for the `home` system collection.
- Wires it to the existing `DELETE /collections/{id}` endpoint (shipped backend-side, returns `{ success: true }`): a new `handleDeleteCollection` + `deleting` state in `useCollectionEdit` confirms via `window.confirm`, hard-deletes (orphaning the collection's content is intentional and acceptable — the backend cleans up association rows), evicts the slug's sessionStorage cache, revalidates the collection + parent + metadata caches, then navigates to `/`.
- Tidies the `deleteCollection` util's return type to `{ success: boolean } | null` to match the backend body (was `void`).

## Test plan
- [x] `useCollectionEdit.delete.test.tsx` (5 tests): confirm → delete → evict storage → revalidate → `push('/')`; parent-slug revalidation; confirm-cancel no-op; API-error surfaces + no navigation; `home` guard.
- [x] `CollectionEditSheet.test.tsx` (+3 tests): Delete button renders on the Structure tab, hidden for `home`, click invokes the handler.
- [x] Full suite: **2262 passed / 130 suites**; `tsc --noEmit` clean; the 4 touched source/test files lint-clean.
- [ ] Manual (admin / local dev): open a collection at `/<slug>?manage=1` → **Edit** → **Structure** tab → confirm the red **Delete collection** button is present (absent for `home`); deleting navigates to `/` and the old slug 404s.

## Notes
- Branch is based before #188; its three-dot (merge-base) diff is exactly the 6 files here, and none overlap #188 → clean merge.
- A pre-existing, unrelated ESLint/Prettier `unicorn/no-nested-ternary` conflict in `app/lib/api/collections.ts` (gallery-access error formatting) is intentionally left untouched and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)