### PR TITLE
feat(user): cover + description top row on /user and admin user page

### DIFF
--- a/app/(admin)/admin/users/[id]/UserDetailEditor.tsx
+++ b/app/(admin)/admin/users/[id]/UserDetailEditor.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { UserForm } from '@/app/components/UserForm/UserForm';
+import { type AdminUserSummary } from '@/app/types/User';
+
+export interface UserDetailEditorProps {
+  user: AdminUserSummary;
+}
+
+/**
+ * Client wrapper that mounts the canonical {@link UserForm} (edit mode) on the user detail page.
+ * Bridges the server page → client callbacks: a successful save refreshes the route so the page
+ * preview below reflects the new values; Cancel returns to the admin hub.
+ */
+export function UserDetailEditor({ user }: UserDetailEditorProps) {
+  const router = useRouter();
+  return (
+    <UserForm
+      mode="edit"
+      user={user}
+      onSuccess={() => router.refresh()}
+      onCancel={() => router.push('/admin')}
+    />
+  );
+}
+
+export default UserDetailEditor;

--- a/app/(admin)/admin/users/[id]/page.module.scss
+++ b/app/(admin)/admin/users/[id]/page.module.scss
@@ -1,4 +1,4 @@
-/* Read-only admin user detail page */
+/* Admin user detail page */
 
 .header {
   display: flex;
@@ -32,53 +32,6 @@
 
   @media (width >= 768px) {
     font-size: 2rem;
-  }
-}
-
-.details {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  margin: 0;
-  padding: 0 var(--page-padding-mobile);
-
-  @media (width >= 768px) {
-    padding: 0;
-  }
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.dt {
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  color: var(--color-on-surface-muted);
-}
-
-.dd {
-  margin: 0;
-  font-size: var(--text-md);
-  color: var(--color-on-surface);
-}
-
-.status {
-  display: inline-block;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  padding: 2px var(--space-2);
-  border-radius: var(--radius-1);
-  background: var(--color-surface-alt, var(--color-surface));
-  border: 1px solid var(--color-border);
-  color: var(--color-on-surface-muted);
-
-  &[data-status='ACTIVE'] {
-    color: var(--color-on-surface);
   }
 }
 

--- a/app/(admin)/admin/users/[id]/page.tsx
+++ b/app/(admin)/admin/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import { getAdminUser, getUserPageById } from '@/app/lib/api/users';
 
 import { GenerateInviteButton } from '../GenerateInviteButton';
 import styles from './page.module.scss';
+import { UserDetailEditor } from './UserDetailEditor';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,24 +33,7 @@ export default async function AdminUserDetailPage({ params }: { params: Promise<
         <h1 className={styles.title}>{user.displayName ?? user.email}</h1>
       </div>
 
-      <dl className={styles.details}>
-        <div className={styles.field}>
-          <dt className={styles.dt}>Email</dt>
-          <dd className={styles.dd}>{user.email}</dd>
-        </div>
-        <div className={styles.field}>
-          <dt className={styles.dt}>Name</dt>
-          <dd className={styles.dd}>{user.displayName ?? '—'}</dd>
-        </div>
-        <div className={styles.field}>
-          <dt className={styles.dt}>Status</dt>
-          <dd className={styles.dd}>
-            <span className={styles.status} data-status={user.status}>
-              {user.status}
-            </span>
-          </dd>
-        </div>
-      </dl>
+      <UserDetailEditor user={user} />
 
       <div className={styles.actions}>
         <GenerateInviteButton userId={user.id} email={user.email} status={user.status} />

--- a/app/components/UserForm/UserForm.tsx
+++ b/app/components/UserForm/UserForm.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/app/components/ui/Button/Button';
 import { Field } from '@/app/components/ui/Field/Field';
 import { FormError } from '@/app/components/ui/Field/FormError';
 import { Input } from '@/app/components/ui/Field/Input';
+import { Textarea } from '@/app/components/ui/Field/Textarea';
 import { ApiError } from '@/app/lib/api/core';
 import {
   type AdminUserCollection,
@@ -40,6 +41,7 @@ export function UserForm(props: UserFormProps) {
   const [emailInput, setEmailInput] = useState('');
   const [displayName, setDisplayName] = useState(isEdit ? (props.user.displayName ?? '') : '');
   const [status, setStatus] = useState<UserStatus>(isEdit ? props.user.status : 'INVITED');
+  const [description, setDescription] = useState(isEdit ? (props.user.description ?? '') : '');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
@@ -99,6 +101,7 @@ export function UserForm(props: UserFormProps) {
       await updateUser(props.user.id, {
         displayName: displayName.trim() ? displayName.trim() : null,
         status,
+        description: description.trim() ? description.trim() : null,
       });
       props.onSuccess();
     } catch (error_) {
@@ -153,6 +156,20 @@ export function UserForm(props: UserFormProps) {
           disabled={submitting}
         />
       </Field>
+
+      {isEdit && (
+        <Field label="Description" htmlFor="user-form-description">
+          <Textarea
+            id="user-form-description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Short profile description shown on the user's page"
+            maxLength={500}
+            rows={4}
+            disabled={submitting}
+          />
+        </Field>
+      )}
 
       {isEdit && (
         <Field label="Status" htmlFor="user-form-status">

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -23,16 +23,20 @@ export interface AdminUserSummary {
   email: string;
   displayName: string | null;
   status: UserStatus;
+  /** Admin-authored profile blurb shown on the user's page; `null` when unset. */
+  description: string | null;
 }
 
 /**
- * Request body for `PATCH /api/admin/users/{id}` — the two admin-editable fields. Email is
- * immutable (it is the login identity and invite target). `displayName` may be `null` to clear it;
- * `status` is required.
+ * Request body for `PATCH /api/admin/users/{id}` — the admin-editable fields. Email is immutable
+ * (it is the login identity and invite target). `displayName` and `description` may be `null` to
+ * clear them; `status` is required. `description` is the profile blurb shown on the user's page
+ * (max 500 chars).
  */
 export interface UserUpdateRequest {
   displayName?: string | null;
   status: UserStatus;
+  description?: string | null;
 }
 
 /** Response body for `GET /api/auth/invite/{token}` (HTTP 200). */

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -564,6 +564,41 @@ function createCoverImageBlock(collection: CollectionModel): ContentParallaxImag
 }
 
 /**
+ * Build a single full-width, text-only header row (no cover image).
+ *
+ * Backs the cover-less `/user` intro: a user with a description but no tagged image still gets a
+ * header. The metadata text block renders at full width with auto height (height 0), mirroring the
+ * mobile metadata row. Returns null when there are no metadata items to show.
+ */
+function createTextOnlyHeaderRow(
+  metadataItems: TextBlockItem[],
+  componentWidth: number
+): RowWithPatternAndSizes | null {
+  if (metadataItems.length === 0) {
+    return null;
+  }
+
+  const textBlock: ContentTextModel = {
+    contentType: 'TEXT',
+    id: -2,
+    items: metadataItems,
+    format: 'plain',
+    formatType: 'plain',
+    align: 'left',
+    orderIndex: -1,
+    visible: true,
+    width: componentWidth,
+    height: 0,
+  };
+
+  return {
+    rowType: 'header',
+    items: [{ content: textBlock, width: componentWidth, height: 0 }],
+    boxTree: { type: 'leaf', content: textBlock },
+  };
+}
+
+/**
  * Create header row with cover image and metadata as a RowWithPatternAndSizes
  *
  * Creates a header row that will be prepended to regular content rows.
@@ -589,8 +624,14 @@ export function createHeaderRow(
   _chunkSize: number = LAYOUT.defaultChunkSize,
   isMobile: boolean = false
 ): RowWithPatternAndSizes | RowWithPatternAndSizes[] | null {
+  // Metadata is independent of the cover; compute it up front so a cover-less collection
+  // (e.g. the /user page for a user who isn't tagged in any image yet) can still render a
+  // description-only intro instead of no header at all.
+  const metadataItems = buildMetadataItems(collection);
+
+  // No cover image: render a text-only intro from the metadata, or nothing if there's none.
   if (!collection.coverImage) {
-    return null;
+    return createTextOnlyHeaderRow(metadataItems, componentWidth);
   }
 
   const coverBlock = createCoverImageBlock(collection);
@@ -602,7 +643,6 @@ export function createHeaderRow(
   const coverAspectRatio = coverBlock.imageWidth / coverBlock.imageHeight;
 
   // Add metadata block if it has content
-  const metadataItems = buildMetadataItems(collection);
   const metadataBlock = createMetadataTextBlock(
     metadataItems,
     coverBlock.imageWidth,

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -107,10 +107,16 @@ describe('UserForm', () => {
       email: 'ken@x.com',
       displayName: 'Ken',
       status: 'INVITED',
+      description: null,
     };
 
-    it('prefills fields, locks the email, saves displayName + status, fires onSuccess', async () => {
-      mockUpdateUser.mockResolvedValue({ ...user, displayName: 'Kenneth', status: 'ACTIVE' });
+    it('prefills fields, locks the email, saves displayName + status + description, fires onSuccess', async () => {
+      mockUpdateUser.mockResolvedValue({
+        ...user,
+        displayName: 'Kenneth',
+        status: 'ACTIVE',
+        description: 'A short bio',
+      });
 
       render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
 
@@ -125,12 +131,16 @@ describe('UserForm', () => {
       fireEvent.change(screen.getByLabelText(/status/i), {
         target: { value: 'ACTIVE' },
       });
+      fireEvent.change(screen.getByLabelText(/description/i), {
+        target: { value: 'A short bio' },
+      });
       fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
         expect(mockUpdateUser).toHaveBeenCalledWith(8, {
           displayName: 'Kenneth',
           status: 'ACTIVE',
+          description: 'A short bio',
         });
       });
       expect(onSuccess).toHaveBeenCalledTimes(1);

--- a/tests/components/UserManagementPanel.test.tsx
+++ b/tests/components/UserManagementPanel.test.tsx
@@ -36,8 +36,8 @@ Object.defineProperty(global.navigator, 'clipboard', {
 });
 
 const USERS: AdminUserSummary[] = [
-  { id: 1, email: 'alice@x.com', displayName: 'Alice', status: 'ACTIVE' },
-  { id: 2, email: 'bob@x.com', displayName: null, status: 'INVITED' },
+  { id: 1, email: 'alice@x.com', displayName: 'Alice', status: 'ACTIVE', description: null },
+  { id: 2, email: 'bob@x.com', displayName: null, status: 'INVITED', description: null },
 ];
 
 describe('UserManagementPanel', () => {

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -858,10 +858,29 @@ describe('convertCollectionContentToImage', () => {
 });
 
 describe('createHeaderRow', () => {
-  it('should return null when collection has no coverImage', () => {
-    const collection = createCollectionModel(1, { coverImage: undefined });
+  it('should return null when collection has no coverImage and no metadata', () => {
+    const collection = createCollectionModel(1, {
+      coverImage: undefined,
+      collectionDate: undefined,
+      description: undefined,
+      locations: [],
+    });
     const result = createHeaderRow(collection, 1200, 2);
     expect(result).toBeNull();
+  });
+
+  it('should return a text-only header row when there is no coverImage but metadata exists', () => {
+    const collection = createCollectionModel(1, {
+      coverImage: undefined,
+      collectionDate: undefined,
+      locations: [],
+      description: 'A short bio',
+    });
+    const row = asSingleRow(createHeaderRow(collection, 1200, 2, false));
+    expect(row).not.toBeNull();
+    expect(row?.rowType).toBe('header');
+    expect(row?.items).toHaveLength(1);
+    expect(row?.items[0]?.content.contentType).toBe('TEXT');
   });
 
   it('should return null when coverImage has no dimensions', () => {
@@ -1326,22 +1345,27 @@ describe('createHeaderRow', () => {
   });
 
   describe('Missing cover image cases', () => {
-    it('should return null when coverImage is null', () => {
+    it('should return null when coverImage is null and there is no metadata', () => {
       const collection = createCollectionModel(1, {
         coverImage: null,
+        collectionDate: undefined,
+        locations: [],
+        description: undefined,
       });
       const result = createHeaderRow(collection, componentWidth, chunkSize);
 
       expect(result).toBeNull();
     });
 
-    it('should return null when coverImage is undefined', () => {
+    it('should render a text-only header when coverImage is undefined but metadata exists', () => {
       const collection = createCollectionModel(1, {
         coverImage: undefined,
       });
-      const result = createHeaderRow(collection, componentWidth, chunkSize);
+      const result = asSingleRow(createHeaderRow(collection, componentWidth, chunkSize));
 
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result?.items).toHaveLength(1);
+      expect(result?.items[0]?.content.contentType).toBe('TEXT');
     });
 
     it('should return null when cover image has no dimensions', () => {


### PR DESCRIPTION
The /user page and admin user detail view already render a synthetic CollectionModel through the standard collection pipeline, so the cover + text top row is the existing header row. This wires it up: createHeaderRow now renders a full-width text-only header row when a collection has metadata (e.g. a user description) but no cover image; UserForm gains an admin-editable Description field (edit mode), reused on /admin/users/[id] via a thin UserDetailEditor wrapper that replaces the read-only detail view; AdminUserSummary + UserUpdateRequest carry description.

Pairs with backend branch user-page-description (random tagged cover + users.description column).