### PR TITLE
feat(viewer): tap-to-fullscreen immersive mode on mobile

### DIFF
--- a/app/components/Content/ContentBlockWithFullScreen.tsx
+++ b/app/components/Content/ContentBlockWithFullScreen.tsx
@@ -88,6 +88,7 @@ export default function ContentBlockWithFullScreen({
     modalRef,
     zoomTargetRef,
     isZoomed,
+    immersive,
     hideImage,
     isSwiping,
     showMetadata,
@@ -234,6 +235,7 @@ export default function ContentBlockWithFullScreen({
           modalRef={modalRef}
           zoomTargetRef={zoomTargetRef}
           isZoomed={isZoomed}
+          immersive={immersive}
           hideImage={hideImage}
           isSwiping={isSwiping}
           showMetadata={showMetadata}

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -35,6 +35,8 @@ interface FullScreenModalProps {
   zoomTargetRef: RefObject<HTMLDivElement | null>;
   /** True while pinch-zoomed past 1× — suppresses tap-to-close so panning doesn't dismiss. */
   isZoomed: boolean;
+  /** Immersive mode: when true, hide all chrome (controls + metadata) for an image-only view. */
+  immersive?: boolean;
   hideImage: (e?: MouseEvent) => void;
   isSwiping: RefObject<boolean>;
   showMetadata: boolean;
@@ -53,6 +55,7 @@ export function FullScreenModal({
   modalRef,
   zoomTargetRef,
   isZoomed,
+  immersive = false,
   hideImage,
   isSwiping,
   showMetadata,
@@ -160,7 +163,7 @@ export function FullScreenModal({
             )}
           </div>
 
-          {currentImageLoaded && (
+          {currentImageLoaded && !immersive && (
             <div
               className={`${styles.metadataOverlay} ${styles.metadataOverlayLoaded}`}
               onClick={e => e.stopPropagation()}
@@ -278,7 +281,7 @@ export function FullScreenModal({
         </div>
       </div>
 
-      {hasPrevious && (
+      {!immersive && hasPrevious && (
         <button
           type="button"
           className={styles.navButtonPrev}
@@ -292,7 +295,7 @@ export function FullScreenModal({
         </button>
       )}
 
-      {hasNext && (
+      {!immersive && hasNext && (
         <button
           type="button"
           className={styles.navButtonNext}
@@ -306,22 +309,24 @@ export function FullScreenModal({
         </button>
       )}
 
-      {fullScreenState.images.length > 1 && (
+      {!immersive && fullScreenState.images.length > 1 && (
         <div className={styles.positionCounter} aria-live="polite">
           {fullScreenState.currentIndex + 1} / {fullScreenState.images.length}
         </div>
       )}
 
-      <button
-        type="button"
-        className={styles.closeButton}
-        onClick={hideImage}
-        aria-label="Close fullscreen image"
-      >
-        <span aria-hidden="true">&#10005;</span>
-      </button>
+      {!immersive && (
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={hideImage}
+          aria-label="Close fullscreen image"
+        >
+          <span aria-hidden="true">&#10005;</span>
+        </button>
+      )}
 
-      {collectionData?.type === CollectionType.CLIENT_GALLERY && !isGif && (
+      {!immersive && collectionData?.type === CollectionType.CLIENT_GALLERY && !isGif && (
         <FullScreenDownloadButton imageId={currentImage.id} />
       )}
     </div>

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -16,6 +16,12 @@ import { INTERACTION } from '@/app/constants';
 import styles from '@/app/styles/fullscreen-image.module.scss';
 import type { ViewableContent } from '@/app/types/Content';
 import {
+  exitFullscreen,
+  fullscreenElement,
+  onFullscreenChange,
+  requestFullscreen,
+} from '@/app/utils/fullscreen';
+import {
   buildTransform,
   clampScale,
   clampTranslate,
@@ -25,6 +31,9 @@ import {
 /** Max gap (ms) and movement (px) between two taps to count as a double-tap. */
 const DOUBLE_TAP_MS = 300;
 const DOUBLE_TAP_SLOP = 30;
+
+/** A single-finger touch that moves less than this (px) between down and up counts as a tap. */
+const TAP_SLOP = 10;
 
 const SCROLL_BLOCKING_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', ' ', 'Home', 'End'];
 
@@ -64,6 +73,8 @@ export function useFullScreenImage(): {
   zoomTargetRef: RefObject<HTMLDivElement | null>;
   /** True while the image is pinch-zoomed past 1×; gates swipe-nav and tap-to-close. */
   isZoomed: boolean;
+  /** True while immersive mode is on (all chrome hidden); touch-toggled, persists across nav. */
+  immersive: boolean;
   isSwiping: RefObject<boolean>;
   showImage: (image: ImageBlock, allImages?: ImageBlock[]) => void;
   hideImage: (e?: MouseEvent) => void;
@@ -92,6 +103,12 @@ export function useFullScreenImage(): {
   const txRef = useRef<number>(0);
   const tyRef = useRef<number>(0);
   const [isZoomed, setIsZoomed] = useState<boolean>(false);
+  // Immersive mode: a stationary tap (touch, at 1×) hides all chrome for an image-only view and,
+  // where the browser supports it, requests native fullscreen to reclaim the address-bar height.
+  // `immersiveRef` mirrors the state so the touch handlers can read/flip it synchronously inside
+  // the gesture, where requestFullscreen must run to satisfy the user-activation requirement.
+  const [immersive, setImmersive] = useState<boolean>(false);
+  const immersiveRef = useRef<boolean>(false);
   // Two-finger pinch in progress: starting finger gap + scale to derive the live scale from.
   const pinchRef = useRef<{ startDist: number; startScale: number } | null>(null);
   // One-finger pan in progress (only while zoomed): last seen finger position.
@@ -157,6 +174,10 @@ export function useFullScreenImage(): {
     setFullScreenState(null);
     setShowMetadata(false);
     setLoadedImageIds(new Set());
+    // Leave immersive mode and native fullscreen on close so the next open starts chromed.
+    immersiveRef.current = false;
+    setImmersive(false);
+    void exitFullscreen();
 
     if (typeof window !== 'undefined') {
       if (pushedHistoryRef.current) {
@@ -290,11 +311,27 @@ export function useFullScreenImage(): {
         setFullScreenState(null);
         setShowMetadata(false);
         setLoadedImageIds(new Set());
+        immersiveRef.current = false;
+        setImmersive(false);
+        void exitFullscreen();
       }
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);
+
+  // Keep immersive state honest when the user leaves native fullscreen through the browser's own UI
+  // (system gesture / Esc). If the document is no longer fullscreen but we still think we're
+  // immersive, drop back to the chromed view so controls return and the user isn't stranded.
+  useEffect(() => {
+    if (!isOpen) return;
+    return onFullscreenChange(() => {
+      if (!fullscreenElement() && immersiveRef.current) {
+        immersiveRef.current = false;
+        setImmersive(false);
+      }
+    });
+  }, [isOpen]);
 
   const isMetadataControl = useCallback((target: HTMLElement | null): boolean => {
     if (!target) return false;
@@ -329,6 +366,14 @@ export function useFullScreenImage(): {
     // produces doesn't also fire tap-to-close. Cleared on the next touchstart.
     const suppressTapClose = () => {
       isSwiping.current = true;
+    };
+
+    // A tap that lands on an interactive control (nav arrows, close, download, or the metadata UI)
+    // must run that control, not toggle immersive. The bare photo toggles; everything chrome-like
+    // is excluded by matching the nearest button/anchor or the metadata overlay container.
+    const isImmersiveTapBlocked = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) return false;
+      return !!target.closest(`button, a, .${styles.metadataOverlay}`);
     };
 
     const handleTouchStart = (e: TouchEvent) => {
@@ -445,21 +490,44 @@ export function useFullScreenImage(): {
         lastTapRef.current = { time: e.timeStamp, x: changed.clientX, y: changed.clientY };
       }
 
-      // Swipe-to-navigate end: only at 1×.
+      // At 1×, a touch-end is either a horizontal swipe-to-navigate or a stationary tap.
       if (scaleRef.current === 1) {
         const deltaX = changed.clientX - touchStartX.current;
         const deltaY = changed.clientY - touchStartY.current;
-        if (
+        const isSwipe =
           isSwiping.current &&
           Math.abs(deltaX) > Math.abs(deltaY) &&
-          Math.abs(deltaX) > INTERACTION.swipeThreshold
-        ) {
+          Math.abs(deltaX) > INTERACTION.swipeThreshold;
+
+        if (isSwipe) {
           if (deltaX > 0) {
             navigateToPrevious();
           } else {
             navigateToNext();
           }
+        } else if (
+          // Stationary tap on the photo → toggle immersive. This lives in the touch handler, so it
+          // is inherently touch-only: desktop mouse clicks keep their close-on-click behavior.
+          !didMoveRef.current &&
+          !isSwiping.current &&
+          Math.abs(deltaX) < TAP_SLOP &&
+          Math.abs(deltaY) < TAP_SLOP &&
+          !isImmersiveTapBlocked(e.target)
+        ) {
+          const next = !immersiveRef.current;
+          immersiveRef.current = next;
+          setImmersive(next);
+          // Sync native fullscreen where supported; both calls are best-effort and never throw, and
+          // run straight from the touch handler so the request keeps its user activation.
+          if (next) {
+            void requestFullscreen(modalElement);
+          } else {
+            void exitFullscreen();
+          }
+          // Swallow the synthetic click this tap produces so it doesn't also close the viewer.
+          suppressTapClose();
         }
+
         setTimeout(() => {
           isSwiping.current = false;
         }, 50);
@@ -490,6 +558,7 @@ export function useFullScreenImage(): {
     modalRef,
     zoomTargetRef,
     isZoomed,
+    immersive,
     isSwiping,
     showImage,
     hideImage,

--- a/app/styles/fullscreen-image.module.scss
+++ b/app/styles/fullscreen-image.module.scss
@@ -23,6 +23,12 @@
   @media (width > 768px) and (height >= 600px) {
     flex-direction: row;
   }
+
+  // When the immersive toggle requests native fullscreen, THIS wrapper becomes the fullscreen root,
+  // so the dark <body>/backdrop behind it no longer paints. Give the letterbox its own black.
+  &:fullscreen {
+    background: #000;
+  }
 }
 
 .overlayContainer {

--- a/app/utils/fullscreen.ts
+++ b/app/utils/fullscreen.ts
@@ -1,0 +1,93 @@
+/**
+ * Thin, feature-detected wrappers around the native Fullscreen API.
+ *
+ * Why this exists: the immersive viewer toggle (see {@link useFullScreenImage}) requests true
+ * browser fullscreen on touch devices to reclaim the address-bar height — the whole point of the
+ * feature. Support is uneven: desktop + Android Chrome expose the standard API, older WebKit (iPad)
+ * only the `webkit`-prefixed one, and iPhone Safari exposes neither for non-`<video>` elements.
+ * These helpers normalize that and NEVER throw, so callers can fire-and-forget and let the
+ * chrome-hide fallback carry the platforms without native support.
+ */
+
+/** Structural view of an element that may carry the legacy webkit fullscreen request. */
+interface FullscreenCapableElement extends HTMLElement {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+}
+
+/** Structural view of the document's standard + legacy webkit fullscreen members. */
+interface FullscreenCapableDocument extends Document {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+}
+
+/** True if some element-level fullscreen request is available in this browser. */
+export function isFullscreenSupported(): boolean {
+  if (typeof document === 'undefined') return false;
+  const el = document.documentElement as FullscreenCapableElement;
+  return (
+    typeof el.requestFullscreen === 'function' || typeof el.webkitRequestFullscreen === 'function'
+  );
+}
+
+/** The element currently in fullscreen (standard, then webkit), or null. */
+export function fullscreenElement(): Element | null {
+  if (typeof document === 'undefined') return null;
+  const doc = document as FullscreenCapableDocument;
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+}
+
+/**
+ * Request fullscreen on `el`. Resolves `false` when there is no element, no supported API, or the
+ * request is rejected (e.g. not triggered by a user gesture). Must be called from within a user
+ * gesture handler to succeed.
+ */
+export async function requestFullscreen(el: HTMLElement | null): Promise<boolean> {
+  if (!el) return false;
+  const target = el as FullscreenCapableElement;
+  const request =
+    typeof target.requestFullscreen === 'function'
+      ? target.requestFullscreen
+      : typeof target.webkitRequestFullscreen === 'function'
+        ? target.webkitRequestFullscreen
+        : null;
+  if (!request) return false;
+  try {
+    await request.call(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Exit fullscreen if the document is currently in it. Best-effort; never throws. */
+export async function exitFullscreen(): Promise<void> {
+  if (typeof document === 'undefined') return;
+  if (!fullscreenElement()) return;
+  const doc = document as FullscreenCapableDocument;
+  const exit =
+    typeof doc.exitFullscreen === 'function'
+      ? doc.exitFullscreen
+      : typeof doc.webkitExitFullscreen === 'function'
+        ? doc.webkitExitFullscreen
+        : null;
+  if (!exit) return;
+  try {
+    await exit.call(doc);
+  } catch {
+    // Best-effort: a failed exit shouldn't surface to the caller.
+  }
+}
+
+/**
+ * Subscribe to fullscreen changes (standard + webkit event names). Returns an unsubscribe function.
+ * Used to keep app state honest when the user leaves native fullscreen via the browser's own UI.
+ */
+export function onFullscreenChange(handler: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+  document.addEventListener('fullscreenchange', handler);
+  document.addEventListener('webkitfullscreenchange', handler);
+  return () => {
+    document.removeEventListener('fullscreenchange', handler);
+    document.removeEventListener('webkitfullscreenchange', handler);
+  };
+}

--- a/tests/components/FullScreenModal/FullScreenModal.immersive.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.immersive.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Immersive-mode rendering for FullScreenModal.
+ *
+ * Immersive mode (touch-toggled in useFullScreenImage) hides ALL chrome — nav arrows, the position
+ * counter, the close button, and the metadata overlay — leaving only the photo. These tests pin
+ * that the `immersive` prop gates every control while the image itself stays mounted.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
+import type { ContentImageModel } from '@/app/types/Content';
+
+// The Modal primitive locks body scroll via useBodyScrollLock, whose cleanup calls window.scrollTo —
+// not implemented in jsdom. We only assert on markup, so stub the lock to keep the test focused.
+jest.mock('@/app/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: jest.fn() }));
+
+const img = (id: number): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: id,
+    visible: true,
+    title: `Image ${id}`,
+    locations: [],
+  }) as ContentImageModel;
+
+const noop = () => {};
+
+const baseProps = {
+  // currentIndex 1 of 3 → both prev and next arrows are eligible to render.
+  fullScreenState: { images: [img(1), img(2), img(3)], currentIndex: 1 },
+  loadedImageIds: new Set<number>([2]),
+  setLoadedImageIds: noop,
+  modalRef: { current: null },
+  zoomTargetRef: { current: null },
+  isZoomed: false,
+  hideImage: noop,
+  isSwiping: { current: false },
+  showMetadata: false,
+  toggleMetadata: noop,
+  router: { push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never,
+  navigateToNext: noop,
+  navigateToPrevious: noop,
+};
+
+describe('FullScreenModal — immersive mode', () => {
+  it('renders all chrome when not immersive', () => {
+    render(<FullScreenModal {...baseProps} immersive={false} />);
+
+    expect(screen.getByLabelText('Close fullscreen image')).toBeInTheDocument();
+    expect(screen.getByLabelText('Previous image')).toBeInTheDocument();
+    expect(screen.getByLabelText('Next image')).toBeInTheDocument();
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Show metadata')).toBeInTheDocument();
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+  });
+
+  it('hides every control in immersive mode but keeps the image', () => {
+    render(<FullScreenModal {...baseProps} immersive />);
+
+    expect(screen.queryByLabelText('Close fullscreen image')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Previous image')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Next image')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 / 3')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Show metadata')).not.toBeInTheDocument();
+
+    // The photo itself stays mounted — immersive hides chrome, not content.
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+  });
+
+  it('defaults to showing chrome when the immersive prop is omitted', () => {
+    render(<FullScreenModal {...baseProps} />);
+    expect(screen.getByLabelText('Close fullscreen image')).toBeInTheDocument();
+  });
+});

--- a/tests/utils/fullscreen.test.ts
+++ b/tests/utils/fullscreen.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the native Fullscreen API wrappers. jsdom implements none of the Fullscreen API,
+ * so each test installs the exact members it needs onto a fresh element / the document and removes
+ * them afterward. This both documents the feature-detection branches and proves the helpers never
+ * throw when the API is missing or rejects.
+ */
+import {
+  exitFullscreen,
+  fullscreenElement,
+  isFullscreenSupported,
+  onFullscreenChange,
+  requestFullscreen,
+} from '@/app/utils/fullscreen';
+
+type TestElement = HTMLElement & {
+  requestFullscreen?: () => Promise<void>;
+  webkitRequestFullscreen?: () => Promise<void> | void;
+};
+
+type TestDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  exitFullscreen?: () => Promise<void>;
+  webkitExitFullscreen?: () => Promise<void> | void;
+};
+
+const docEl = () => document.documentElement as TestElement;
+const testDoc = () => document as TestDocument;
+
+afterEach(() => {
+  Reflect.deleteProperty(document.documentElement, 'requestFullscreen');
+  Reflect.deleteProperty(document.documentElement, 'webkitRequestFullscreen');
+  Reflect.deleteProperty(document, 'webkitFullscreenElement');
+  Reflect.deleteProperty(document, 'exitFullscreen');
+  Reflect.deleteProperty(document, 'webkitExitFullscreen');
+});
+
+describe('isFullscreenSupported', () => {
+  it('is false when neither the standard nor webkit request exists', () => {
+    expect(isFullscreenSupported()).toBe(false);
+  });
+
+  it('is true when the standard requestFullscreen exists', () => {
+    docEl().requestFullscreen = jest.fn(() => Promise.resolve());
+    expect(isFullscreenSupported()).toBe(true);
+  });
+
+  it('is true when only the webkit request exists', () => {
+    docEl().webkitRequestFullscreen = jest.fn();
+    expect(isFullscreenSupported()).toBe(true);
+  });
+});
+
+describe('fullscreenElement', () => {
+  it('returns null when nothing is fullscreen', () => {
+    expect(fullscreenElement()).toBeNull();
+  });
+
+  it('falls back to the webkit fullscreen element', () => {
+    testDoc().webkitFullscreenElement = document.body;
+    expect(fullscreenElement()).toBe(document.body);
+  });
+});
+
+describe('requestFullscreen', () => {
+  it('returns false for a null element', async () => {
+    await expect(requestFullscreen(null)).resolves.toBe(false);
+  });
+
+  it('returns false when the element exposes no fullscreen API', async () => {
+    await expect(requestFullscreen(document.createElement('div'))).resolves.toBe(false);
+  });
+
+  it('calls the standard API and resolves true', async () => {
+    const el = document.createElement('div') as TestElement;
+    const spy = jest.fn(() => Promise.resolve());
+    el.requestFullscreen = spy;
+    await expect(requestFullscreen(el)).resolves.toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the webkit API and resolves true', async () => {
+    const el = document.createElement('div') as TestElement;
+    const spy = jest.fn();
+    el.webkitRequestFullscreen = spy;
+    await expect(requestFullscreen(el)).resolves.toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves false when the request rejects (e.g. no user gesture)', async () => {
+    const el = document.createElement('div') as TestElement;
+    el.requestFullscreen = jest.fn().mockRejectedValue(new Error('denied'));
+    await expect(requestFullscreen(el)).resolves.toBe(false);
+  });
+});
+
+describe('exitFullscreen', () => {
+  it('no-ops when the document is not fullscreen', async () => {
+    const spy = jest.fn(() => Promise.resolve());
+    testDoc().exitFullscreen = spy;
+    await exitFullscreen();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('calls exit when an element is fullscreen', async () => {
+    testDoc().webkitFullscreenElement = document.body;
+    const spy = jest.fn(() => Promise.resolve());
+    testDoc().exitFullscreen = spy;
+    await exitFullscreen();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a rejected exit', async () => {
+    testDoc().webkitFullscreenElement = document.body;
+    testDoc().exitFullscreen = jest.fn().mockRejectedValue(new Error('nope'));
+    await expect(exitFullscreen()).resolves.toBeUndefined();
+  });
+});
+
+describe('onFullscreenChange', () => {
+  it('fires the handler on both standard and webkit events, and stops after unsubscribe', () => {
+    const handler = jest.fn();
+    const unsubscribe = onFullscreenChange(handler);
+
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    document.dispatchEvent(new Event('webkitfullscreenchange'));
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    document.dispatchEvent(new Event('fullscreenchange'));
+    document.dispatchEvent(new Event('webkitfullscreenchange'));
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a tap-to-fullscreen "immersive" mode to the mobile photo viewer. While viewing a photo, a tap hides all on-screen chrome for an image-only view and — where the browser allows — enters native fullscreen to reclaim the address-bar height. Motivated by mobile **landscape**, where the browser's top toolbar eats scarce vertical space.

## Behavior

- **Tap the photo (touch, at 1×)** → toggle immersive: hide nav arrows, the `N / total` counter, the close ✕, the metadata overlay, and the client-gallery download button. Tap again to restore.
- **Native fullscreen** is requested on the same tap where supported (Android Chrome, desktop, iPad). **iPhone Safari** has no element-level fullscreen, so it gracefully falls back to chrome-hide only (iOS already auto-minimizes its toolbar in landscape).
- A `fullscreenchange` listener keeps state honest: leaving native fullscreen via a system gesture restores the chrome so the user is never stranded.
- **Touch-only by construction** — the toggle lives in the `touchend` handler, so desktop mouse clicks keep their existing close-on-click behavior.
- **Close** is unchanged: ✕ (when chrome shown), Back, and Esc.
- Pinch-zoom and swipe-nav are untouched; a stationary tap while zoomed (>1×) does **not** toggle (keeps pan / double-tap-reset intact).

## Design defaults

- Immersive **persists** across next/prev navigation; resets on close.
- Entering immersive doesn't reset the metadata-panel state.
- Instant hide (no fade) for v1.

## Implementation

- New, feature-detected `app/utils/fullscreen.ts` (`isFullscreenSupported`, `requestFullscreen`, `exitFullscreen`, `fullscreenElement`, `onFullscreenChange`) — normalizes standard + `webkit` APIs and never throws.
- `useFullScreenImage`: `immersive` state + a stationary-tap branch in `handleTouchEnd`; `fullscreenchange` sync; exits fullscreen on close/Back.
- `FullScreenModal`: new optional `immersive` prop gates all chrome (conditional render, keeps the focus trap clean).
- `:fullscreen` black background so the native-FS letterbox stays black.

## Testing

- `tests/utils/fullscreen.test.ts` — feature-detection + request/exit/onChange wrappers with mocked APIs.
- `tests/components/FullScreenModal/FullScreenModal.immersive.test.tsx` — all controls hidden when immersive, image still mounted; default-shows when prop omitted.
- Full suite green: 135 suites / 2298 tests. `tsc`, ESLint, Stylelint clean.

## Verification note

The toggle is a **touch gesture**, so it can't be exercised by a desktop browser preview (no touch taps; native FS on click is desktop-only and intentionally excluded). Verified via unit/component tests, type-check, and lint. Worth a real-device smoke test on Android Chrome (true fullscreen) and iPhone Safari (chrome-hide fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)