### PR TITLE
feat(admin): identity merge — absorb tag-only people into accounts

### DIFF
--- a/app/(admin)/admin/users/[id]/page.module.scss
+++ b/app/(admin)/admin/users/[id]/page.module.scss
@@ -82,6 +82,29 @@
   }
 }
 
+.badge {
+  display: inline-block;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-1);
+  background: var(--color-surface-alt, var(--color-surface));
+  border: 1px solid var(--color-border);
+  color: var(--color-on-surface-muted);
+}
+
+.hint {
+  margin: var(--space-5) 0 0;
+  padding: 0 var(--page-padding-mobile);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+
+  @media (width >= 768px) {
+    padding: 0;
+  }
+}
+
 .actions {
   padding: var(--space-5) var(--page-padding-mobile) 0;
 

--- a/app/(admin)/admin/users/[id]/page.tsx
+++ b/app/(admin)/admin/users/[id]/page.tsx
@@ -52,7 +52,7 @@ export default async function AdminUserDetailPage({ params }: { params: Promise<
       </dl>
 
       <div className={styles.actions}>
-        <GenerateInviteButton userId={user.id} email={user.email} status={user.status} />
+        <GenerateInviteButton userId={user.id} email={user.email ?? ''} status={user.status} />
       </div>
 
       {page ? (

--- a/app/(admin)/admin/users/[id]/page.tsx
+++ b/app/(admin)/admin/users/[id]/page.tsx
@@ -21,6 +21,42 @@ export default async function AdminUserDetailPage({ params }: { params: Promise<
   const user = await getAdminUser(userId).catch(() => null);
   if (!user) notFound();
 
+  // Tag-only PERSON identities have no account: no email, no invite/reset, no gallery page.
+  // Render a minimal safe view (also guards direct-URL access) — merging is done from the panel.
+  if (user.status === 'PERSON') {
+    return (
+      <PageShell pageType="collectionsCollection">
+        <div className={styles.header}>
+          <Link href="/admin" className={styles.back}>
+            ← Admin
+          </Link>
+          <h1 className={styles.title}>{user.displayName ?? '—'}</h1>
+        </div>
+
+        <dl className={styles.details}>
+          <div className={styles.field}>
+            <dt className={styles.dt}>Email</dt>
+            <dd className={styles.dd}>—</dd>
+          </div>
+          <div className={styles.field}>
+            <dt className={styles.dt}>Name</dt>
+            <dd className={styles.dd}>{user.displayName ?? '—'}</dd>
+          </div>
+          <div className={styles.field}>
+            <dt className={styles.dt}>Status</dt>
+            <dd className={styles.dd}>
+              <span className={styles.badge}>tag-only · no account</span>
+            </dd>
+          </div>
+        </dl>
+
+        <p className={styles.hint}>
+          Tag-only identity — merge it into an account from the Users panel.
+        </p>
+      </PageShell>
+    );
+  }
+
   const page = await getUserPageById(userId).catch(() => null);
 
   return (

--- a/app/components/MergeIdentityModal/MergeIdentityModal.module.scss
+++ b/app/components/MergeIdentityModal/MergeIdentityModal.module.scss
@@ -1,0 +1,66 @@
+/* MergeIdentityModal — confirmation card for absorbing a tag-only PERSON into a survivor */
+
+.card {
+  width: 100%;
+  max-width: 32rem;
+  padding: var(--space-8) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-on-surface);
+  overflow-wrap: anywhere;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.select {
+  width: 100%;
+  font-family: inherit;
+  font-size: var(--text-md);
+  line-height: 1.5;
+  height: var(--menu-item-height);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-color: var(--color-fg);
+  }
+}
+
+.preview {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  color: var(--color-on-surface);
+}
+
+.muted {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}

--- a/app/components/MergeIdentityModal/MergeIdentityModal.tsx
+++ b/app/components/MergeIdentityModal/MergeIdentityModal.tsx
@@ -48,7 +48,12 @@ export function MergeIdentityModal({
     if (!id) return;
     setLoading(true);
     try {
-      setPreview(await getMergePreview(source.id, id));
+      const result = await getMergePreview(source.id, id);
+      if (result == null) {
+        setError('That identity no longer exists — refresh the page.');
+        return;
+      }
+      setPreview(result);
     } catch {
       setError('Could not load a preview for that identity.');
     } finally {
@@ -115,7 +120,11 @@ export function MergeIdentityModal({
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={confirm} disabled={targetId == null || loading} loading={loading}>
+          <Button
+            onClick={confirm}
+            disabled={targetId == null || preview == null || loading}
+            loading={loading}
+          >
             Merge
           </Button>
         </div>

--- a/app/components/MergeIdentityModal/MergeIdentityModal.tsx
+++ b/app/components/MergeIdentityModal/MergeIdentityModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { Modal } from '@/app/components/ui/Modal/Modal';
+import { ApiError } from '@/app/lib/api/core';
+import { getMergePreview, mergeUser } from '@/app/lib/api/users';
+import { type AdminUserSummary, type MergePreview } from '@/app/types/User';
+
+import styles from './MergeIdentityModal.module.scss';
+
+export interface MergeIdentityModalProps {
+  /** The tag-only PERSON being absorbed. */
+  source: AdminUserSummary;
+  /** Candidate survivors (every identity except the source). */
+  candidates: AdminUserSummary[];
+  open: boolean;
+  onClose: () => void;
+  onMerged: () => void;
+}
+
+const labelFor = (u: AdminUserSummary) =>
+  u.email ? `${u.displayName ?? '—'} (${u.email})` : `${u.displayName ?? '—'} · tag-only`;
+
+/**
+ * Confirmation modal for absorbing a tag-only PERSON (`source`) into a surviving identity. A native
+ * `<select>` survivor-picker loads a {@link getMergePreview} on change; confirming calls
+ * {@link mergeUser} then `onMerged`. The merge is irreversible (the source row is hard-deleted).
+ */
+export function MergeIdentityModal({
+  source,
+  candidates,
+  open,
+  onClose,
+  onMerged,
+}: MergeIdentityModalProps) {
+  const [targetId, setTargetId] = useState<number | null>(null);
+  const [preview, setPreview] = useState<MergePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPreview = async (id: number) => {
+    setTargetId(id);
+    setPreview(null);
+    setError(null);
+    if (!id) return;
+    setLoading(true);
+    try {
+      setPreview(await getMergePreview(source.id, id));
+    } catch {
+      setError('Could not load a preview for that identity.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const confirm = async () => {
+    if (targetId == null) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await mergeUser(targetId, source.id);
+      onMerged();
+    } catch (error_) {
+      setError(
+        error_ instanceof ApiError && error_.status === 409
+          ? 'That merge is not allowed (only tag-only people can be absorbed).'
+          : 'Merge failed. Please try again.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} variant="overlay" labelledBy="merge-identity-title">
+      <div className={styles.card}>
+        <h2 id="merge-identity-title" className={styles.title}>
+          Merge “{source.displayName ?? '—'}” into…
+        </h2>
+        <label className={styles.field}>
+          <span>Keep this identity:</span>
+          <select
+            className={styles.select}
+            value={targetId ?? ''}
+            onChange={e => void loadPreview(Number(e.target.value))}
+          >
+            <option value="">Select an identity…</option>
+            {candidates.map(c => (
+              <option key={c.id} value={c.id}>
+                {labelFor(c)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {loading && <p className={styles.muted}>Working…</p>}
+        {error && <FormError>{error}</FormError>}
+        {preview && !loading && (
+          <p className={styles.preview}>
+            Moves <strong>{preview.imageTagCount}</strong> image tag(s) and{' '}
+            <strong>{preview.collectionCount}</strong> collection(s) from{' '}
+            <strong>{preview.sourceName ?? '—'}</strong> onto{' '}
+            <strong>{preview.targetName ?? '—'}</strong>
+            {preview.duplicatesCollapsed > 0
+              ? `, collapsing ${preview.duplicatesCollapsed} duplicate(s)`
+              : ''}
+            , then permanently deletes “{preview.sourceName ?? '—'}”. This can’t be undone.
+          </p>
+        )}
+
+        <div className={styles.actions}>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={confirm} disabled={targetId == null || loading} loading={loading}>
+            Merge
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default MergeIdentityModal;

--- a/app/components/UserForm/UserForm.tsx
+++ b/app/components/UserForm/UserForm.tsx
@@ -36,7 +36,7 @@ export type UserFormProps =
 export function UserForm(props: UserFormProps) {
   const isEdit = props.mode === 'edit';
   const editUser = isEdit ? props.user : null;
-  const [email] = useState(isEdit ? props.user.email : '');
+  const [email] = useState(isEdit ? (props.user.email ?? '') : '');
   const [emailInput, setEmailInput] = useState('');
   const [displayName, setDisplayName] = useState(isEdit ? (props.user.displayName ?? '') : '');
   const [status, setStatus] = useState<UserStatus>(isEdit ? props.user.status : 'INVITED');

--- a/app/components/UserManagementPanel/UserManagementPanel.module.scss
+++ b/app/components/UserManagementPanel/UserManagementPanel.module.scss
@@ -87,6 +87,17 @@
   }
 }
 
+/* Non-navigable identity for tag-only PERSON rows (no account detail page to reach). */
+.rowStatic {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1 1 220px;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  color: inherit;
+}
+
 /* Name over email, so the row stays readable in the narrow admin-hub column. */
 .identity {
   display: flex;

--- a/app/components/UserManagementPanel/UserManagementPanel.module.scss
+++ b/app/components/UserManagementPanel/UserManagementPanel.module.scss
@@ -136,3 +136,23 @@
   margin-left: auto;
   white-space: nowrap;
 }
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.badge {
+  flex: none;
+  margin-left: var(--space-2);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-1);
+  font-size: var(--text-xs);
+  background: var(--color-surface, var(--color-bg));
+  border: 1px solid var(--color-border);
+  color: var(--color-on-surface-muted);
+}

--- a/app/components/UserManagementPanel/UserManagementPanel.tsx
+++ b/app/components/UserManagementPanel/UserManagementPanel.tsx
@@ -93,22 +93,34 @@ export function UserManagementPanel() {
             <ul className={styles.list}>
               {users.map(user => (
                 <li key={user.id} className={styles.row}>
-                  <button
-                    type="button"
-                    className={styles.rowMain}
-                    onClick={() => router.push(`/admin/users/${user.id}`)}
-                  >
-                    <span className={styles.identity}>
-                      <span className={styles.name}>{user.displayName ?? '—'}</span>
-                      <span className={styles.email}>{user.email ?? ''}</span>
-                    </span>
-                    <span className={styles.status} data-status={user.status}>
-                      {user.status}
-                    </span>
-                    {user.status === 'PERSON' && (
+                  {user.status === 'PERSON' ? (
+                    // Tag-only people have no account detail page — render a static, non-navigable
+                    // identity so a click can't reach the account-only `/admin/users/[id]` view.
+                    <div className={styles.rowStatic}>
+                      <span className={styles.identity}>
+                        <span className={styles.name}>{user.displayName ?? '—'}</span>
+                        <span className={styles.email}>{user.email ?? ''}</span>
+                      </span>
+                      <span className={styles.status} data-status={user.status}>
+                        {user.status}
+                      </span>
                       <span className={styles.badge}>tag-only · no account</span>
-                    )}
-                  </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className={styles.rowMain}
+                      onClick={() => router.push(`/admin/users/${user.id}`)}
+                    >
+                      <span className={styles.identity}>
+                        <span className={styles.name}>{user.displayName ?? '—'}</span>
+                        <span className={styles.email}>{user.email ?? ''}</span>
+                      </span>
+                      <span className={styles.status} data-status={user.status}>
+                        {user.status}
+                      </span>
+                    </button>
+                  )}
                   <div className={styles.rowActions}>
                     {user.status === 'PERSON' ? (
                       <Button variant="secondary" size="sm" onClick={() => setMergeFor(user)}>

--- a/app/components/UserManagementPanel/UserManagementPanel.tsx
+++ b/app/components/UserManagementPanel/UserManagementPanel.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 import { GenerateInviteButton } from '@/app/(admin)/admin/users/GenerateInviteButton';
+import { revalidateMetadataCache } from '@/app/components/ContentCollection/edit/collectionEditUtils';
+import { MergeIdentityModal } from '@/app/components/MergeIdentityModal/MergeIdentityModal';
 import { Button } from '@/app/components/ui/Button/Button';
 import { UserForm } from '@/app/components/UserForm/UserForm';
 import { listUsers } from '@/app/lib/api/users';
@@ -24,15 +26,17 @@ export function UserManagementPanel() {
   const [users, setUsers] = useState<AdminUserSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<View>({ mode: 'list' });
+  const [showPeople, setShowPeople] = useState(false);
+  const [mergeFor, setMergeFor] = useState<AdminUserSummary | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      setUsers(await listUsers());
+      setUsers(await listUsers({ includePeople: showPeople }));
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [showPeople]);
 
   useEffect(() => {
     void refresh();
@@ -50,6 +54,16 @@ export function UserManagementPanel() {
     <section className={styles.panel} aria-label="User management">
       <div className={styles.header}>
         <h2 className={styles.title}>{headerTitle}</h2>
+        {view.mode === 'list' && (
+          <label className={styles.toggle}>
+            <input
+              type="checkbox"
+              checked={showPeople}
+              onChange={e => setShowPeople(e.target.checked)}
+            />
+            Show tag-only people
+          </label>
+        )}
         {view.mode === 'list' ? (
           <Button variant="secondary" size="sm" onClick={() => setView({ mode: 'create' })}>
             + New User
@@ -86,30 +100,55 @@ export function UserManagementPanel() {
                   >
                     <span className={styles.identity}>
                       <span className={styles.name}>{user.displayName ?? '—'}</span>
-                      <span className={styles.email}>{user.email}</span>
+                      <span className={styles.email}>{user.email ?? ''}</span>
                     </span>
                     <span className={styles.status} data-status={user.status}>
                       {user.status}
                     </span>
+                    {user.status === 'PERSON' && (
+                      <span className={styles.badge}>tag-only · no account</span>
+                    )}
                   </button>
                   <div className={styles.rowActions}>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setView({ mode: 'edit', user })}
-                    >
-                      Update
-                    </Button>
-                    <GenerateInviteButton
-                      userId={user.id}
-                      email={user.email}
-                      status={user.status}
-                    />
+                    {user.status === 'PERSON' ? (
+                      <Button variant="secondary" size="sm" onClick={() => setMergeFor(user)}>
+                        Merge…
+                      </Button>
+                    ) : (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setView({ mode: 'edit', user })}
+                        >
+                          Update
+                        </Button>
+                        <GenerateInviteButton
+                          userId={user.id}
+                          email={user.email ?? ''}
+                          status={user.status}
+                        />
+                      </>
+                    )}
                   </div>
                 </li>
               ))}
             </ul>
           )))}
+
+        {view.mode === 'list' && mergeFor && (
+          <MergeIdentityModal
+            source={mergeFor}
+            candidates={users.filter(u => u.id !== mergeFor.id)}
+            open
+            onClose={() => setMergeFor(null)}
+            onMerged={async () => {
+              setMergeFor(null);
+              await revalidateMetadataCache();
+              void refresh();
+            }}
+          />
+        )}
       </div>
     </section>
   );

--- a/app/lib/api/users.ts
+++ b/app/lib/api/users.ts
@@ -25,6 +25,8 @@ import {
   type AdminUserSummary,
   type CreateUserResponse,
   type InvitePreview,
+  type MergePreview,
+  type MergeResult,
   type UserCreateRequest,
   type UserUpdateRequest,
 } from '@/app/types/User';
@@ -51,11 +53,31 @@ export async function createUser(req: UserCreateRequest): Promise<CreateUserResp
 
 /**
  * List all user accounts via the admin endpoint (newest first). Returns `[]` when the endpoint
- * yields no body.
+ * yields no body. Pass `includePeople: true` to also surface tag-only `PERSON` rows.
  */
-export async function listUsers(): Promise<AdminUserSummary[]> {
-  const result = await fetchAdminGetApi<AdminUserSummary[]>('/users');
+export async function listUsers(opts?: { includePeople?: boolean }): Promise<AdminUserSummary[]> {
+  const endpoint = opts?.includePeople ? '/users?includePeople=true' : '/users';
+  const result = await fetchAdminGetApi<AdminUserSummary[]>(endpoint);
   return result ?? [];
+}
+
+/** Preview what a merge of `sourceId` into `targetId` would move. `null` if either id is gone. */
+export async function getMergePreview(
+  sourceId: number,
+  targetId: number
+): Promise<MergePreview | null> {
+  return await fetchAdminGetApi<MergePreview>(
+    `/users/${sourceId}/merge-preview?targetId=${targetId}`
+  );
+}
+
+/** Absorb tag-only `sourceId` into surviving `targetId`. Throws ApiError(409) on an illegal merge. */
+export async function mergeUser(targetId: number, sourceId: number): Promise<MergeResult> {
+  const result = await fetchAdminPostJsonApi<MergeResult>(`/users/${targetId}/merge`, { sourceId });
+  if (!result) {
+    throw new ApiError('Unexpected empty response from merge', 500);
+  }
+  return result;
 }
 
 /**

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -14,15 +14,34 @@ export interface CreateUserResponse {
   inviteUrl: string;
 }
 
-/** Account lifecycle status — mirrors the backend `UserStatus` enum. */
-export type UserStatus = 'INVITED' | 'ACTIVE' | 'DISABLED';
+/** Account lifecycle status — mirrors the backend `UserStatus` enum. `PERSON` = tag-only identity. */
+export type UserStatus = 'INVITED' | 'ACTIVE' | 'DISABLED' | 'PERSON';
 
 /** Row in the admin user list (`GET /api/admin/users`). Excludes any secret fields. */
 export interface AdminUserSummary {
   id: number;
-  email: string;
+  /** `null` for tag-only PERSON rows (no account). */
+  email: string | null;
   displayName: string | null;
   status: UserStatus;
+}
+
+/** Preview of a pending identity merge (`GET /api/admin/users/{sourceId}/merge-preview`). */
+export interface MergePreview {
+  sourceId: number;
+  sourceName: string | null;
+  targetId: number;
+  targetName: string | null;
+  imageTagCount: number;
+  collectionCount: number;
+  duplicatesCollapsed: number;
+}
+
+/** Result of a completed merge (`POST /api/admin/users/{targetId}/merge`). */
+export interface MergeResult {
+  movedImageTags: number;
+  movedCollections: number;
+  duplicatesCollapsed: number;
 }
 
 /**

--- a/tests/components/UserManagementPanel.merge.test.tsx
+++ b/tests/components/UserManagementPanel.merge.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tests the identity-merge flow on UserManagementPanel: toggling "Show tag-only people" reveals a
+ * PERSON row with a Merge action; opening the modal, picking a survivor, and confirming calls
+ * {@link mergeUser} with `(targetId, sourceId)`.
+ *
+ * Auto-mocks the users API and stubs `revalidateMetadataCache` (the merge success path calls it).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { UserManagementPanel } from '@/app/components/UserManagementPanel/UserManagementPanel';
+import { getMergePreview, listUsers, mergeUser } from '@/app/lib/api/users';
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('@/app/lib/api/users');
+jest.mock('@/app/components/ContentCollection/edit/collectionEditUtils', () => ({
+  revalidateMetadataCache: jest.fn(async () => {}),
+}));
+
+const account = {
+  id: 1,
+  email: 'danny@danny.com',
+  displayName: 'Danny',
+  status: 'ACTIVE' as const,
+};
+const person = { id: 2, email: null, displayName: 'Danny Nieves', status: 'PERSON' as const };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (listUsers as jest.Mock).mockImplementation(async (opts?: { includePeople?: boolean }) =>
+    opts?.includePeople ? [account, person] : [account]
+  );
+  (getMergePreview as jest.Mock).mockResolvedValue({
+    sourceId: 2,
+    sourceName: 'Danny Nieves',
+    targetId: 1,
+    targetName: 'Danny',
+    imageTagCount: 3,
+    collectionCount: 1,
+    duplicatesCollapsed: 0,
+  });
+  (mergeUser as jest.Mock).mockResolvedValue({
+    movedImageTags: 3,
+    movedCollections: 1,
+    duplicatesCollapsed: 0,
+  });
+});
+
+it('merges a tag-only person into an account', async () => {
+  const user = userEvent.setup();
+  render(<UserManagementPanel />);
+
+  // toggle on -> person row appears with a Merge button
+  await user.click(await screen.findByLabelText(/show tag-only people/i));
+  await user.click(await screen.findByRole('button', { name: /merge/i }));
+
+  // pick the survivor + confirm
+  await user.selectOptions(await screen.findByRole('combobox'), '1');
+  expect(await screen.findByText(/permanently deletes/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /^merge$/i }));
+
+  expect(mergeUser).toHaveBeenCalledWith(1, 2);
+});

--- a/tests/components/UserManagementPanel.merge.test.tsx
+++ b/tests/components/UserManagementPanel.merge.test.tsx
@@ -1,18 +1,20 @@
 /**
  * Tests the identity-merge flow on UserManagementPanel: toggling "Show tag-only people" reveals a
  * PERSON row with a Merge action; opening the modal, picking a survivor, and confirming calls
- * {@link mergeUser} with `(targetId, sourceId)`.
+ * {@link mergeUser} with `(targetId, sourceId)`. Also covers the safety guards: a null preview keeps
+ * the confirm disabled, and PERSON rows are non-navigable (no account detail page to reach).
  *
  * Auto-mocks the users API and stubs `revalidateMetadataCache` (the merge success path calls it).
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { UserManagementPanel } from '@/app/components/UserManagementPanel/UserManagementPanel';
 import { getMergePreview, listUsers, mergeUser } from '@/app/lib/api/users';
 
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
 jest.mock('@/app/lib/api/users');
 jest.mock('@/app/components/ContentCollection/edit/collectionEditUtils', () => ({
   revalidateMetadataCache: jest.fn(async () => {}),
@@ -61,4 +63,35 @@ it('merges a tag-only person into an account', async () => {
   await user.click(screen.getByRole('button', { name: /^merge$/i }));
 
   expect(mergeUser).toHaveBeenCalledWith(1, 2);
+});
+
+it('keeps the confirm disabled (and never merges) when the preview is null', async () => {
+  (getMergePreview as jest.Mock).mockResolvedValue(null);
+  const user = userEvent.setup();
+  render(<UserManagementPanel />);
+
+  await user.click(await screen.findByLabelText(/show tag-only people/i));
+  await user.click(await screen.findByRole('button', { name: /merge/i }));
+  await user.selectOptions(await screen.findByRole('combobox'), '1');
+
+  // null preview surfaces an error, no preview text, and a disabled confirm
+  expect(await screen.findByText(/no longer exists/i)).toBeInTheDocument();
+  expect(screen.queryByText(/permanently deletes/i)).not.toBeInTheDocument();
+  const confirm = screen.getByRole('button', { name: /^merge$/i });
+  expect(confirm).toBeDisabled();
+
+  await user.click(confirm);
+  expect(mergeUser).not.toHaveBeenCalled();
+});
+
+it('does not navigate to a detail page when a tag-only person row is clicked', async () => {
+  const user = userEvent.setup();
+  render(<UserManagementPanel />);
+
+  await user.click(await screen.findByLabelText(/show tag-only people/i));
+  // The PERSON row identity is a static element, not a navigating button.
+  const personRow = (await screen.findByText('Danny Nieves')).closest('li') as HTMLElement;
+  await user.click(within(personRow).getByText('Danny Nieves'));
+
+  expect(mockPush).not.toHaveBeenCalled();
 });

--- a/tests/lib/api/users.test.ts
+++ b/tests/lib/api/users.test.ts
@@ -12,9 +12,11 @@ import {
   createUser,
   getAdminUser,
   getInvitePreview,
+  getMergePreview,
   getUserPageById,
   listUserCollections,
   listUsers,
+  mergeUser,
   regenerateInvite,
   removeUserCollection,
   setUserCollectionRole,
@@ -374,5 +376,54 @@ describe('getUserPageById', () => {
     (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(null);
 
     expect(await getUserPageById(5)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listUsers includePeople
+// ---------------------------------------------------------------------------
+
+describe('listUsers includePeople', () => {
+  it('requests ?includePeople=true when asked', async () => {
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue([]);
+    await listUsers({ includePeople: true });
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/users?includePeople=true');
+  });
+  it('requests plain /users by default', async () => {
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue([]);
+    await listUsers();
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/users');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMergePreview
+// ---------------------------------------------------------------------------
+
+describe('getMergePreview', () => {
+  it('GETs the preview with the targetId query', async () => {
+    const preview = { sourceId: 2, targetId: 1, imageTagCount: 3 };
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(preview);
+    const result = await getMergePreview(2, 1);
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/users/2/merge-preview?targetId=1');
+    expect(result).toEqual(preview);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeUser
+// ---------------------------------------------------------------------------
+
+describe('mergeUser', () => {
+  it('POSTs sourceId to the target merge endpoint', async () => {
+    const res = { movedImageTags: 2, movedCollections: 1, duplicatesCollapsed: 0 };
+    (core.fetchAdminPostJsonApi as jest.Mock).mockResolvedValue(res);
+    const result = await mergeUser(1, 2);
+    expect(core.fetchAdminPostJsonApi).toHaveBeenCalledWith('/users/1/merge', { sourceId: 2 });
+    expect(result).toEqual(res);
+  });
+  it('propagates ApiError(409) for an illegal merge', async () => {
+    (core.fetchAdminPostJsonApi as jest.Mock).mockRejectedValue(new ApiError('Conflict', 409));
+    await expect(mergeUser(1, 2)).rejects.toMatchObject({ name: 'ApiError', status: 409 });
   });
 });


### PR DESCRIPTION
## Identity merge — frontend

Admin UI to absorb a tag-only `PERSON` (e.g. "Danny Nieves") into a surviving account/identity (e.g. "Danny") — the successor to the deleted V31 person→account link.

### What's included
- `app/types/User.ts`: `PERSON` status, nullable `email`, `MergePreview`/`MergeResult`.
- `app/lib/api/users.ts`: `getMergePreview`, `mergeUser`, `listUsers({ includePeople })`.
- `MergeIdentityModal`: native-select survivor picker, preview-then-confirm (cannot fire without a loaded preview).
- `UserManagementPanel`: default-off "Show tag-only people" toggle, `tag-only · no account` badge, Merge action on PERSON rows only.
- PERSON-safe `/admin/users/[id]` + non-navigable PERSON rows; `revalidateMetadataCache()` after a merge.

### Testing
jest **2307 passing**, tsc clean, eslint clean on touched files.

### Notes
- Pairs with the backend PR — **deploy together** (new endpoints; the merge re-points tags/memberships then hard-deletes the source PERSON row).
- Merged latest `main`; resolved the user-detail page styles and stubbed `UserDetailEditor` in a pre-existing main test that rendered a client component without mocking `useRouter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)