### PR TITLE
feat(admin): compact single-line user rows with status dot

### DIFF
--- a/app/(admin)/admin/users/GenerateInviteButton.tsx
+++ b/app/(admin)/admin/users/GenerateInviteButton.tsx
@@ -30,6 +30,7 @@ export function GenerateInviteButton({ userId, email, status }: GenerateInviteBu
   const [error, setError] = useState<string | null>(null);
 
   const actionLabel = status === 'ACTIVE' ? 'Reset password link' : 'Resend invite';
+  const buttonLabel = status === 'ACTIVE' ? 'Reset pw' : 'Resend';
 
   const handleGenerate = async () => {
     setOpen(true);
@@ -59,7 +60,7 @@ export function GenerateInviteButton({ userId, email, status }: GenerateInviteBu
   return (
     <>
       <Button variant="secondary" size="sm" onClick={handleGenerate}>
-        {actionLabel}
+        {buttonLabel}
       </Button>
       <Modal open={open} onClose={handleClose} variant="overlay" labelledBy="generate-invite-title">
         <div className={styles.card}>

--- a/app/components/UserManagementPanel/UserManagementPanel.module.scss
+++ b/app/components/UserManagementPanel/UserManagementPanel.module.scss
@@ -95,12 +95,53 @@
   min-width: 0;
 }
 
+/* Dot + name share a line; the email sits below. */
+.nameLine {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* Status at a glance: green active, amber invited, red disabled. */
+.dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-on-surface-muted);
+
+  &[data-status='ACTIVE'] {
+    background: var(--color-success);
+  }
+
+  &[data-status='INVITED'] {
+    background: var(--color-warning);
+  }
+
+  &[data-status='DISABLED'] {
+    background: var(--color-danger);
+  }
+}
+
 .name {
   font-weight: 600;
   color: var(--color-on-surface);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .email {
@@ -111,28 +152,13 @@
   white-space: nowrap;
 }
 
-.status {
-  display: inline-block;
-  flex: none;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  padding: 2px var(--space-2);
-  border-radius: var(--radius-1);
-  background: var(--color-surface, var(--color-bg));
-  border: 1px solid var(--color-border);
-  color: var(--color-on-surface-muted);
-
-  &[data-status='ACTIVE'] {
-    color: var(--color-on-surface);
-  }
-}
-
+/* Update over Reset pw, mirroring the name-over-email stack on the left. */
 .rowActions {
   display: flex;
   flex: none;
-  align-items: center;
-  gap: var(--space-2);
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
   margin-left: auto;
   white-space: nowrap;
 }

--- a/app/components/UserManagementPanel/UserManagementPanel.tsx
+++ b/app/components/UserManagementPanel/UserManagementPanel.tsx
@@ -85,11 +85,12 @@ export function UserManagementPanel() {
                     onClick={() => router.push(`/admin/users/${user.id}`)}
                   >
                     <span className={styles.identity}>
-                      <span className={styles.name}>{user.displayName ?? '—'}</span>
+                      <span className={styles.nameLine}>
+                        <span className={styles.dot} data-status={user.status} aria-hidden="true" />
+                        <span className={styles.name}>{user.displayName ?? '—'}</span>
+                        <span className={styles.srOnly}>{user.status}</span>
+                      </span>
                       <span className={styles.email}>{user.email}</span>
-                    </span>
-                    <span className={styles.status} data-status={user.status}>
-                      {user.status}
                     </span>
                   </button>
                   <div className={styles.rowActions}>


### PR DESCRIPTION
## Summary
Tightens the Admin Users panel so each user fits on a single row.

- **Shorter action label** — `Reset password link` → `Reset pw` (active users) / `Resend invite` → `Resend` (invited/disabled). The modal keeps the full descriptive title.
- **Status dot instead of text badge** — colored dot next to the name: green = active, amber = invited, red = disabled (uses `--color-success` / `--color-warning` / `--color-danger`).
- **Two-line row layout** — name + `Update` on top, email + `Reset pw` below, with actions right-aligned and stacked.
- Status text is preserved for screen readers via a visually-hidden span, so dropping the visible badge doesn't lose accessibility.

## Files
- `app/(admin)/admin/users/GenerateInviteButton.tsx` — short button label, full modal title unchanged
- `app/components/UserManagementPanel/UserManagementPanel.tsx` — dot + sr-only status, stacked actions
- `app/components/UserManagementPanel/UserManagementPanel.module.scss` — `.dot`, `.nameLine`, `.srOnly`; removed `.status`; `.rowActions` now a vertical stack

## Note
The status type has three states (`INVITED`, `ACTIVE`, `DISABLED`), so amber was added for `INVITED` rather than a strict green/red binary.

## Verification
Prettier, ESLint, Stylelint, and `tsc --noEmit` all pass. No live browser pass — the `/admin` panel is behind admin auth and depends on the backend `listUsers` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)