### PR TITLE
fix(auth+admin): live menu auth-state on logout; editable admin user email

### DIFF
--- a/app/components/UserForm/UserForm.tsx
+++ b/app/components/UserForm/UserForm.tsx
@@ -31,14 +31,14 @@ export type UserFormProps =
 /**
  * Reusable inline form for creating or editing a user. In `create` mode it collects email + display
  * name, calls {@link createUser}, then shows the copyable invite link. In `edit` mode it prefills
- * the user's values, locks the email (immutable identity), and saves display name + status via
- * {@link updateUser}. Designed to live inside `UserManagementPanel`'s body, not a modal.
+ * the user's values and saves email (the login identity — the server rejects with 409 if another
+ * user owns it), display name, status, and description via {@link updateUser}. Designed to live
+ * inside `UserManagementPanel`'s body, not a modal.
  */
 export function UserForm(props: UserFormProps) {
   const isEdit = props.mode === 'edit';
   const editUser = isEdit ? props.user : null;
-  const [email] = useState(isEdit ? (props.user.email ?? '') : '');
-  const [emailInput, setEmailInput] = useState('');
+  const [email, setEmail] = useState(isEdit ? (props.user.email ?? '') : '');
   const [displayName, setDisplayName] = useState(isEdit ? (props.user.displayName ?? '') : '');
   const [status, setStatus] = useState<UserStatus>(isEdit ? props.user.status : 'INVITED');
   const [description, setDescription] = useState(isEdit ? (props.user.description ?? '') : '');
@@ -72,15 +72,16 @@ export function UserForm(props: UserFormProps) {
     e.preventDefault();
     setError(null);
 
+    if (!email.trim()) {
+      setError('Email is required.');
+      return;
+    }
+
     if (props.mode === 'create') {
-      if (!emailInput.trim()) {
-        setError('Email is required.');
-        return;
-      }
       try {
         setSubmitting(true);
         const result = await createUser({
-          email: emailInput.trim(),
+          email: email.trim(),
           ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
         });
         setInviteUrl(result.inviteUrl);
@@ -99,17 +100,20 @@ export function UserForm(props: UserFormProps) {
     try {
       setSubmitting(true);
       await updateUser(props.user.id, {
+        email: email.trim(),
         displayName: displayName.trim() ? displayName.trim() : null,
         status,
         description: description.trim() ? description.trim() : null,
       });
       props.onSuccess();
     } catch (error_) {
-      setError(
-        error_ instanceof ApiError && error_.status === 404
-          ? 'This user no longer exists — refresh the list.'
-          : 'Failed to update user. Please try again.'
-      );
+      if (error_ instanceof ApiError && error_.status === 409) {
+        setError('A user with that email already exists.');
+      } else if (error_ instanceof ApiError && error_.status === 404) {
+        setError('This user no longer exists — refresh the list.');
+      } else {
+        setError('Failed to update user. Please try again.');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -137,12 +141,11 @@ export function UserForm(props: UserFormProps) {
         <Input
           id="user-form-email"
           type="email"
-          value={isEdit ? email : emailInput}
-          onChange={e => setEmailInput(e.target.value)}
+          value={email}
+          onChange={e => setEmail(e.target.value)}
           placeholder="client@example.com"
           autoComplete="off"
           disabled={submitting}
-          readOnly={isEdit}
         />
       </Field>
 

--- a/app/components/UserManagementPanel/UserManagementPanel.tsx
+++ b/app/components/UserManagementPanel/UserManagementPanel.tsx
@@ -42,6 +42,8 @@ export function UserManagementPanel() {
     try {
       await loginAsUser(userId);
       // Full navigation so the freshly-set ezac_session cookie is used for the /user server render.
+      // Also doubles as the auth-state refresh: loginAsUser does NOT dispatch AUTH_CHANGED_EVENT,
+      // so swapping this for router.push would resurrect the stale-menu bug (useFetchMe never refetches).
       window.location.assign('/user');
     } catch (error) {
       logger.error('UserManagementPanel', 'impersonation failed', error, { userId });

--- a/app/hooks/useFetchMe.ts
+++ b/app/hooks/useFetchMe.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { me as fetchMe } from '@/app/lib/api/auth';
+import { AUTH_CHANGED_EVENT, me as fetchMe } from '@/app/lib/api/auth';
 import { type MeResponse } from '@/app/types/Auth';
 
 export interface UseFetchMeResult {
@@ -11,8 +11,12 @@ export interface UseFetchMeResult {
 }
 
 /**
- * Fetch the current principal via `me()` once on mount. `loading` is true until the
- * first resolution; `me` is null when logged out (or still loading).
+ * Fetch the current principal via `me()` on mount, and refetch whenever
+ * `AUTH_CHANGED_EVENT` fires on `window` (dispatched by `login()`/`loginWithPasskey()`/
+ * `logout()` in `app/lib/api/auth`) — so always-mounted consumers update on auth
+ * changes without a remount. `loading` is true only until the FIRST resolution;
+ * refetches never flip it back, so consumers don't flash their loading state during
+ * logout/login. `me` is null when logged out (or before the first resolution).
  *
  * This is the client-FETCH counterpart to `MeProvider`/`useMe`, which exposes the
  * server-resolved principal via context. Use this hook for surfaces rendered OUTSIDE
@@ -24,18 +28,30 @@ export function useFetchMe(): UseFetchMeResult {
 
   useEffect(() => {
     let active = true;
-    fetchMe()
-      .then(result => {
-        if (active) setMe(result);
-      })
-      .catch(() => {
-        if (active) setMe(null);
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
+    // Monotonic token: only the newest in-flight request may apply state, so a
+    // stale response from a rapid logout/login pair can never overwrite a newer one.
+    let latestRequest = 0;
+
+    const run = () => {
+      const requestId = ++latestRequest;
+      const isCurrent = () => active && requestId === latestRequest;
+      fetchMe()
+        .then(result => {
+          if (isCurrent()) setMe(result);
+        })
+        .catch(() => {
+          if (isCurrent()) setMe(null);
+        })
+        .finally(() => {
+          if (isCurrent()) setLoading(false);
+        });
+    };
+
+    run();
+    window.addEventListener(AUTH_CHANGED_EVENT, run);
     return () => {
       active = false;
+      window.removeEventListener(AUTH_CHANGED_EVENT, run);
     };
   }, []);
 

--- a/app/lib/api/auth.ts
+++ b/app/lib/api/auth.ts
@@ -13,6 +13,25 @@ import { ApiError, getApiBaseUrl, getServerCookieHeader } from '@/app/lib/api/co
 import { type MeResponse } from '@/app/types/Auth';
 
 /**
+ * Browser event dispatched on `window` whenever a client-side auth call changes the
+ * session — successful `login()`, `loginWithPasskey()`, or `logout()`. Client hooks
+ * that cache the principal (`useFetchMe`) listen for it and refetch, so always-mounted
+ * surfaces (the nav menu) update without a remount or hard refresh.
+ */
+export const AUTH_CHANGED_EVENT = 'auth-changed';
+
+/**
+ * Dispatch {@link AUTH_CHANGED_EVENT}. Success paths only — a failed call must not
+ * poke listeners into refetching, since the session may still be alive server-side.
+ * Window-guarded because this module is also imported in server contexts (`meServer`).
+ */
+function dispatchAuthChanged(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+  }
+}
+
+/**
  * Throw an `ApiError` carrying the backend message (or a status fallback) for a
  * non-OK response. Mirrors the error extraction in `validateClientGalleryAccess`.
  */
@@ -36,8 +55,9 @@ async function throwFromResponse(res: Response): Promise<never> {
 /**
  * Break-glass / bootstrap password login. POSTs `{email, password}` to
  * `/api/proxy/api/auth/login`. Resolves on `204` (the backend sets the
- * `ezac_session` cookie, forwarded by the proxy). Throws `ApiError(401)` on bad
- * credentials and `ApiError(429)` when rate-limited.
+ * `ezac_session` cookie, forwarded by the proxy) and dispatches
+ * {@link AUTH_CHANGED_EVENT} so client listeners refetch the principal. Throws
+ * `ApiError(401)` on bad credentials and `ApiError(429)` when rate-limited.
  */
 export async function login(email: string, password: string): Promise<void> {
   if (!email) throw new Error('email is required');
@@ -52,12 +72,15 @@ export async function login(email: string, password: string): Promise<void> {
   if (!res.ok) {
     await throwFromResponse(res);
   }
+  dispatchAuthChanged();
 }
 
 /**
  * Revoke the current session. POSTs to `/api/proxy/api/auth/logout`; the backend
  * returns `204` and clears the `ezac_session` cookie (forwarded by the proxy).
- * Throws `ApiError` on any non-OK status.
+ * Dispatches {@link AUTH_CHANGED_EVENT} on success so client listeners refetch the
+ * principal. Throws `ApiError` on any non-OK status (without dispatching — the
+ * session may still be alive server-side).
  */
 export async function logout(): Promise<void> {
   const res = await fetch('/api/proxy/api/auth/logout', {
@@ -68,6 +91,7 @@ export async function logout(): Promise<void> {
   if (!res.ok) {
     await throwFromResponse(res);
   }
+  dispatchAuthChanged();
 }
 
 /**
@@ -220,7 +244,8 @@ interface RequestOptionsJSON {
  * assertion ceremony: fetch request options for `email`, decode the base64url
  * binary fields, call `navigator.credentials.get()`, encode the assertion back
  * to base64url, and POST it to `/webauthn/login/finish` (the backend sets the
- * session cookie on `204`). Throws `ApiError` (e.g. `429`) on a non-OK round-trip.
+ * session cookie on `204`). Dispatches {@link AUTH_CHANGED_EVENT} once the finish
+ * step succeeds. Throws `ApiError` (e.g. `429`) on a non-OK round-trip.
  */
 export async function loginWithPasskey(email: string): Promise<void> {
   if (!email) throw new Error('email is required');
@@ -272,6 +297,7 @@ export async function loginWithPasskey(email: string): Promise<void> {
   if (!finishRes.ok) {
     await throwFromResponse(finishRes);
   }
+  dispatchAuthChanged();
 }
 
 /**

--- a/app/lib/api/users.ts
+++ b/app/lib/api/users.ts
@@ -115,10 +115,11 @@ export async function loginAsUser(userId: number): Promise<void> {
 }
 
 /**
- * Update an existing user's display name and status via the admin endpoint.
+ * Update an existing user's email, display name, status, and description via the admin endpoint.
  *
  * @returns the refreshed `AdminUserSummary`.
  * @throws `ApiError(404)` when the user no longer exists.
+ * @throws `ApiError(409)` when another user already owns the requested email.
  */
 export async function updateUser(id: number, body: UserUpdateRequest): Promise<AdminUserSummary> {
   const result = await fetchAdminPatchJsonApi<AdminUserSummary>(`/users/${id}`, body);

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -48,10 +48,10 @@ export interface MergeResult {
 
 /**
  * Request body for `PATCH /api/admin/users/{id}` — the admin-editable fields. `email` is optional:
- * omitted or blank leaves the login email unchanged; when present the server lowercases it and
- * responds `409 Conflict` if another user already owns it. `displayName` and `description` may be
- * `null` to clear them; `status` is required. `description` is the profile blurb shown on the
- * user's page (max 500 chars).
+ * omitted or empty leaves the login email unchanged (whitespace-only gets a `400` from the
+ * server); when non-empty the server lowercases it and responds `409 Conflict` if another user
+ * already owns it. `displayName` and `description` may be `null` to clear them; `status` is
+ * required. `description` is the profile blurb shown on the user's page (max 500 chars).
  */
 export interface UserUpdateRequest {
   email?: string;

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -47,12 +47,14 @@ export interface MergeResult {
 }
 
 /**
- * Request body for `PATCH /api/admin/users/{id}` — the admin-editable fields. Email is immutable
- * (it is the login identity and invite target). `displayName` and `description` may be `null` to
- * clear them; `status` is required. `description` is the profile blurb shown on the user's page
- * (max 500 chars).
+ * Request body for `PATCH /api/admin/users/{id}` — the admin-editable fields. `email` is optional:
+ * omitted or blank leaves the login email unchanged; when present the server lowercases it and
+ * responds `409 Conflict` if another user already owns it. `displayName` and `description` may be
+ * `null` to clear them; `status` is required. `description` is the profile blurb shown on the
+ * user's page (max 500 chars).
  */
 export interface UserUpdateRequest {
+  email?: string;
   displayName?: string | null;
   status: UserStatus;
   description?: string | null;

--- a/tests/components/MenuDropdown.test.tsx
+++ b/tests/components/MenuDropdown.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { MenuDropdown } from '@/app/components/MenuDropdown/MenuDropdown';
-import { useFetchMe } from '@/app/hooks/useFetchMe';
 import * as authApi from '@/app/lib/api/auth';
+import { type MeResponse } from '@/app/types/Auth';
 
 const mockPush = jest.fn();
 const mockRefresh = jest.fn();
@@ -12,22 +12,23 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
   usePathname: () => mockPathname,
 }));
-jest.mock('@/app/hooks/useFetchMe', () => ({ useFetchMe: jest.fn() }));
-jest.mock('@/app/lib/api/auth', () => ({ logout: jest.fn() }));
+// The real useFetchMe runs in these tests — only the api layer is mocked, so the
+// menu's auth buttons reflect genuine hook behavior. AUTH_CHANGED_EVENT mirrors
+// the real constant, pinned to 'auth-changed' in tests/lib/api/auth.test.ts.
+jest.mock('@/app/lib/api/auth', () => ({
+  AUTH_CHANGED_EVENT: 'auth-changed',
+  me: jest.fn(),
+  logout: jest.fn(),
+}));
 jest.mock('@/app/lib/actions/clearCache', () => ({ clearCacheAction: jest.fn() }));
 jest.mock('@/app/utils/environment', () => ({
   isLocalEnvironment: () => false,
 }));
 
-const mockUseFetchMe = useFetchMe as jest.MockedFunction<typeof useFetchMe>;
+const mockMe = authApi.me as jest.MockedFunction<typeof authApi.me>;
 const mockLogout = authApi.logout as jest.MockedFunction<typeof authApi.logout>;
 
-function setMe(
-  value: { email: string; mfaSatisfied: boolean; galleries: [] } | null,
-  loading = false
-) {
-  mockUseFetchMe.mockReturnValue({ me: value, loading });
-}
+const principal: MeResponse = { email: 'a@b.com', mfaSatisfied: true, galleries: [] };
 
 describe('MenuDropdown — auth actions', () => {
   beforeEach(() => {
@@ -36,13 +37,12 @@ describe('MenuDropdown — auth actions', () => {
   });
 
   it('shows "Log out" when logged in and calls logout + redirects home', async () => {
-    setMe({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    mockMe.mockResolvedValue(principal);
     mockLogout.mockResolvedValue();
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
 
-    const btn = screen.getByRole('button', { name: /log out/i });
-    expect(btn).toBeInTheDocument();
+    const btn = await screen.findByRole('button', { name: /log out/i });
     expect(screen.queryByRole('button', { name: /log in/i })).not.toBeInTheDocument();
 
     fireEvent.click(btn);
@@ -51,21 +51,40 @@ describe('MenuDropdown — auth actions', () => {
     expect(mockRefresh).toHaveBeenCalled();
   });
 
-  it('shows "Log in" when logged out and navigates to /login', () => {
-    setMe(null);
+  it('swaps "Log out" for "Log in" after logout without a remount', async () => {
+    mockMe.mockResolvedValueOnce(principal).mockResolvedValue(null);
+    // Mirror the real logout() contract: dispatch auth-changed on success.
+    mockLogout.mockImplementation(async () => {
+      window.dispatchEvent(new Event(authApi.AUTH_CHANGED_EVENT));
+    });
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
 
-    const btn = screen.getByRole('button', { name: /log in/i });
-    expect(btn).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /log out/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument()
+    );
+    expect(screen.queryByRole('button', { name: /log out/i })).not.toBeInTheDocument();
+    expect(mockMe).toHaveBeenCalledTimes(2); // refetched, not remounted
+    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('shows "Log in" when logged out and navigates to /login', async () => {
+    mockMe.mockResolvedValue(null);
+
+    render(<MenuDropdown isOpen onClose={jest.fn()} />);
+
+    const btn = await screen.findByRole('button', { name: /log in/i });
     expect(screen.queryByRole('button', { name: /log out/i })).not.toBeInTheDocument();
 
     fireEvent.click(btn);
     expect(mockPush).toHaveBeenCalledWith('/login');
   });
 
-  it('shows neither while loading', () => {
-    setMe(null, true);
+  it('shows neither auth button while me() is still resolving', () => {
+    mockMe.mockReturnValue(new Promise<never>(() => {}));
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
 
@@ -73,20 +92,22 @@ describe('MenuDropdown — auth actions', () => {
     expect(screen.queryByRole('button', { name: /log out/i })).not.toBeInTheDocument();
   });
 
-  it('shows "Home" off the home page and navigates to /', () => {
-    setMe(null);
+  it('shows "Home" off the home page and navigates to /', async () => {
+    mockMe.mockResolvedValue(null);
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
+    await screen.findByRole('button', { name: /log in/i }); // settle the me() fetch
 
     fireEvent.click(screen.getByRole('button', { name: /^home$/i }));
     expect(mockPush).toHaveBeenCalledWith('/');
   });
 
-  it('hides "Home" when already on the home page', () => {
-    setMe(null);
+  it('hides "Home" when already on the home page', async () => {
+    mockMe.mockResolvedValue(null);
     mockPathname = '/';
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
+    await screen.findByRole('button', { name: /log in/i }); // settle the me() fetch
 
     expect(screen.queryByRole('button', { name: /^home$/i })).not.toBeInTheDocument();
   });

--- a/tests/components/MenuDropdown.test.tsx
+++ b/tests/components/MenuDropdown.test.tsx
@@ -13,10 +13,11 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
 }));
 // The real useFetchMe runs in these tests — only the api layer is mocked, so the
-// menu's auth buttons reflect genuine hook behavior. AUTH_CHANGED_EVENT mirrors
-// the real constant, pinned to 'auth-changed' in tests/lib/api/auth.test.ts.
+// menu's auth buttons reflect genuine hook behavior. The real AUTH_CHANGED_EVENT
+// constant is passed through (also pinned in tests/lib/api/auth.test.ts).
 jest.mock('@/app/lib/api/auth', () => ({
-  AUTH_CHANGED_EVENT: 'auth-changed',
+  AUTH_CHANGED_EVENT: (jest.requireActual('@/app/lib/api/auth') as { AUTH_CHANGED_EVENT: string })
+    .AUTH_CHANGED_EVENT,
   me: jest.fn(),
   logout: jest.fn(),
 }));

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -3,8 +3,9 @@
  *
  * Create mode: collects email + display name, calls createUser, shows the copyable invite link,
  * and "Done" fires onSuccess. Validation + 409 surface inline (role="alert").
- * Edit mode: prefills fields, locks email (readonly), saves displayName + status via updateUser,
- * and Cancel fires onCancel.
+ * Edit mode: prefills fields (email included — it is editable), saves email + displayName +
+ * status + description via updateUser, surfaces 409 email conflicts inline, and Cancel fires
+ * onCancel.
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -110,7 +111,7 @@ describe('UserForm', () => {
       description: null,
     };
 
-    it('prefills fields, locks the email, saves displayName + status + description, fires onSuccess', async () => {
+    it('prefills fields with an editable email, saves email + displayName + status + description, fires onSuccess', async () => {
       mockUpdateUser.mockResolvedValue({
         ...user,
         displayName: 'Kenneth',
@@ -122,7 +123,7 @@ describe('UserForm', () => {
 
       const emailInput = screen.getByLabelText(/email/i);
       expect(emailInput).toHaveValue('ken@x.com');
-      expect(emailInput).toHaveAttribute('readonly');
+      expect(emailInput).not.toHaveAttribute('readonly');
       expect(screen.getByLabelText(/display name/i)).toHaveValue('Ken');
 
       fireEvent.change(screen.getByLabelText(/display name/i), {
@@ -138,12 +139,50 @@ describe('UserForm', () => {
 
       await waitFor(() => {
         expect(mockUpdateUser).toHaveBeenCalledWith(8, {
+          email: 'ken@x.com',
           displayName: 'Kenneth',
           status: 'ACTIVE',
           description: 'A short bio',
         });
       });
       expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a changed email in the update payload and fires onSuccess', async () => {
+      mockUpdateUser.mockResolvedValue({ ...user, email: 'kenneth@y.com' });
+
+      render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
+
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: 'kenneth@y.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateUser).toHaveBeenCalledWith(8, {
+          email: 'kenneth@y.com',
+          displayName: 'Ken',
+          status: 'INVITED',
+          description: null,
+        });
+      });
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a 409 email conflict as an "already exists" error and does not fire onSuccess', async () => {
+      mockUpdateUser.mockRejectedValue(new ApiError('Conflict', 409));
+
+      render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
+
+      fireEvent.change(screen.getByLabelText(/email/i), {
+        target: { value: 'taken@x.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/already exists/i);
+      });
+      expect(onSuccess).not.toHaveBeenCalled();
     });
 
     it('Cancel fires onCancel', () => {

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -4,8 +4,8 @@
  * Create mode: collects email + display name, calls createUser, shows the copyable invite link,
  * and "Done" fires onSuccess. Validation + 409 surface inline (role="alert").
  * Edit mode: prefills fields (email included — it is editable), saves email + displayName +
- * status + description via updateUser, surfaces 409 email conflicts inline, and Cancel fires
- * onCancel.
+ * status + description via updateUser, requires a non-empty email, surfaces 409 email conflicts
+ * inline, and Cancel fires onCancel.
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -167,6 +167,18 @@ describe('UserForm', () => {
         });
       });
       expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('validates that email is required (no API call, inline error)', async () => {
+      render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
+
+      fireEvent.change(screen.getByLabelText(/email/i), { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/email is required/i);
+      });
+      expect(mockUpdateUser).not.toHaveBeenCalled();
     });
 
     it('surfaces a 409 email conflict as an "already exists" error and does not fire onSuccess', async () => {

--- a/tests/hooks/useFetchMe.test.ts
+++ b/tests/hooks/useFetchMe.test.ts
@@ -4,10 +4,11 @@ import { useFetchMe } from '@/app/hooks/useFetchMe';
 import * as authApi from '@/app/lib/api/auth';
 import { type MeResponse } from '@/app/types/Auth';
 
-// AUTH_CHANGED_EVENT mirrors the real constant — pinned to 'auth-changed' in
-// tests/lib/api/auth.test.ts, which tests the unmocked module.
+// The real AUTH_CHANGED_EVENT constant is passed through so the hook listens on the
+// exact event name production dispatches (also pinned in tests/lib/api/auth.test.ts).
 jest.mock('@/app/lib/api/auth', () => ({
-  AUTH_CHANGED_EVENT: 'auth-changed',
+  AUTH_CHANGED_EVENT: (jest.requireActual('@/app/lib/api/auth') as { AUTH_CHANGED_EVENT: string })
+    .AUTH_CHANGED_EVENT,
   me: jest.fn(),
 }));
 
@@ -112,6 +113,47 @@ describe('useFetchMe', () => {
       resolveFirstRefetch(null);
     });
     expect(result.current.me).toEqual(principal);
+  });
+
+  it('lets a refetch supersede a still-pending mount fetch', async () => {
+    let resolveMount!: (value: MeResponse | null) => void;
+    let resolveRefetch!: (value: MeResponse | null) => void;
+    mockMe
+      .mockImplementationOnce(
+        () =>
+          new Promise<MeResponse | null>(resolve => {
+            resolveMount = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<MeResponse | null>(resolve => {
+            resolveRefetch = resolve;
+          })
+      );
+
+    const { result } = renderHook(() => useFetchMe());
+    expect(result.current.loading).toBe(true);
+
+    dispatchAuthChanged(); // mount fetch still in flight
+
+    // Nothing has settled as the newest request yet — still the initial load.
+    expect(mockMe).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(true);
+
+    // The refetch (newest) settles: loading converges exactly here.
+    await act(async () => {
+      resolveRefetch(principal);
+    });
+    expect(result.current.me).toEqual(principal);
+    expect(result.current.loading).toBe(false);
+
+    // The stale mount response lands late and must not apply.
+    await act(async () => {
+      resolveMount(null);
+    });
+    expect(result.current.me).toEqual(principal);
+    expect(result.current.loading).toBe(false);
   });
 
   it('removes the auth-changed listener on unmount', async () => {

--- a/tests/hooks/useFetchMe.test.ts
+++ b/tests/hooks/useFetchMe.test.ts
@@ -1,13 +1,25 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { useFetchMe } from '@/app/hooks/useFetchMe';
 import * as authApi from '@/app/lib/api/auth';
+import { type MeResponse } from '@/app/types/Auth';
 
+// AUTH_CHANGED_EVENT mirrors the real constant — pinned to 'auth-changed' in
+// tests/lib/api/auth.test.ts, which tests the unmocked module.
 jest.mock('@/app/lib/api/auth', () => ({
+  AUTH_CHANGED_EVENT: 'auth-changed',
   me: jest.fn(),
 }));
 
 const mockMe = authApi.me as jest.MockedFunction<typeof authApi.me>;
+
+const principal: MeResponse = { email: 'a@b.com', mfaSatisfied: true, galleries: [] };
+
+function dispatchAuthChanged() {
+  act(() => {
+    window.dispatchEvent(new Event(authApi.AUTH_CHANGED_EVENT));
+  });
+}
 
 describe('useFetchMe', () => {
   beforeEach(() => {
@@ -15,14 +27,14 @@ describe('useFetchMe', () => {
   });
 
   it('starts loading, then resolves the principal', async () => {
-    mockMe.mockResolvedValue({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    mockMe.mockResolvedValue(principal);
 
     const { result } = renderHook(() => useFetchMe());
     expect(result.current.loading).toBe(true);
     expect(result.current.me).toBeNull();
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.me).toEqual({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    expect(result.current.me).toEqual(principal);
   });
 
   it('resolves to null when logged out (me() returns null)', async () => {
@@ -39,5 +51,79 @@ describe('useFetchMe', () => {
     const { result } = renderHook(() => useFetchMe());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.me).toBeNull();
+  });
+
+  it('refetches on auth-changed without flipping loading back to true', async () => {
+    let resolveRefetch!: (value: MeResponse | null) => void;
+    mockMe.mockResolvedValueOnce(principal).mockImplementationOnce(
+      () =>
+        new Promise<MeResponse | null>(resolve => {
+          resolveRefetch = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useFetchMe());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.me).toEqual(principal);
+
+    dispatchAuthChanged();
+
+    // Refetch in flight: the previous principal stays visible, no loading flash.
+    expect(mockMe).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.me).toEqual(principal);
+
+    await act(async () => {
+      resolveRefetch(null);
+    });
+    expect(result.current.me).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('never lets a stale refetch response overwrite a newer one', async () => {
+    let resolveFirstRefetch!: (value: MeResponse | null) => void;
+    let resolveSecondRefetch!: (value: MeResponse | null) => void;
+    mockMe
+      .mockResolvedValueOnce(principal)
+      .mockImplementationOnce(
+        () =>
+          new Promise<MeResponse | null>(resolve => {
+            resolveFirstRefetch = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<MeResponse | null>(resolve => {
+            resolveSecondRefetch = resolve;
+          })
+      );
+
+    const { result } = renderHook(() => useFetchMe());
+    await waitFor(() => expect(result.current.me).toEqual(principal));
+
+    dispatchAuthChanged(); // e.g. logout
+    dispatchAuthChanged(); // e.g. immediate re-login
+
+    // The newer request resolves first; the stale one lands late and must lose.
+    await act(async () => {
+      resolveSecondRefetch(principal);
+    });
+    await act(async () => {
+      resolveFirstRefetch(null);
+    });
+    expect(result.current.me).toEqual(principal);
+  });
+
+  it('removes the auth-changed listener on unmount', async () => {
+    mockMe.mockResolvedValue(null);
+
+    const { result, unmount } = renderHook(() => useFetchMe());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockMe).toHaveBeenCalledTimes(1);
+
+    unmount();
+    window.dispatchEvent(new Event(authApi.AUTH_CHANGED_EVENT));
+
+    expect(mockMe).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/lib/api/auth.test.ts
+++ b/tests/lib/api/auth.test.ts
@@ -3,7 +3,15 @@
  * Mirrors the fetch-mock idiom of tests/lib/api/collections.test.ts.
  */
 
-import { login, loginWithPasskey, logout, me, meServer, registerPasskey } from '@/app/lib/api/auth';
+import {
+  AUTH_CHANGED_EVENT,
+  login,
+  loginWithPasskey,
+  logout,
+  me,
+  meServer,
+  registerPasskey,
+} from '@/app/lib/api/auth';
 import { ApiError, getApiBaseUrl, getServerCookieHeader } from '@/app/lib/api/core';
 import { type MeResponse } from '@/app/types/Auth';
 
@@ -26,8 +34,19 @@ Object.defineProperty(global.navigator, 'credentials', {
   writable: true,
 });
 
+// Observe AUTH_CHANGED_EVENT dispatches. Registered once — jsdom's window is
+// shared across this file and jest.clearAllMocks() resets call history per test.
+const authChangedListener = jest.fn();
+window.addEventListener(AUTH_CHANGED_EVENT, authChangedListener);
+
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe('AUTH_CHANGED_EVENT', () => {
+  it("is the 'auth-changed' contract string client listeners subscribe to", () => {
+    expect(AUTH_CHANGED_EVENT).toBe('auth-changed');
+  });
 });
 
 describe('login', () => {
@@ -60,6 +79,18 @@ describe('login', () => {
     );
   });
 
+  it('dispatches auth-changed on a successful login', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+    });
+
+    await login('admin@example.com', 'super-secret');
+
+    expect(authChangedListener).toHaveBeenCalledTimes(1);
+  });
+
   it('throws ApiError with status 401 on bad credentials', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,
@@ -71,6 +102,7 @@ describe('login', () => {
     const caught = await login('admin@example.com', 'wrong').catch(error => error);
     expect(caught).toBeInstanceOf(ApiError);
     expect((caught as ApiError).status).toBe(401);
+    expect(authChangedListener).not.toHaveBeenCalled();
   });
 
   it('throws ApiError with status 429 when rate-limited', async () => {
@@ -108,7 +140,19 @@ describe('logout', () => {
     );
   });
 
-  it('throws ApiError on a non-OK status', async () => {
+  it('dispatches auth-changed on a successful logout', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+    });
+
+    await logout();
+
+    expect(authChangedListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws ApiError on a non-OK status and does not dispatch auth-changed', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 500,
@@ -117,6 +161,7 @@ describe('logout', () => {
     });
 
     await expect(logout()).rejects.toMatchObject({ name: 'ApiError', status: 500 });
+    expect(authChangedListener).not.toHaveBeenCalled();
   });
 });
 
@@ -328,6 +373,9 @@ describe('loginWithPasskey', () => {
     expect(finishBody.response.authenticatorData).toBe('rw'); // 0xAF
     expect(finishBody.response.signature).toBe('vw'); // 0xBF
     expect(finishBody.response.userHandle).toBe('AQ'); // 0x01
+
+    // Session established on finish 204 — the auth-changed contract fires once.
+    expect(authChangedListener).toHaveBeenCalledTimes(1);
   });
 
   it('throws ApiError 429 when login/start is rate-limited', async () => {
@@ -343,6 +391,45 @@ describe('loginWithPasskey', () => {
       status: 429,
     });
     expect(mockCredentialsGet).not.toHaveBeenCalled();
+    expect(authChangedListener).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch auth-changed when login/finish fails', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({
+          challenge: 'Aa-_',
+          allowCredentials: [],
+          rpId: 'localhost',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ message: 'Unauthorized' }),
+      });
+
+    mockCredentialsGet.mockResolvedValue({
+      id: 'cred-id',
+      rawId: new Uint8Array([0x01]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: new Uint8Array([0x01]).buffer,
+        authenticatorData: new Uint8Array([0xaf]).buffer,
+        signature: new Uint8Array([0xbf]).buffer,
+        userHandle: null,
+      },
+    });
+
+    await expect(loginWithPasskey('admin@example.com')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+    });
+    expect(authChangedListener).not.toHaveBeenCalled();
   });
 
   it('omits userHandle from the finish body when the authenticator returns none', async () => {
@@ -390,9 +477,7 @@ describe('meServer', () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
-      json: jest
-        .fn()
-        .mockResolvedValue({ email: 'c@x.com', mfaSatisfied: true, galleries: [] }),
+      json: jest.fn().mockResolvedValue({ email: 'c@x.com', mfaSatisfied: true, galleries: [] }),
     });
 
     const result = await meServer();


### PR DESCRIPTION
## Summary
- **Logout staleness fix**: `logout()`/`login()`/`loginWithPasskey()` now broadcast an `auth-changed` event on success; `useFetchMe` (MenuDropdown's auth source) listens and refetches with a monotonic request token (stale responses can never win) and no loading flash. The menu flips to 'Log In' immediately on logout — no hard refresh.
- **Editable admin email (FE half)**: the shared `UserForm` unlocks email in edit mode (unified state, dead `emailInput` removed), sends `email` in the update payload, maps 409 → 'A user with that email already exists.'
- Hardening from review: impersonation-nav constraint comment, `jest.requireActual` event constant, interleaving + edit-mode-required tests, stale JSDoc fixes.

## Verification
- Full suite **2454/2454** (156 suites), `tsc --noEmit` clean, ESLint clean.
- Per-task spec-compliance review + adversarial quality review + final whole-branch integration review: **0 critical / 0 important findings**.
- Browser-verified: email field editable in the real admin modal; submit flow clean.

## Merge order
Merge/deploy the backend counterpart (`0202-user-email-editable-be`) first or together — against an old backend the email field is silently ignored (graceful no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)