### PR TITLE
fix(auth): close FE half of the anonymous admin API authorization hole

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -10,7 +10,7 @@ import styles from './layout.module.scss';
  * opts the subtree into the dark surface via `data-surface="dark"`.
  */
 export default async function AdminLayout({ children }: { children: ReactNode }) {
-  await requireAdmin(); // non-enforcing today
+  await requireAdmin(); // redirects non-admins (and anon) to /login
   return (
     <div data-surface="dark" className={styles.surface}>
       <AdminScrollManager />

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -34,6 +34,7 @@ function forwardHeaders(req: NextRequest): Headers {
         'accept-encoding',
         'cf-ray',
         'cf-connecting-ip',
+        'x-real-ip',
         'x-forwarded-for',
         'x-forwarded-proto',
         'x-forwarded-host',
@@ -49,9 +50,18 @@ function forwardHeaders(req: NextRequest): Headers {
   // Ensure JSON by default for non-multipart when client did not set
   if (!headers.has('accept')) headers.set('accept', 'application/json, */*;q=0.1');
   // Re-inject sanitized real IP (stripped above to prevent header smuggling).
+  //
+  // Source order, most-trusted first:
+  //   1. `x-vercel-forwarded-for` first hop — harmless, absent on Amplify.
+  //   2. LAST hop of `x-forwarded-for` — on CloudFront/Amplify the client IP is
+  //      appended by the trusted edge, so the last hop is the real client. We do
+  //      NOT trust `x-real-ip`: it's fully client-controllable and spoofable on
+  //      Amplify (where the Vercel header never populates).
+  // TODO(CloudFlare Phase 2): drop this injection entirely and switch to
+  // `CF-Connecting-IP`, which CloudFlare sets and clients cannot forge.
   const realIpRaw =
     req.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ??
-    req.headers.get('x-real-ip') ??
+    req.headers.get('x-forwarded-for')?.split(',').pop()?.trim() ??
     '';
   if (realIpRaw && /^[\d.:A-Fa-f]+$/.test(realIpRaw)) {
     headers.set('X-Real-IP', realIpRaw);
@@ -64,7 +74,21 @@ function forwardHeaders(req: NextRequest): Headers {
 async function handle(req: NextRequest, context: { params: Promise<{ path: string[] }> }) {
   const params = await context.params;
   const method = req.method;
-  const targetUrl = buildTargetUrl(params.path || [], req.nextUrl.search);
+  const pathParts = params.path || [];
+  const targetUrl = buildTargetUrl(pathParts, req.nextUrl.search);
+
+  // Belt & suspenders: refuse anonymous admin API in production before forwarding.
+  // The backend `hasRole('ADMIN')` on the `ezac_session` cookie stays authoritative;
+  // this is a cheap early reject + defense in depth. `api/dev/**` is exempt (dev-only,
+  // @Profile-gated on the backend) and dev is unaffected (localhost admin has no login).
+  const resolvedPath = pathParts.join('/').replace(/^\/+/, '');
+  if (
+    process.env.NODE_ENV === 'production' &&
+    resolvedPath.startsWith('api/admin/') &&
+    !req.cookies.get('ezac_session')?.value
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
 
   const ALLOWED_ORIGINS = new Set(
     [

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -81,6 +81,10 @@ async function handle(req: NextRequest, context: { params: Promise<{ path: strin
   // The backend `hasRole('ADMIN')` on the `ezac_session` cookie stays authoritative;
   // this is a cheap early reject + defense in depth. `api/dev/**` is exempt (dev-only,
   // @Profile-gated on the backend) and dev is unaffected (localhost admin has no login).
+  // The `startsWith('api/admin/')` match below is intentionally exact/case-sensitive
+  // (an odd-cased or bare `api/admin` path is not caught here) — that's acceptable
+  // because this check is NOT the real gate; the backend's `hasRole('ADMIN')`
+  // authorizes every request regardless of what this early check catches.
   const resolvedPath = pathParts.join('/').replace(/^\/+/, '');
   if (
     process.env.NODE_ENV === 'production' &&

--- a/app/lib/api/auth.ts
+++ b/app/lib/api/auth.ts
@@ -9,6 +9,8 @@
  * `null` on 401 so "logged out" is data, not an error.
  */
 
+import { cache } from 'react';
+
 import { ApiError, getApiBaseUrl, getServerCookieHeader } from '@/app/lib/api/core';
 import { type MeResponse } from '@/app/types/Auth';
 
@@ -116,8 +118,15 @@ export async function me(): Promise<MeResponse | null> {
  * Server-side counterpart to {@link me}. Server Components cannot call `me()` (relative URL +
  * `credentials:'same-origin'` only work in the browser), so this resolves the absolute backend URL
  * via `getApiBaseUrl` and forwards `ezac_session` via `getServerCookieHeader`. Returns null on 401.
+ *
+ * Wrapped in React's `cache()` so multiple independent callers within the SAME request (e.g. the
+ * `(admin)` layout's `requireAdmin()` and a page's own `Promise.all`) share one backend round-trip
+ * instead of each issuing their own `/api/auth/me` fetch — this is a read of the request's own
+ * session, which cannot change mid-request. `cache()` is per-request (Next.js resets it for every
+ * incoming request), so there is no cross-request staleness risk; the underlying `fetch` itself
+ * still uses `cache: 'no-store'`, `cache()` only dedupes the *call*, not the HTTP cache policy.
  */
-export async function meServer(): Promise<MeResponse | null> {
+export const meServer = cache(async (): Promise<MeResponse | null> => {
   const cookieHeader = await getServerCookieHeader();
   const res = await fetch(`${getApiBaseUrl('auth')}/me`, {
     method: 'GET',
@@ -129,7 +138,7 @@ export async function meServer(): Promise<MeResponse | null> {
     await throwFromResponse(res);
   }
   return (await res.json()) as MeResponse;
-}
+});
 
 /**
  * Decode a base64url string (no padding, `-`/`_` alphabet) into an `ArrayBuffer`.

--- a/app/lib/api/core.ts
+++ b/app/lib/api/core.ts
@@ -189,7 +189,20 @@ const fetchBase = async <T>(
 ): Promise<T | null> => {
   try {
     const url = buildSimpleApiUrl(endpointType === 'write' ? WRITE : ADMIN, endpoint);
-    const response = await fetch(url, options);
+
+    // On the server, forward the inbound `ezac_session` cookie so the backend's
+    // admin authorization (hasRole('ADMIN')) sees the acting admin's session on
+    // SSR write fetches. Returns null in the browser (fetch already sends
+    // same-origin cookies) and at build time — so this only affects SSR.
+    const cookieHeader = await getServerCookieHeader();
+    const headers: Record<string, string> = {
+      ...(options.headers as Record<string, string> | undefined),
+    };
+    if (cookieHeader) {
+      headers.Cookie = cookieHeader;
+    }
+
+    const response = await fetch(url, { ...options, headers });
 
     if (!response.ok) {
       await throwApiError(response);
@@ -308,12 +321,22 @@ export async function fetchAdminGetApi<T>(
   try {
     const url = buildSimpleApiUrl(ADMIN, endpoint);
 
+    // On the server, forward the inbound `ezac_session` cookie so the backend's
+    // admin authorization (hasRole('ADMIN')) sees the acting admin's session on
+    // SSR reads (all-images, comments, metadata, /admin, /admin/users/[id],
+    // /explore). Returns null in the browser and at build time — SSR only.
+    const cookieHeader = await getServerCookieHeader();
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string> | undefined),
+    };
+    if (cookieHeader) {
+      headers.Cookie = cookieHeader;
+    }
+
     const response = await fetch(url, {
       ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
+      headers,
     });
 
     if (!response.ok) {

--- a/app/types/Auth.ts
+++ b/app/types/Auth.ts
@@ -13,6 +13,13 @@ export interface GalleryMembership {
 
 export interface MeResponse {
   email: string;
+  /**
+   * Admin flag on the user row — deliberately SEPARATE from "being logged in".
+   * An admin impersonating another user ("log in as") still needs admin
+   * capabilities, so admin-ness is a row-level boolean, not inferred from the
+   * session identity. Backend `is_admin` → this field via `/api/auth/me`.
+   */
+  isAdmin: boolean;
   mfaSatisfied: boolean;
   galleries: GalleryMembership[];
 }

--- a/app/utils/admin.ts
+++ b/app/utils/admin.ts
@@ -1,47 +1,33 @@
-import { type NextRequest } from 'next/server';
+import { redirect } from 'next/navigation';
+
+import { meServer } from '@/app/lib/api/auth';
 
 /**
- * Admin middleware helpers
+ * Admin authorization helpers.
  *
- * Feature flags and authorization checks for admin routes.
- *
- * Environment variables:
- * - ADMIN_ROUTES_ENABLED: 'true' to allow admin routes outside local/dev
- * - ADMIN_TOKEN: Optional secret. When provided, requests must include either:
- *   - Header: 'x-admin-token: <ADMIN_TOKEN>'
- *   - Cookie: 'admin_token=<ADMIN_TOKEN>'
+ * Page-group gating now runs in two places: the `proxy.ts` middleware performs an
+ * `ezac_session` presence check on the whole (admin) route group, and
+ * {@link requireAdmin} (below) enforces the actual `isAdmin` flag server-side. The
+ * old `ADMIN_TOKEN` / `ADMIN_ROUTES_ENABLED` static-token mechanism was retired
+ * with the session model and has been removed.
  */
 
 /**
- * Returns true if admin routes are enabled for non-local environments.
- */
-export const isAdminRoutesEnabled = (): boolean => {
-  return process.env.ADMIN_ROUTES_ENABLED === 'true';
-};
-
-/**
- * Validates admin authorization for a request using a static token.
+ * Admin gate (SERVER-SIDE). Resolves the acting principal via {@link meServer}
+ * and redirects logged-in-but-not-admin (and anonymous) users to `/login`.
+ * Called by the (admin) layout and the `?manage`/edit gate in `app/[slug]`.
  *
- * Guard clauses:
- * - If no ADMIN_TOKEN is configured, return true (feature-flag only gating applies)
- * - If ADMIN_TOKEN is set, require header or cookie to match
- */
-export const hasValidAdminAuth = (request: NextRequest): boolean => {
-  const requiredToken = process.env.ADMIN_TOKEN;
-  if (!requiredToken) return true;
-
-  const headerToken = request.headers.get('x-admin-token');
-  if (headerToken && headerToken === requiredToken) return true;
-
-  const cookieToken = request.cookies.get('admin_token')?.value;
-  return !!(cookieToken && cookieToken === requiredToken);
-};
-
-/**
- * Admin gate seam (SERVER-SIDE). No-op today — enforcement is perimeter-only via
- * `INTERNAL_API_SECRET`. This is the single future hook point for identity/session
- * auth; when that lands, add redirect()/notFound() here.
+ * `meServer()` returns null both for anonymous requests AND outside a request
+ * scope (build time / `generateStaticParams`), and both map to `redirect('/login')`.
+ * That is safe here because every (admin) page is `force-dynamic`, so this only
+ * runs per-request — never during static generation.
+ *
+ * Admin-ness comes from the row-level `isAdmin` flag, NOT session identity, so an
+ * admin impersonating another user retains access.
  */
 export async function requireAdmin(): Promise<void> {
-  return;
+  const principal = await meServer();
+  if (!principal || !principal.isAdmin) {
+    redirect('/login');
+  }
 }

--- a/app/utils/admin.ts
+++ b/app/utils/admin.ts
@@ -17,10 +17,12 @@ import { meServer } from '@/app/lib/api/auth';
  * and redirects logged-in-but-not-admin (and anonymous) users to `/login`.
  * Called by the (admin) layout and the `?manage`/edit gate in `app/[slug]`.
  *
- * `meServer()` returns null both for anonymous requests AND outside a request
- * scope (build time / `generateStaticParams`), and both map to `redirect('/login')`.
- * That is safe here because every (admin) page is `force-dynamic`, so this only
- * runs per-request — never during static generation.
+ * `meServer()` returns null for anonymous requests (a 401 from `/api/auth/me`), which
+ * maps to `redirect('/login')` just like a logged-in non-admin. It would ALSO return
+ * null if somehow invoked outside a request scope (no cookie to forward → the backend
+ * still gets hit, cookie-less, and 401s the same way) — but that never happens here:
+ * every (admin) page is `force-dynamic`, so this only runs per-request, never during
+ * static generation.
  *
  * Admin-ness comes from the row-level `isAdmin` flag, NOT session identity, so an
  * admin impersonating another user retains access.

--- a/docs/007-security-hardening.md
+++ b/docs/007-security-hardening.md
@@ -6,6 +6,7 @@ The contact form shipped as the site's first real public API endpoint — DB-bac
 
 ## Remaining work (deduped)
 
+- ✅ **Anonymous admin-API authorization hole — CLOSED (2026-07-04, 0203 cycle).** `/api/admin/**` was `permitAll` in every profile (prod's only gate was the transport-level `InternalSecretFilter`), so an anonymous request through the BFF reached admin PII reads and the invite→accept account-takeover chain. Now gated by `hasRole('ADMIN')` behind the `app.admin.enforce-authz` toggle, inside the `InternalSecretFilter` perimeter (two-layer prod defense). Details: [2026-07-04-0203-admin-authz-implementation](superpowers/plans/2026-07-04-0203-admin-authz-implementation.md).
 - **Add the unguarded admin routes to `proxy.ts`** (`all-collections` / `all-images` / `collection/manage/*`) — they have no admin-token check today. Highest priority ([007-proxy-route-gating](superpowers/plans/007-proxy-route-gating.md)).
 - **Gate `/metadata` behind admin auth** — same class of fix; the route-gating groundwork shipped with [001](001-design-review.md) (admin gating already on `/all-collections` + `/all-images`).
 - **Generalize the rate-limit config** — the `app.contact.rate-limit-*` props are contact-specific; refactor to a per-path map before adding a 2nd public endpoint.
@@ -25,6 +26,10 @@ The contact form shipped as the site's first real public API endpoint — DB-bac
 ## Blocked on / open
 
 - Dependabot's 7 frontend vulnerabilities are independent of this chapter's work — track via GitHub Security, fix opportunistically.
+
+## Decisions
+
+- **AWS API Gateway / WAF in front of the public Spring endpoint — not warranted (2026-07-04).** Settled during the 0203 admin-authz cycle: the real risk was missing app-layer authorization (the anonymous `/api/admin/**` hole, now closed via `hasRole('ADMIN')` + `app.admin.enforce-authz` behind the `InternalSecretFilter` perimeter), which a WAF/API Gateway would not have caught. A WAF filters malformed traffic; it does not know the app's authZ model. CloudFlare Phase 2 stays the right origin-protection tool (DDoS / rate-limit / real-IP) but is a separate concern. Detail: [2026-07-04-0203-admin-authz-implementation](superpowers/plans/2026-07-04-0203-admin-authz-implementation.md).
 
 ---
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,22 +1,28 @@
-// NOTE: this file is currently UNWIRED — there is no middleware.ts and next.config.js does not reference it, so none of this runs. Wiring it as middleware is the open 007 task. Real perimeter protection today = the BFF INTERNAL_API_SECRET channel gate (app/api/proxy/[...path]/route.ts).
+// This file IS the Next.js middleware. In Next 16 a root `proxy.ts` (formerly
+// `middleware.ts`) is the framework convention and runs on every matched request
+// in every environment, prod included — it is NOT unwired. It is the page-level
+// perimeter for the (admin) route group; the BFF INTERNAL_API_SECRET channel gate
+// (app/api/proxy/[...path]/route.ts) authenticates the proxy, not the user, and the
+// backend `hasRole('ADMIN')` on the `ezac_session` cookie is authoritative for the API.
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { hasValidAdminAuth, isAdminRoutesEnabled } from '@/app/utils/admin';
 import { isLocalEnvironment } from '@/app/utils/environment';
 
 /**
  * Global Next.js Proxy
  * - Local-only admin hub at /admin (and /homePage escape route)
- * - Protects admin App Router routes (create/edit collections)
+ * - Gates the whole (admin) App Router route group on an `ezac_session` cookie
+ *   in non-local environments (presence check; the backend validates the session)
  * - Maintains legacy local-only protection for /cdn tooling routes
- * - Supports feature flags and simple token-based authorization for gradual rollout
+ * - Feature-flagged legacy /catalog → /collection redirects
  */
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // 1) Local-only admin hub. /admin* and /homePage are dev-console paths;
-  //    in non-local environments they redirect to / so they are not discoverable.
-  if (pathname === '/admin' || pathname.startsWith('/admin/') || pathname === '/homePage') {
+  // 1) /homePage is a local-only dev escape hatch (the real home page reachable
+  //    from the localhost / → /admin redirect). In non-local it redirects to /
+  //    so it is not discoverable.
+  if (pathname === '/homePage') {
     if (!isLocalEnvironment()) {
       return NextResponse.redirect(new URL('/', request.url));
     }
@@ -49,8 +55,14 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  // 5) Admin routes protection (App Router group (admin) does not alter URL)
+  // 5) Admin route group gate. Covers the WHOLE (admin) App Router group (the
+  //    group folder does not alter the URL), including the /admin hub and
+  //    /admin/users/[id]. Local/dev passes through for fast iteration; every
+  //    other environment requires an `ezac_session` cookie (presence check —
+  //    the backend validates the session and enforces `isAdmin`).
   const isAdminRoute =
+    pathname === '/admin' ||
+    pathname.startsWith('/admin/') ||
     pathname === '/collection/manage' ||
     pathname.startsWith('/collection/manage/') ||
     /\/collection\/.+\/edit$/.test(pathname) ||
@@ -69,22 +81,16 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Allow freely in local/dev to speed up iteration
+  // Allow freely in local/dev to speed up iteration.
   if (isLocalEnvironment()) {
     return NextResponse.next();
   }
 
-  // In non-local environments, require feature flag and optional auth
-  if (!isAdminRoutesEnabled()) {
-    return new NextResponse('Admin features are disabled', { status: 403 });
-  }
-
-  if (!hasValidAdminAuth(request)) {
-    // Optional: indicate auth requirement via header for debugging
-    return new NextResponse('Unauthorized', {
-      status: 401,
-      headers: { 'WWW-Authenticate': 'Bearer realm="admin"' },
-    });
+  // Non-local: require an `ezac_session` cookie. Middleware can only check
+  // presence (it can't validate the session); the (admin) layout's
+  // requireAdmin() + the backend enforce the actual ADMIN authorization.
+  if (!request.cookies.get('ezac_session')?.value) {
+    return NextResponse.redirect(new URL('/login', request.url));
   }
 
   return NextResponse.next();
@@ -92,10 +98,10 @@ export function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Admin hub (local-only) and the localhost / → /admin redirect.
-    // Including '/' here means the middleware runs on every public home
-    // page hit; the rule short-circuits in non-local so the prod cost is
-    // a single env check.
+    // The whole (admin) route group + the /homePage escape hatch + the
+    // localhost / → /admin redirect. Including '/' here means the middleware
+    // runs on every public home page hit; the rule short-circuits in non-local
+    // so the prod cost is a single env check.
     '/',
     '/admin',
     '/admin/:path*',

--- a/tests/api/proxy/route.test.ts
+++ b/tests/api/proxy/route.test.ts
@@ -11,7 +11,7 @@
 
 import { NextRequest } from 'next/server';
 
-import { POST } from '@/app/api/proxy/[...path]/route';
+import { GET, POST } from '@/app/api/proxy/[...path]/route';
 
 describe('Vercel BFF proxy /api/proxy/[...path] — Set-Cookie forwarding', () => {
   const ORIGINAL_ENV = process.env;
@@ -245,5 +245,178 @@ describe('Vercel BFF proxy /api/proxy/[...path] — write-method origin allowanc
       NODE_ENV: 'production',
     };
     expect(await postFrom('http://192.168.68.60:3000')).toBe(403);
+  });
+});
+
+describe('Vercel BFF proxy /api/proxy/[...path] — anonymous admin API refusal (prod)', () => {
+  const ORIGINAL_ENV = process.env;
+
+  function setProd() {
+    process.env = {
+      ...ORIGINAL_ENV,
+      INTERNAL_API_SECRET: 'test-secret',
+      API_URL: 'http://backend.test',
+      NEXT_PUBLIC_APP_URL: 'https://example.com',
+      NODE_ENV: 'production',
+    };
+  }
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects an anonymous admin GET with 401 and does NOT forward', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/admin/users', {
+      method: 'GET',
+    });
+    const res = await GET(req, {
+      params: Promise.resolve({ path: ['api', 'admin', 'users'] }),
+    } as never);
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards an admin GET when the ezac_session cookie is present', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/admin/users', {
+      method: 'GET',
+      headers: { cookie: 'ezac_session=abc123' },
+    });
+    const res = await GET(req, {
+      params: Promise.resolve({ path: ['api', 'admin', 'users'] }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // The forwarded request carries the session cookie through to the backend.
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Headers).get('cookie')).toBe('ezac_session=abc123');
+  });
+
+  it('does NOT gate a non-admin (read) path — anonymous read forwards', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/read/collections', {
+      method: 'GET',
+    });
+    const res = await GET(req, {
+      params: Promise.resolve({ path: ['api', 'read', 'collections'] }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT gate api/dev/** admin-adjacent paths', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/dev/seed', {
+      method: 'GET',
+    });
+    const res = await GET(req, {
+      params: Promise.resolve({ path: ['api', 'dev', 'seed'] }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT gate admin paths in development (localhost admin has no login)', async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      INTERNAL_API_SECRET: 'test-secret',
+      API_URL: 'http://backend.test',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+      NODE_ENV: 'development',
+    };
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('http://localhost:3000/api/proxy/api/admin/users', {
+      method: 'GET',
+    });
+    const res = await GET(req, {
+      params: Promise.resolve({ path: ['api', 'admin', 'users'] }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Vercel BFF proxy /api/proxy/[...path] — real-IP header sanitization', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      INTERNAL_API_SECRET: 'test-secret',
+      API_URL: 'http://backend.test',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+      NODE_ENV: 'development',
+    };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  async function forwardWith(headers: Record<string, string>): Promise<RequestInit> {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+    const req = new NextRequest('http://localhost:3000/api/proxy/api/read/collections', {
+      method: 'GET',
+      headers,
+    });
+    await GET(req, {
+      params: Promise.resolve({ path: ['api', 'read', 'collections'] }),
+    } as never);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    return init;
+  }
+
+  it('does NOT forward a spoofed inbound x-real-ip as X-Real-IP', async () => {
+    const init = await forwardWith({ 'x-real-ip': '6.6.6.6' });
+    // x-real-ip is client-controllable and no longer a source; without a trusted
+    // header there is no X-Real-IP to forward.
+    expect((init.headers as Headers).get('x-real-ip')).toBeNull();
+  });
+
+  it('forwards the LAST hop of x-forwarded-for as X-Real-IP (CloudFront-appended client IP)', async () => {
+    const init = await forwardWith({ 'x-forwarded-for': '10.0.0.1, 203.0.113.9' });
+    expect((init.headers as Headers).get('x-real-ip')).toBe('203.0.113.9');
+  });
+
+  it('prefers x-vercel-forwarded-for first hop when present', async () => {
+    const init = await forwardWith({
+      'x-vercel-forwarded-for': '198.51.100.7, 10.0.0.1',
+      'x-forwarded-for': '10.0.0.1, 203.0.113.9',
+    });
+    expect((init.headers as Headers).get('x-real-ip')).toBe('198.51.100.7');
+  });
+
+  it('does not forward a non-IP-shaped last hop', async () => {
+    const init = await forwardWith({ 'x-forwarded-for': 'not-an-ip' });
+    expect((init.headers as Headers).get('x-real-ip')).toBeNull();
   });
 });

--- a/tests/app/user/page.test.tsx
+++ b/tests/app/user/page.test.tsx
@@ -68,7 +68,7 @@ import { getUserPage } from '@/app/lib/api/user';
 import UserPage from '@/app/user/page';
 import { resolveSsrViewport } from '@/app/utils/ssrViewport';
 
-const authedPrincipal = { email: 'c@x.com', mfaSatisfied: true, galleries: [] };
+const authedPrincipal = { email: 'c@x.com', isAdmin: false, mfaSatisfied: true, galleries: [] };
 
 const collectionBlock = (id: number) => ({ id, contentType: 'COLLECTION' });
 // isContentImage requires an `imageUrl` field, so the fixture supplies one.

--- a/tests/components/Content/SaveHeart.test.tsx
+++ b/tests/components/Content/SaveHeart.test.tsx
@@ -27,6 +27,7 @@ beforeEach(() => {
 // Any logged-in principal — no gallery membership required for saves.
 const viewer: MeResponse = {
   email: 'viewer@example.com',
+  isAdmin: false,
   mfaSatisfied: false,
   galleries: [],
 };

--- a/tests/components/Content/SelectStar.test.tsx
+++ b/tests/components/Content/SelectStar.test.tsx
@@ -29,6 +29,7 @@ beforeEach(() => {
 
 const client: MeResponse = {
   email: 'client@example.com',
+  isAdmin: false,
   mfaSatisfied: false,
   galleries: [{ collectionId: 3, role: 'CLIENT' }],
 };

--- a/tests/components/MenuDropdown.test.tsx
+++ b/tests/components/MenuDropdown.test.tsx
@@ -29,7 +29,12 @@ jest.mock('@/app/utils/environment', () => ({
 const mockMe = authApi.me as jest.MockedFunction<typeof authApi.me>;
 const mockLogout = authApi.logout as jest.MockedFunction<typeof authApi.logout>;
 
-const principal: MeResponse = { email: 'a@b.com', mfaSatisfied: true, galleries: [] };
+const principal: MeResponse = {
+  email: 'a@b.com',
+  isAdmin: false,
+  mfaSatisfied: true,
+  galleries: [],
+};
 
 describe('MenuDropdown — auth actions', () => {
   beforeEach(() => {

--- a/tests/components/SendMessageButton/SendMessageButton.test.tsx
+++ b/tests/components/SendMessageButton/SendMessageButton.test.tsx
@@ -11,7 +11,12 @@ const mockSubmit = contactApi.submitContactMessage as jest.MockedFunction<
   typeof contactApi.submitContactMessage
 >;
 
-const me: MeResponse = { email: 'user@example.com', mfaSatisfied: true, galleries: [] };
+const me: MeResponse = {
+  email: 'user@example.com',
+  isAdmin: false,
+  mfaSatisfied: true,
+  galleries: [],
+};
 
 function renderWithMe(principal: MeResponse | null) {
   return render(

--- a/tests/components/auth/MeProvider.test.tsx
+++ b/tests/components/auth/MeProvider.test.tsx
@@ -10,6 +10,7 @@ import { type MeResponse } from '@/app/types/Auth';
 
 const me: MeResponse = {
   email: 'a@b.com',
+  isAdmin: false,
   mfaSatisfied: false,
   galleries: [],
 };

--- a/tests/hooks/useFetchMe.test.ts
+++ b/tests/hooks/useFetchMe.test.ts
@@ -14,7 +14,12 @@ jest.mock('@/app/lib/api/auth', () => ({
 
 const mockMe = authApi.me as jest.MockedFunction<typeof authApi.me>;
 
-const principal: MeResponse = { email: 'a@b.com', mfaSatisfied: true, galleries: [] };
+const principal: MeResponse = {
+  email: 'a@b.com',
+  isAdmin: false,
+  mfaSatisfied: true,
+  galleries: [],
+};
 
 function dispatchAuthChanged() {
   act(() => {

--- a/tests/lib/api/auth.test.ts
+++ b/tests/lib/api/auth.test.ts
@@ -168,6 +168,7 @@ describe('logout', () => {
 describe('me', () => {
   const meBody: MeResponse = {
     email: 'admin@example.com',
+    isAdmin: true,
     mfaSatisfied: true,
     galleries: [],
   };
@@ -477,7 +478,9 @@ describe('meServer', () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
-      json: jest.fn().mockResolvedValue({ email: 'c@x.com', mfaSatisfied: true, galleries: [] }),
+      json: jest
+        .fn()
+        .mockResolvedValue({ email: 'c@x.com', isAdmin: false, mfaSatisfied: true, galleries: [] }),
     });
 
     const result = await meServer();

--- a/tests/lib/api/core.test.ts
+++ b/tests/lib/api/core.test.ts
@@ -478,3 +478,72 @@ describe('getServerCookieHeader', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('admin fetchers forward the server session cookie (SSR)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const nextHeaders = require('next/headers') as { cookies: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Server runtime (no window) so getServerCookieHeader reads the cookie store.
+    Object.defineProperty(global, 'window', { value: undefined, writable: true });
+    nextHeaders.cookies.mockResolvedValue({
+      getAll: () => [{ name: 'ezac_session', value: 'sess-token' }],
+    });
+  });
+
+  it('attaches the Cookie header on fetchAdminGetApi', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ data: 'ok' }),
+    });
+
+    await fetchAdminGetApi('/users');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/admin'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Cookie: 'ezac_session=sess-token',
+        }),
+      })
+    );
+  });
+
+  it('attaches the Cookie header on an admin write fetcher (fetchAdminPostJsonApi)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ data: 'ok' }),
+    });
+
+    await fetchAdminPostJsonApi('/users', { name: 'x' });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/admin'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Cookie: 'ezac_session=sess-token',
+        }),
+      })
+    );
+  });
+
+  it('omits the Cookie header when the cookie store is empty', async () => {
+    nextHeaders.cookies.mockResolvedValue({ getAll: () => [] });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ data: 'ok' }),
+    });
+
+    await fetchAdminGetApi('/users');
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers).not.toHaveProperty('Cookie');
+  });
+});

--- a/tests/lib/components/CollectionPageWrapper.meTile.test.tsx
+++ b/tests/lib/components/CollectionPageWrapper.meTile.test.tsx
@@ -57,7 +57,12 @@ describe('CollectionPageWrapper — Me tile injection', () => {
   });
 
   it('injects the Me tile at index 1 of home content for a logged-in viewer', async () => {
-    mockMeServer.mockResolvedValue({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    mockMeServer.mockResolvedValue({
+      email: 'a@b.com',
+      isAdmin: false,
+      mfaSatisfied: true,
+      galleries: [],
+    });
     mockGetUserPage.mockResolvedValue({
       ...homeCollection(),
       coverImage: {
@@ -82,7 +87,12 @@ describe('CollectionPageWrapper — Me tile injection', () => {
   });
 
   it('injects a placeholder Me tile when getUserPage() returns null for a logged-in viewer', async () => {
-    mockMeServer.mockResolvedValue({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    mockMeServer.mockResolvedValue({
+      email: 'a@b.com',
+      isAdmin: false,
+      mfaSatisfied: true,
+      galleries: [],
+    });
     mockGetUserPage.mockResolvedValue(null);
     mockGetCollectionBySlug.mockResolvedValue(homeCollection());
 
@@ -107,7 +117,12 @@ describe('CollectionPageWrapper — Me tile injection', () => {
   });
 
   it('does NOT inject the Me tile on a non-home slug even when logged in', async () => {
-    mockMeServer.mockResolvedValue({ email: 'a@b.com', mfaSatisfied: true, galleries: [] });
+    mockMeServer.mockResolvedValue({
+      email: 'a@b.com',
+      isAdmin: false,
+      mfaSatisfied: true,
+      galleries: [],
+    });
     mockGetCollectionBySlug.mockResolvedValue(homeCollection({ slug: 'portfolio' }));
 
     const element = await CollectionPageWrapper({ slug: 'portfolio' });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -3,9 +3,11 @@
  *
  * Tests for the Next.js middleware (proxy.ts).
  *
- * Covers the admin hub redirect rules (local-only `/admin` + `/homePage`
- * passthrough; non-local redirects to `/`; localhost `/` → `/admin`) and the
- * `/cdn`, `/catalog`, and `/comments` rules.
+ * Covers the admin hub / dev-console rules (local-only `/homePage` passthrough;
+ * localhost `/` → `/admin`), the `/cdn` + `/catalog` rules, and the (admin)
+ * route-group session gate: in non-local environments every (admin) route
+ * requires an `ezac_session` cookie or redirects to `/login`; local passes
+ * through.
  */
 
 import { NextRequest } from 'next/server';
@@ -22,15 +24,16 @@ function setProd() {
   process.env = { ...ORIGINAL_ENV, NODE_ENV: 'production', NEXT_PUBLIC_ENV: 'production' };
 }
 
-function makeRequest(pathname: string): NextRequest {
-  return new NextRequest(`http://localhost:3000${pathname}`);
+function makeRequest(pathname: string, opts: { session?: boolean } = {}): NextRequest {
+  const headers = opts.session ? { cookie: 'ezac_session=abc123' } : undefined;
+  return new NextRequest(`http://localhost:3000${pathname}`, headers ? { headers } : undefined);
 }
 
 afterEach(() => {
   process.env = ORIGINAL_ENV;
 });
 
-describe('proxy middleware — admin hub redirects (localhost)', () => {
+describe('proxy middleware — dev-console rules (localhost)', () => {
   beforeEach(() => setLocal());
 
   it('redirects / → /admin on localhost', () => {
@@ -44,8 +47,8 @@ describe('proxy middleware — admin hub redirects (localhost)', () => {
     expect(res.headers.get('x-middleware-next')).toBe('1');
   });
 
-  it('passes /admin/foo through on localhost', () => {
-    const res = proxy(makeRequest('/admin/foo'));
+  it('passes /admin/users/1 through on localhost', () => {
+    const res = proxy(makeRequest('/admin/users/1'));
     expect(res.headers.get('x-middleware-next')).toBe('1');
   });
 
@@ -55,22 +58,10 @@ describe('proxy middleware — admin hub redirects (localhost)', () => {
   });
 });
 
-describe('proxy middleware — admin hub gating (non-local)', () => {
+describe('proxy middleware — /homePage + / (non-local)', () => {
   beforeEach(() => setProd());
 
-  it('redirects /admin → / in prod', () => {
-    const res = proxy(makeRequest('/admin'));
-    expect(res.status).toBe(307);
-    expect(res.headers.get('location')).toBe('http://localhost:3000/');
-  });
-
-  it('redirects /admin/foo → / in prod', () => {
-    const res = proxy(makeRequest('/admin/foo'));
-    expect(res.status).toBe(307);
-    expect(res.headers.get('location')).toBe('http://localhost:3000/');
-  });
-
-  it('redirects /homePage → / in prod', () => {
+  it('redirects /homePage → / in prod (local-only escape hatch)', () => {
     const res = proxy(makeRequest('/homePage'));
     expect(res.status).toBe(307);
     expect(res.headers.get('location')).toBe('http://localhost:3000/');
@@ -121,95 +112,59 @@ describe('proxy middleware — existing /catalog rule (regression)', () => {
   });
 });
 
-describe('proxy middleware — existing /comments admin gating (regression)', () => {
-  it('passes /comments through on localhost', () => {
-    setLocal();
-    const res = proxy(makeRequest('/comments'));
+describe('proxy middleware — (admin) group session gate (non-local)', () => {
+  beforeEach(() => setProd());
+
+  // The whole (admin) App Router group is gated. Each of these routes, when hit
+  // anonymously in prod, must redirect to /login; with an ezac_session cookie it
+  // passes through (the backend then validates the session + enforces isAdmin).
+  const adminRoutes = [
+    '/admin',
+    '/admin/users/1',
+    '/all-collections',
+    '/all-collections/foo',
+    '/all-images',
+    '/all-images/foo',
+    '/comments',
+    '/comments/foo',
+    '/metadata',
+    '/metadata/foo',
+    '/collection/manage',
+    '/collection/manage/foo',
+    '/collection/some-slug/edit',
+    '/explore',
+    '/explore/foo',
+  ];
+
+  it.each(adminRoutes)('redirects %s → /login when no ezac_session', pathname => {
+    const res = proxy(makeRequest(pathname));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost:3000/login');
+  });
+
+  it.each(adminRoutes)('passes %s through when ezac_session is present', pathname => {
+    const res = proxy(makeRequest(pathname, { session: true }));
     expect(res.headers.get('x-middleware-next')).toBe('1');
-  });
-
-  it('returns 403 on /comments in prod when admin routes disabled', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'false';
-    const res = proxy(makeRequest('/comments'));
-    expect(res.status).toBe(403);
-  });
-
-  it('returns 401 on /comments in prod when admin routes enabled but auth missing', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'true';
-    process.env.ADMIN_TOKEN = 'secret123';
-    const res = proxy(makeRequest('/comments'));
-    expect(res.status).toBe(401);
   });
 });
 
-describe('proxy middleware — /explore admin gating', () => {
-  it('passes /explore through on localhost', () => {
-    setLocal();
-    const res = proxy(makeRequest('/explore'));
+describe('proxy middleware — (admin) group passthrough (localhost)', () => {
+  beforeEach(() => setLocal());
+
+  const adminRoutes = [
+    '/admin',
+    '/all-collections',
+    '/all-images',
+    '/comments',
+    '/metadata',
+    '/collection/manage',
+    '/collection/some-slug/edit',
+    '/explore',
+  ];
+
+  it.each(adminRoutes)('passes %s through on localhost (no session needed)', pathname => {
+    const res = proxy(makeRequest(pathname));
     expect(res.headers.get('x-middleware-next')).toBe('1');
-  });
-
-  it('returns 403 on /explore in prod when admin routes disabled', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'false';
-    const res = proxy(makeRequest('/explore'));
-    expect(res.status).toBe(403);
-  });
-
-  it('returns 401 on /explore in prod when admin routes enabled but auth missing', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'true';
-    process.env.ADMIN_TOKEN = 'secret123';
-    const res = proxy(makeRequest('/explore'));
-    expect(res.status).toBe(401);
-  });
-});
-
-describe('proxy middleware — /all-collections admin gating', () => {
-  it('passes /all-collections through on localhost', () => {
-    setLocal();
-    const res = proxy(makeRequest('/all-collections'));
-    expect(res.headers.get('x-middleware-next')).toBe('1');
-  });
-
-  it('returns 403 on /all-collections in prod when admin routes disabled', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'false';
-    const res = proxy(makeRequest('/all-collections'));
-    expect(res.status).toBe(403);
-  });
-
-  it('returns 401 on /all-collections in prod when admin routes enabled but auth missing', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'true';
-    process.env.ADMIN_TOKEN = 'secret123';
-    const res = proxy(makeRequest('/all-collections'));
-    expect(res.status).toBe(401);
-  });
-});
-
-describe('proxy middleware — /all-images admin gating', () => {
-  it('passes /all-images through on localhost', () => {
-    setLocal();
-    const res = proxy(makeRequest('/all-images'));
-    expect(res.headers.get('x-middleware-next')).toBe('1');
-  });
-
-  it('returns 403 on /all-images in prod when admin routes disabled', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'false';
-    const res = proxy(makeRequest('/all-images'));
-    expect(res.status).toBe(403);
-  });
-
-  it('returns 401 on /all-images in prod when admin routes enabled but auth missing', () => {
-    setProd();
-    process.env.ADMIN_ROUTES_ENABLED = 'true';
-    process.env.ADMIN_TOKEN = 'secret123';
-    const res = proxy(makeRequest('/all-images'));
-    expect(res.status).toBe(401);
   });
 });
 

--- a/tests/utils/admin.test.ts
+++ b/tests/utils/admin.test.ts
@@ -1,98 +1,58 @@
-import { hasValidAdminAuth, isAdminRoutesEnabled, requireAdmin } from '@/app/utils/admin';
+import { redirect } from 'next/navigation';
 
-function createMockRequest(options: { headerToken?: string; cookieToken?: string }) {
+import { meServer } from '@/app/lib/api/auth';
+import { type MeResponse } from '@/app/types/Auth';
+import { requireAdmin } from '@/app/utils/admin';
+
+jest.mock('next/navigation', () => ({
+  // `redirect` throws a NEXT_REDIRECT sentinel in real Next so control never
+  // falls through; mimic that so tests can assert the throw AND that no code
+  // after the redirect runs.
+  redirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+jest.mock('@/app/lib/api/auth', () => ({
+  meServer: jest.fn(),
+}));
+
+const mockMeServer = meServer as jest.MockedFunction<typeof meServer>;
+const mockRedirect = redirect as jest.MockedFunction<typeof redirect>;
+
+function principal(overrides: Partial<MeResponse> = {}): MeResponse {
   return {
-    headers: {
-      get: (name: string) => (name === 'x-admin-token' ? (options.headerToken ?? null) : null),
-    },
-    cookies: {
-      get: (name: string) =>
-        name === 'admin_token' && options.cookieToken ? { value: options.cookieToken } : undefined,
-    },
-  } as unknown as Parameters<typeof hasValidAdminAuth>[0];
+    email: 'user@example.com',
+    isAdmin: false,
+    mfaSatisfied: true,
+    galleries: [],
+    ...overrides,
+  };
 }
 
-const originalEnv = process.env;
-
-beforeEach(() => {
-  process.env = { ...originalEnv };
-});
-
-afterAll(() => {
-  process.env = originalEnv;
-});
-
 describe('requireAdmin', () => {
-  it('resolves to undefined (non-enforcing today)', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves without redirecting for an admin principal', async () => {
+    mockMeServer.mockResolvedValue(principal({ isAdmin: true }));
+
     await expect(requireAdmin()).resolves.toBeUndefined();
-  });
-});
-
-describe('isAdminRoutesEnabled', () => {
-  it('returns true when ADMIN_ROUTES_ENABLED is "true"', () => {
-    process.env.ADMIN_ROUTES_ENABLED = 'true';
-    expect(isAdminRoutesEnabled()).toBe(true);
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 
-  it('returns false when ADMIN_ROUTES_ENABLED is "false"', () => {
-    process.env.ADMIN_ROUTES_ENABLED = 'false';
-    expect(isAdminRoutesEnabled()).toBe(false);
+  it('redirects to /login for a logged-in non-admin', async () => {
+    mockMeServer.mockResolvedValue(principal({ isAdmin: false }));
+
+    await expect(requireAdmin()).rejects.toThrow('NEXT_REDIRECT:/login');
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
   });
 
-  it('returns false when ADMIN_ROUTES_ENABLED is undefined', () => {
-    delete process.env.ADMIN_ROUTES_ENABLED;
-    expect(isAdminRoutesEnabled()).toBe(false);
-  });
+  it('redirects to /login when anonymous (meServer returns null)', async () => {
+    mockMeServer.mockResolvedValue(null);
 
-  it('returns false when ADMIN_ROUTES_ENABLED is an empty string', () => {
-    process.env.ADMIN_ROUTES_ENABLED = '';
-    expect(isAdminRoutesEnabled()).toBe(false);
-  });
-});
-
-describe('hasValidAdminAuth', () => {
-  it('returns true when no ADMIN_TOKEN is configured (feature-flag only)', () => {
-    delete process.env.ADMIN_TOKEN;
-    const request = createMockRequest({});
-    expect(hasValidAdminAuth(request)).toBe(true);
-  });
-
-  it('returns true when header token matches ADMIN_TOKEN', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({ headerToken: 'secret123' });
-    expect(hasValidAdminAuth(request)).toBe(true);
-  });
-
-  it('returns false when header token does not match ADMIN_TOKEN', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({ headerToken: 'wrong-token' });
-    expect(hasValidAdminAuth(request)).toBe(false);
-  });
-
-  it('returns true when cookie token matches ADMIN_TOKEN', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({ cookieToken: 'secret123' });
-    expect(hasValidAdminAuth(request)).toBe(true);
-  });
-
-  it('returns false when cookie token does not match ADMIN_TOKEN', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({ cookieToken: 'wrong-cookie' });
-    expect(hasValidAdminAuth(request)).toBe(false);
-  });
-
-  it('returns false when no token is provided but ADMIN_TOKEN is set', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({});
-    expect(hasValidAdminAuth(request)).toBe(false);
-  });
-
-  it('returns true when header is valid even if cookie is wrong (header takes priority)', () => {
-    process.env.ADMIN_TOKEN = 'secret123';
-    const request = createMockRequest({
-      headerToken: 'secret123',
-      cookieToken: 'wrong-cookie',
-    });
-    expect(hasValidAdminAuth(request)).toBe(true);
+    await expect(requireAdmin()).rejects.toThrow('NEXT_REDIRECT:/login');
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
   });
 });

--- a/tests/utils/galleryAccess.test.ts
+++ b/tests/utils/galleryAccess.test.ts
@@ -10,12 +10,14 @@ const clientMembership = { collectionId: 7, role: 'CLIENT' as const };
 
 const clientMe: MeResponse = {
   email: 'client@example.com',
+  isAdmin: false,
   mfaSatisfied: false,
   galleries: [clientMembership],
 };
 
 const generalMe: MeResponse = {
   email: 'general@example.com',
+  isAdmin: false,
   mfaSatisfied: false,
   galleries: [{ collectionId: 7, role: 'GENERAL' }],
 };


### PR DESCRIPTION
## Summary

Paired with themancalledzac/edens.zac.backend#113, which gates `/api/admin/**` on `hasRole("ADMIN")`. This PR closes the frontend side of the same hole: the BFF proxy (`app/api/proxy/[...path]/route.ts`) forwarded every request to `/api/admin/**` with the internal BFF secret and **no session or path gate**, so any anonymous internet client could reach admin endpoints in prod.

**Confirmed live before this fix** (read-only status-code checks against `https://zacedens.com`, response bodies discarded): anonymous `GET /api/proxy/api/admin/users` and `/api/proxy/api/admin/messages` both returned **200**.

## The fix

- **Session-cookie forwarding wired into admin SSR fetches** (`fetchAdminGetApi`, `fetchBase` in `app/lib/api/core.ts`) so server-rendered admin pages keep working once the backend requires a session — previously only read-fetches forwarded cookies server-side, so this was a real functional gap, not just a security one. Deduped via React's `cache()` (matching two existing precedents in this codebase) after a double-fetch was caught in review.
- **`route.ts` refuses anonymous `api/admin/**` calls in production with a 401** before forwarding — belt-and-suspenders; the backend `hasRole("ADMIN")` gate is authoritative regardless.
- **`proxy.ts`** (confirmed to be live Next 16 middleware — a stale "UNWIRED" comment predating this PR was wrong) now session-gates the entire `(admin)` page group, redirecting anonymous requests to `/login`. Includes a routing fix so `/admin/users/[id]` is actually reachable by real admins in prod (the prior rule redirected all of `/admin*` to `/`, unconditionally, predating that page's existence).
- **`requireAdmin()`** upgraded from a documented no-op to a real server-side gate.
- **`isAdmin` added to the `/api/auth/me` shape**, wired through from the paired backend PR.
- **`x-real-ip` hardened**: this deploys on AWS Amplify, where the old primary IP source (`x-vercel-forwarded-for`) never populates, silently falling back to a client-spoofable `x-real-ip` header used by the backend rate limiter. Now derived from the CloudFront-appended last hop of `x-forwarded-for`; a second, independent spoofing gap (the client-controlled header wasn't even in the strip list) was found and closed during review.
- Dead `ADMIN_TOKEN`/feature-flag admin-auth code removed (repo-wide sweep confirmed no orphaned references remain).

## Review process

Same two-stage independent review per commit as the paired backend PR, plus a holistic whole-branch review and participation in the cross-repo adversarial exploit-chain hunt — verdict: the hole is genuinely and fully closed, and the frontend's gates are confirmed to be true defense-in-depth (the backend alone is sufficient to block every anonymous path).

## Test plan

- `jest`: **156 suites / 2481 tests passed**
- `tsc --noEmit`: clean
- `prettier`/`eslint`: clean on all changed files
- New tests cover: anonymous admin API → 401 + not forwarded; cookie present → forwards; dev/read paths unaffected; spoofed `x-real-ip` not trusted; `(admin)` group redirects to `/login` anonymously in prod, passes through locally; admin SSR fetchers attach the session cookie

## ⚠️ Deploy requirements — read before merging

1. **Merge themancalledzac/edens.zac.backend#113 first (or together).** This frontend gracefully forwards a cookie the *old* backend simply ignores, so backend-first is safe; frontend-first would briefly 401 real admins if the backend isn't there yet to honor the cookie.
2. **Merging is not sufficient — both services must be deployed to production to close the hole.**
3. See the backend PR for the `ADMIN_BOOTSTRAP_EMAIL`/`ADMIN_BOOTSTRAP_PASSWORD` post-deploy requirement — without it, there will be zero admins after this ships.

Paired PR: themancalledzac/edens.zac.backend#113