### PR TITLE
Show admin UI for isAdmin principals in prod (0206)

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { getCollectionBySlug } from '@/app/lib/api/collections';
 import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
 import { CollectionType } from '@/app/types/Collection';
 import { requireAdmin } from '@/app/utils/admin';
-import { isLocalEnvironment } from '@/app/utils/environment';
 
 interface CollectionPageProps {
   params: Promise<{
@@ -71,9 +70,9 @@ export async function generateMetadata({ params }: CollectionPageProps): Promise
  * Route handler for individual collections by slug (e.g. /film, /portfolio-work).
  * Renders via the shared CollectionPageWrapper.
  *
- * `?manage=1` enters the in-place edit surface. It is a local-dev-only affordance,
- * parked until a real admin auth gate exists, so it is hard-disabled outside local
- * dev — production/preview never enter edit mode. Revive by wiring real auth here.
+ * `?manage=1` enters the in-place edit surface. Authorization is enforced by
+ * {@link requireAdmin} below (redirects anonymous/non-admin viewers to /login) — a
+ * real `isAdmin` principal, not an environment check, is what gates this in prod.
  */
 export default async function CollectionPage({ params, searchParams }: CollectionPageProps) {
   const { slug } = await params;
@@ -87,7 +86,7 @@ export default async function CollectionPage({ params, searchParams }: Collectio
   }
 
   const resolvedSearchParams = await searchParams;
-  const editMode = resolvedSearchParams?.manage === '1' && isLocalEnvironment();
+  const editMode = resolvedSearchParams?.manage === '1';
 
   if (editMode) {
     await requireAdmin();

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type Ref, useCallback, useState } from 'react';
 
+import { useMe } from '@/app/components/auth/MeProvider';
 import ClientGalleryDownload from '@/app/components/ClientGalleryDownload/ClientGalleryDownload';
 import { useCollectionFilter } from '@/app/components/ContentCollection/CollectionFilterContext';
 import { InlineEditableText } from '@/app/components/ContentCollection/edit/InlineEditableText';
@@ -29,7 +30,6 @@ import {
   buildWrapperClassName,
   resolveValidDimensions,
 } from '@/app/utils/contentRendererUtils';
-import { isLocalEnvironment } from '@/app/utils/environment';
 import { slugify } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
 import { manageHref } from '@/app/utils/manageUrl';
@@ -166,15 +166,20 @@ export default function CollectionContentRenderer({
 
   const collectionFilter = useCollectionFilter();
   const inlineEdit = useInlineEdit();
+  const me = useMe();
 
-  // Localhost-only shortcut into manage mode, pinned to the header cover image. Shown only on the
+  // Admin-only shortcut into manage mode, pinned to the header cover image. Shown only on the
   // public view (manage path sets currentCollectionId) for the cover block (contentId === -1).
+  // Reads `useMe()` (server-resolved principal, mounted via MeProvider in CollectionPageClient —
+  // no extra client fetch) rather than useFetchMe(), since this component renders once per
+  // content tile and a per-tile client fetch would duplicate the /api/auth/me call across the
+  // whole grid.
   const showCoverUpdateShortcut =
     contentType === 'IMAGE' &&
     contentId === COVER_IMAGE_CONTENT_ID &&
     currentCollectionId == null &&
     !!collectionSlug &&
-    isLocalEnvironment();
+    !!me?.isAdmin;
 
   const handleCoverUpdateClick = useCallback(
     (event: { stopPropagation: () => void }) => {

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -51,6 +51,7 @@ export function MenuDropdown({
   const [isClearing, startClearing] = useTransition();
 
   const { me, loading: meLoading } = useFetchMe();
+  const isAdmin = me?.isAdmin ?? false;
 
   const handleLogin = () => {
     router.push('/login');
@@ -264,7 +265,7 @@ export function MenuDropdown({
 
         {showContactForm && <ContactForm onSubmit={handleContactSubmit} />}
 
-        {isLocalEnvironment() && (
+        {isAdmin && (
           <div className={styles.dropdownMenuItem}>
             <button
               type="button"
@@ -276,7 +277,7 @@ export function MenuDropdown({
           </div>
         )}
 
-        {isLocalEnvironment() && (
+        {isAdmin && (
           <div className={styles.dropdownMenuItem}>
             <button
               type="button"
@@ -288,7 +289,7 @@ export function MenuDropdown({
           </div>
         )}
 
-        {isLocalEnvironment() && pageType === 'collection' && (
+        {isAdmin && pageType === 'collection' && (
           <div className={styles.dropdownMenuItem}>
             <button
               type="button"
@@ -300,7 +301,7 @@ export function MenuDropdown({
           </div>
         )}
 
-        {isLocalEnvironment() && (
+        {isAdmin && (
           <div className={styles.dropdownMenuItem}>
             <button
               type="button"
@@ -312,7 +313,7 @@ export function MenuDropdown({
           </div>
         )}
 
-        {isLocalEnvironment() && (
+        {isAdmin && (
           <div className={styles.dropdownMenuItem}>
             <button
               type="button"
@@ -324,6 +325,11 @@ export function MenuDropdown({
           </div>
         )}
 
+        {/* Clear Cache stays local-only: it POSTs to the dev-profile-only backend
+            endpoint /api/admin/cache/clear (controller/dev/AdminController.java,
+            @Profile("dev")), which does not exist in prod/preview. Unlike the other
+            admin items above, gating this on isAdmin alone would show a button that
+            404s for real admins in prod. */}
         {isLocalEnvironment() && (
           <div className={styles.dropdownMenuItem}>
             <button

--- a/tests/app/slug-page.manage.test.tsx
+++ b/tests/app/slug-page.manage.test.tsx
@@ -24,7 +24,7 @@ async function renderPage(slug: string, manage?: string) {
   render(element);
 }
 
-describe('app/[slug]/page.tsx — ?manage=1 entry (parked to local dev)', () => {
+describe('app/[slug]/page.tsx — ?manage=1 entry (isAdmin-gated via requireAdmin, no environment gate)', () => {
   const originalEnv = process.env.NEXT_PUBLIC_ENV;
 
   beforeEach(() => {
@@ -54,12 +54,23 @@ describe('app/[slug]/page.tsx — ?manage=1 entry (parked to local dev)', () => 
     expect(mockRequireAdmin).toHaveBeenCalledTimes(1);
   });
 
-  it('parks ?manage=1 in production: editMode=false, requireAdmin NOT called', async () => {
+  it('passes editMode=true and calls requireAdmin when ?manage=1 in production (no longer parked)', async () => {
     process.env.NEXT_PUBLIC_ENV = 'production';
     await renderPage('film', '1');
 
-    expect(mockWrapper.mock.calls[0][0]).toMatchObject({ slug: 'film', editMode: false });
-    expect(mockRequireAdmin).not.toHaveBeenCalled();
+    expect(mockWrapper.mock.calls[0][0]).toMatchObject({ slug: 'film', editMode: true });
+    expect(mockRequireAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects a non-admin viewer to /login in production via requireAdmin, even with ?manage=1', async () => {
+    process.env.NEXT_PUBLIC_ENV = 'production';
+    const redirectError = new Error('NEXT_REDIRECT');
+    mockRequireAdmin.mockRejectedValueOnce(redirectError);
+
+    await expect(renderPage('film', '1')).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockRequireAdmin).toHaveBeenCalledTimes(1);
+    // CollectionPageWrapper must not render for a viewer requireAdmin rejects.
+    expect(mockWrapper).not.toHaveBeenCalled();
   });
 
   it('treats any non-"1" manage value as non-edit', async () => {

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -27,13 +27,21 @@ const mockToggleArrayFilter = jest.fn();
 jest.mock('@/app/components/ui/FilterToolbar/FilterToolbar', () => ({
   FilterToolbar: () => null,
 }));
-jest.mock('@/app/utils/environment', () => ({
-  isLocalEnvironment: jest.fn(() => false),
+jest.mock('@/app/components/auth/MeProvider', () => ({
+  useMe: jest.fn(() => null),
 }));
 
-import { isLocalEnvironment } from '@/app/utils/environment';
+import { useMe } from '@/app/components/auth/MeProvider';
+import { type MeResponse } from '@/app/types/Auth';
 
-const mockIsLocalEnvironment = isLocalEnvironment as jest.MockedFunction<typeof isLocalEnvironment>;
+const mockUseMe = useMe as jest.MockedFunction<typeof useMe>;
+
+const adminPrincipal: MeResponse = {
+  email: 'admin@b.com',
+  isAdmin: true,
+  mfaSatisfied: true,
+  galleries: [],
+};
 
 const baseProps = {
   contentId: 42,
@@ -230,7 +238,7 @@ describe('CollectionContentRenderer — coverless collection tile (regression)',
   });
 });
 
-describe('CollectionContentRenderer — cover "Update" shortcut (localhost public view)', () => {
+describe('CollectionContentRenderer — cover "Update" shortcut (isAdmin-gated)', () => {
   // The header cover image is the parallax IMAGE block with the sentinel id -1.
   const coverProps = {
     contentId: -1,
@@ -250,11 +258,11 @@ describe('CollectionContentRenderer — cover "Update" shortcut (localhost publi
 
   beforeEach(() => {
     pushMock.mockClear();
-    mockIsLocalEnvironment.mockReturnValue(false);
+    mockUseMe.mockReturnValue(null);
   });
 
-  it('shows the shortcut and navigates to ?manage=1 on localhost public view', () => {
-    mockIsLocalEnvironment.mockReturnValue(true);
+  it('shows the shortcut and navigates to ?manage=1 for an isAdmin principal', () => {
+    mockUseMe.mockReturnValue(adminPrincipal);
     render(<CollectionContentRenderer {...coverProps} />);
 
     const button = screen.getByRole('button', { name: 'Update' });
@@ -262,26 +270,37 @@ describe('CollectionContentRenderer — cover "Update" shortcut (localhost publi
     expect(pushMock).toHaveBeenCalledWith('/my-gallery?manage=1');
   });
 
-  it('does not show the shortcut in production (non-localhost)', () => {
-    mockIsLocalEnvironment.mockReturnValue(false);
+  it('does not show the shortcut for a logged-out viewer (useMe() returns null)', () => {
+    mockUseMe.mockReturnValue(null);
     render(<CollectionContentRenderer {...coverProps} />);
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 
-  it('does not show the shortcut in manage mode (currentCollectionId set)', () => {
-    mockIsLocalEnvironment.mockReturnValue(true);
+  it('does not show the shortcut for a logged-in non-admin principal', () => {
+    mockUseMe.mockReturnValue({
+      email: 'user@b.com',
+      isAdmin: false,
+      mfaSatisfied: true,
+      galleries: [],
+    });
+    render(<CollectionContentRenderer {...coverProps} />);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the shortcut in manage mode (currentCollectionId set), even for an admin', () => {
+    mockUseMe.mockReturnValue(adminPrincipal);
     render(<CollectionContentRenderer {...coverProps} currentCollectionId={7} />);
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 
-  it('does not show the shortcut on a non-cover image (contentId !== -1)', () => {
-    mockIsLocalEnvironment.mockReturnValue(true);
+  it('does not show the shortcut on a non-cover image (contentId !== -1), even for an admin', () => {
+    mockUseMe.mockReturnValue(adminPrincipal);
     render(<CollectionContentRenderer {...coverProps} contentId={123} enableParallax={false} />);
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 
-  it('does not show the shortcut when no collectionSlug is available', () => {
-    mockIsLocalEnvironment.mockReturnValue(true);
+  it('does not show the shortcut when no collectionSlug is available, even for an admin', () => {
+    mockUseMe.mockReturnValue(adminPrincipal);
     render(<CollectionContentRenderer {...coverProps} collectionSlug={undefined} />);
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });

--- a/tests/components/MenuDropdown.test.tsx
+++ b/tests/components/MenuDropdown.test.tsx
@@ -36,6 +36,13 @@ const principal: MeResponse = {
   galleries: [],
 };
 
+const adminPrincipal: MeResponse = {
+  email: 'admin@b.com',
+  isAdmin: true,
+  mfaSatisfied: true,
+  galleries: [],
+};
+
 describe('MenuDropdown — auth actions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -116,5 +123,83 @@ describe('MenuDropdown — auth actions', () => {
     await screen.findByRole('button', { name: /log in/i }); // settle the me() fetch
 
     expect(screen.queryByRole('button', { name: /^home$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('MenuDropdown — admin item gating (isAdmin, not isLocalEnvironment)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPathname = '/some-collection';
+  });
+
+  it('shows Explore/Create/Metadata/Comments for an isAdmin principal (prod-shaped: isLocalEnvironment mocked false)', async () => {
+    mockMe.mockResolvedValue(adminPrincipal);
+
+    render(<MenuDropdown isOpen onClose={jest.fn()} />);
+
+    expect(await screen.findByRole('button', { name: 'Explore' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Metadata' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument();
+  });
+
+  it('shows Update only when pageType is "collection" for an isAdmin principal', async () => {
+    mockMe.mockResolvedValue(adminPrincipal);
+
+    render(
+      <MenuDropdown isOpen onClose={jest.fn()} pageType="collection" collectionSlug="my-gallery" />
+    );
+
+    const updateBtn = await screen.findByRole('button', { name: 'Update' });
+    fireEvent.click(updateBtn);
+    expect(mockPush).toHaveBeenCalledWith('/my-gallery?manage=1');
+  });
+
+  it('hides Update when pageType is not "collection", even for an isAdmin principal', async () => {
+    mockMe.mockResolvedValue(adminPrincipal);
+
+    render(<MenuDropdown isOpen onClose={jest.fn()} pageType="default" />);
+    await screen.findByRole('button', { name: 'Explore' }); // settle the me() fetch
+
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('hides Explore/Create/Update/Metadata/Comments for a logged-in non-admin principal', async () => {
+    mockMe.mockResolvedValue(principal); // isAdmin: false
+
+    render(
+      <MenuDropdown isOpen onClose={jest.fn()} pageType="collection" collectionSlug="my-gallery" />
+    );
+    await screen.findByRole('button', { name: /log out/i }); // settle the me() fetch
+
+    expect(screen.queryByRole('button', { name: 'Explore' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Metadata' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Comments' })).not.toBeInTheDocument();
+  });
+
+  it('hides Explore/Create/Update/Metadata/Comments for an anonymous (logged-out) viewer', async () => {
+    mockMe.mockResolvedValue(null);
+
+    render(
+      <MenuDropdown isOpen onClose={jest.fn()} pageType="collection" collectionSlug="my-gallery" />
+    );
+    await screen.findByRole('button', { name: /log in/i }); // settle the me() fetch
+
+    expect(screen.queryByRole('button', { name: 'Explore' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Metadata' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Comments' })).not.toBeInTheDocument();
+  });
+
+  it('hides Clear Cache for an isAdmin principal in a prod-shaped environment (isLocalEnvironment mocked false) — stays local-only even for real admins', async () => {
+    mockMe.mockResolvedValue(adminPrincipal);
+
+    render(<MenuDropdown isOpen onClose={jest.fn()} />);
+    await screen.findByRole('button', { name: 'Explore' }); // settle the me() fetch; other admin items ARE visible
+
+    expect(screen.queryByRole('button', { name: /clear cache/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Un-parks the 0179-era localhost-only admin affordances now that real admin identity exists (0203/0204): 5 MenuDropdown items (Explore/Create/Update/Metadata/Comments) + the collection cover "Update" shortcut + `/{slug}?manage=1` edit mode now key off `isAdmin` from `/api/auth/me` instead of `isLocalEnvironment()`. Clear Cache stays local-only — its endpoint lives in the dev-profile controller and doesn't exist in prod.

Visibility only: authorization remains `requireAdmin()` on pages + `hasRole('ADMIN')` on the API.

## Verification
tsc clean · 156 suites / 2489 tests green (+8 net) · every ungated item's endpoint verified to exist in prod-profile controllers (two independent traces) · MeProvider availability traced across all CollectionContentRenderer render paths (crash-proof null default) · no hydration mismatch (principal starts null on both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)