### PR TITLE
docs: fix stale pre-0203 admin-auth comments (0204 review follow-up)

### DIFF
--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -1,4 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import ContentBlockWithFullScreen from '@/app/components/Content/ContentBlockWithFullScreen';
 import { PageShell } from '@/app/components/ui/PageShell/PageShell';
 import { getAdminHomeTiles } from '@/app/lib/api/adminHome';

--- a/app/(admin)/admin/users/[id]/page.tsx
+++ b/app/(admin)/admin/users/[id]/page.tsx
@@ -1,5 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later
-// (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 

--- a/app/(admin)/all-collections/page.tsx
+++ b/app/(admin)/all-collections/page.tsx
@@ -1,4 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
 
 export const dynamic = 'force-dynamic';

--- a/app/(admin)/all-images/page.tsx
+++ b/app/(admin)/all-images/page.tsx
@@ -1,4 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import { notFound } from 'next/navigation';
 
 import AllImagesClient from '@/app/components/Admin/AllImagesClient';

--- a/app/(admin)/comments/page.tsx
+++ b/app/(admin)/comments/page.tsx
@@ -1,4 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import { PageShell } from '@/app/components/ui/PageShell/PageShell';
 import { getAdminMessages } from '@/app/lib/api/messages';
 

--- a/app/(admin)/metadata/page.tsx
+++ b/app/(admin)/metadata/page.tsx
@@ -1,4 +1,5 @@
-// Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later (see docs 009). Gating centralized in app/(admin)/layout.tsx.
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
 import { MetadataPageClient } from '@/app/components/MetadataPage/MetadataPageClient';
 import { getMetadata } from '@/app/lib/api/collections';
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -10,7 +10,7 @@ import { isLocalEnvironment } from '@/app/utils/environment';
 
 /**
  * Global Next.js Proxy
- * - Local-only admin hub at /admin (and /homePage escape route)
+ * - Localhost landing: / redirects to the /admin hub; /homePage is the local-only escape route
  * - Gates the whole (admin) App Router route group on an `ezac_session` cookie
  *   in non-local environments (presence check; the backend validates the session)
  * - Maintains legacy local-only protection for /cdn tooling routes


### PR DESCRIPTION
## Summary

The 0204-remove-impersonation final review found pre-existing comments that misdescribe the now-shipped 0203/0206 admin-auth state. They were deliberately left out of #204 to keep that diff minimal. This PR fixes the comment text only — **zero behavior change** (13 insertions / 8 deletions, all comment lines).

### Fixed

1. **`(admin)` page headers — 6 files** (review flagged `app/(admin)/admin/users/[id]/page.tsx`; the identical boilerplate existed in `admin/`, `comments/`, `all-collections/`, `all-images/`, `metadata/` too): replaced *"Admin = perimeter today (BFF INTERNAL_API_SECRET) → authenticated admin principal later"* with the shipped reality — backend enforces `hasRole('ADMIN')` on `/api/admin/**` (0203), page gating centralized in `app/(admin)/layout.tsx` via `requireAdmin()`.
2. **`proxy.ts:13`**: *"Local-only admin hub at /admin"* → the hub ships in every environment (isAdmin-gated since 0206); the bullet now describes what the proxy rules actually do — the localhost `/ → /admin` landing redirect and the local-only `/homePage` escape route.

### Verified already fixed (no edit)

3. `app/[slug]/page.tsx` *"parked until a real admin auth gate exists"* — already rewritten by 0206 (f52961a, "un-park local-only gates"); the current comment correctly describes the `requireAdmin()` call below it. No "parked" text remains in the repo.

## Verification

- `prettier --write` on touched files: unchanged
- `eslint --fix` on touched files: clean
- `tsc --noEmit`: clean
- `git diff` reviewed: comment lines only

🤖 Generated with [Claude Code](https://claude.com/claude-code)