### PR TITLE
docs(admin): correct stale Clear Cache comment after BE 0207

### DIFF
--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -325,11 +325,12 @@ export function MenuDropdown({
           </div>
         )}
 
-        {/* Clear Cache stays local-only: it POSTs to the dev-profile-only backend
-            endpoint /api/admin/cache/clear (controller/dev/AdminController.java,
-            @Profile("dev")), which does not exist in prod/preview. Unlike the other
-            admin items above, gating this on isAdmin alone would show a button that
-            404s for real admins in prod. */}
+        {/* Clear Cache stays local-only by choice: evicting the backend's
+            in-process admin caches + nuking the Next route cache is a dev
+            workflow tool, not something to surface on every prod page. Since
+            BE 0207 the endpoint (/api/admin/cache/clear) exists in all
+            profiles behind the /api/admin/** ADMIN gate, so this gating is
+            product preference — no longer 404-avoidance. */}
         {isLocalEnvironment() && (
           <div className={styles.dropdownMenuItem}>
             <button


### PR DESCRIPTION
Companion to backend [PR #116](https://github.com/themancalledzac/edens.zac.backend/pull/116) (merged + deployed).

The MenuDropdown comment next to the local-only **Clear Cache** button claimed `/api/admin/cache/clear` *"does not exist in prod/preview"* because the backend `AdminController` was `@Profile("dev")`. That is no longer true: since BE 0207 the whole controller serves in all profiles behind the `/api/admin/**` `hasRole("ADMIN")` gate, so the endpoint exists in prod. The button stays `isLocalEnvironment()`-gated by product choice (it's a dev workflow tool), not to dodge a 404.

Comment-only change — no behavior change. The `/admin` tiles fetch (`getAdminHomeTiles` → `/admin-home/tiles`) is unchanged and now resolves in prod thanks to the backend fix.

## Verification
- `prettier --write`: unchanged (already formatted)
- `eslint`: clean (exit 0)
- `tsc --noEmit`: clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)