### PR TITLE
fix(auth): restore public /explore swept into the session gate by 0203 F4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ For SCSS files, also run Stylelint:
 
 ## Common Mistakes to Avoid
 
+- Writing comments inside React component code (JSX `{/* ... */}` or inline `//` in component bodies) - documentation belongs in docblocks (JSDoc above the file/component/function) only
 - Using `'use client'` unnecessarily - prefer Server Components
 - Using `any` type - always use proper TypeScript types
 - Creating components without corresponding SCSS modules

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -265,17 +265,17 @@ export function MenuDropdown({
 
         {showContactForm && <ContactForm onSubmit={handleContactSubmit} />}
 
-        {isAdmin && (
-          <div className={styles.dropdownMenuItem}>
-            <button
-              type="button"
-              className={styles.dropdownMenuButton}
-              onClick={handleNavigation.explore}
-            >
-              <span className={styles.dropdownMenuOptions}>Explore</span>
-            </button>
-          </div>
-        )}
+        {/* Explore is public nav (the /explore taxonomy directory is deliberately
+            ungated — see proxy.ts), so it renders for logged-out visitors too. */}
+        <div className={styles.dropdownMenuItem}>
+          <button
+            type="button"
+            className={styles.dropdownMenuButton}
+            onClick={handleNavigation.explore}
+          >
+            <span className={styles.dropdownMenuOptions}>Explore</span>
+          </button>
+        </div>
 
         {isAdmin && (
           <div className={styles.dropdownMenuItem}>

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -33,6 +33,10 @@ interface MenuDropdownProps {
  * Features body scroll locking, click-outside-to-close on desktop, and
  * social media integration. Manages nested form states and navigation.
  *
+ * Public items (including Explore — the /explore taxonomy directory is
+ * deliberately ungated, see proxy.ts) render for logged-out visitors; admin
+ * items are gated on the `isAdmin` principal.
+ *
  * @param isOpen - Controls dropdown visibility
  * @param onClose - Callback to close the dropdown
  */
@@ -265,8 +269,6 @@ export function MenuDropdown({
 
         {showContactForm && <ContactForm onSubmit={handleContactSubmit} />}
 
-        {/* Explore is public nav (the /explore taxonomy directory is deliberately
-            ungated — see proxy.ts), so it renders for logged-out visitors too. */}
         <div className={styles.dropdownMenuItem}>
           <button
             type="button"

--- a/docs/000-summary.md
+++ b/docs/000-summary.md
@@ -12,13 +12,13 @@
 
 ## 🧭 Start here
 
-| File                                   | What it is                                                                          |
-| -------------------------------------- | ----------------------------------------------------------------------------------- |
-| [previous-work.md](previous-work.md)   | Shipped-feature log — "what got built and when."                                    |
-| The 9 chapters below                   | Each is an epic; open the chapter file for its remaining-work list + sections.       |
+| File                                   | What it is                                                                               |
+| -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [previous-work.md](previous-work.md)   | Shipped-feature log — "what got built and when."                                         |
+| The 9 chapters below                   | Each is an epic; open the chapter file for its remaining-work list + sections.           |
 | [../ai_guidelines/](../ai_guidelines/) | Canonical project conventions (API, CSS, lint, TS, testing) — referenced by `CLAUDE.md`. |
-| [handoffs/](handoffs/)                 | Session handoff runbooks (gitignored, local-only).                                   |
-| [user-flow/](user-flow/)               | Tracked as-built user-flow map (mermaid + SVG) — needs a refresh pass post-0182–0204. |
+| [handoffs/](handoffs/)                 | Session handoff runbooks (gitignored, local-only).                                       |
+| [user-flow/](user-flow/)               | Tracked as-built user-flow map (mermaid + SVG) — needs a refresh pass post-0182–0204.    |
 
 ---
 
@@ -55,7 +55,7 @@ Refactor + tests + observability + deps. **Shipped & archived** (→ [previous-w
 
 ### [007 · Security Hardening](007-security-hardening.md) 🟢
 
-Cross-cutting hardening surfaced by the (shipped) contact form. **✅ Admin route gating shipped** (0203 F4 — all-collections/all-images/collection-manage/metadata are in the proxy matcher) **and the anonymous admin-API hole is closed** (0203, `is_admin` + `hasRole(ADMIN)`). Open: a **regression** — 0203's matcher swept up the deliberately-public `/explore` page — + the CloudFlare Phase 2 migration.
+Cross-cutting hardening surfaced by the (shipped) contact form. **✅ Admin route gating shipped** (0203 F4 — all-collections/all-images/collection-manage/metadata are in the proxy matcher) **and the anonymous admin-API hole is closed** (0203, `is_admin` + `hasRole(ADMIN)`). **✅ The `/explore` over-gate regression is fixed** (2026-07-06 — public again, Explore nav shows logged-out). Open: the CloudFlare Phase 2 migration.
 **Sections:** [contact messages](superpowers/plans/007-contact-messages.md) 📘 · [CloudFlare Phase 2](superpowers/plans/007-cloudflare-phase2.md) 🟢
 
 ### [008 · Collection / Admin](008-collection-admin.md) ✅ / 🟢
@@ -74,14 +74,13 @@ The API-contract reference (still-missing endpoints that block frontend work) + 
 
 > **Sequencing decision (2026-06-02):** perf/LCP is **deferred to the END** of the refactoring phases — optimization rides on top of clean structure. `/todoist-done <desc>` marks items complete in Todoist.
 
-1. **Fix `/explore` public access** — 0203's proxy matcher login-walls the deliberately-public taxonomy page in prod. → [007](007-security-hardening.md).
-2. **Merge the 0204 pair** (impersonation removal, FE+BE PRs pending) → then archive its spec+plan (kept-until-merge in `superpowers/`). → [008](008-collection-admin.md).
-3. **Track B leftovers** — mount-or-drop `Breadcrumb.tsx` decision; verify people/location chip-click-to-filter. → [004](004-content-discovery.md).
-4. **A3 Spot-1** — Save-as-Collection on the tag-view page itself (`TODO(A3)` in `useCollectionEdit.tsx:1353`). → [004](004-content-discovery.md) / [008](008-collection-admin.md).
-5. **`/user` ↔ `/admin/users/[id]` layout unification** — visual follow-up from 0204. → [008](008-collection-admin.md).
-6. **Client-gallery BCrypt** — P1-4 from the security handoff; reconcile BE shipped-state first. → [003](003-client-gallery-security.md).
-7. **Standing queue**: mobile-admin Phase 3 · `STAGING` collection ([008](008-collection-admin.md)) · CloudFlare Phase 2 ([007](007-security-hardening.md)) · 006 tail (Sentry/CloudWatch, decomposition, property tests) · perf ⛔ backend-blocked · SaveHeart 44px tap target.
-8. **Deferred by design**: A2 dynamic Home · Track D automation (auto-related, CLIP auto-tag — BE ML design doc exists, 0% built) · ABAC vision · liked-images.
+1. **Merge the 0204 pair** (impersonation removal, FE+BE PRs pending) → then archive its spec+plan (kept-until-merge in `superpowers/`). → [008](008-collection-admin.md).
+2. **Track B leftovers** — mount-or-drop `Breadcrumb.tsx` decision; verify people/location chip-click-to-filter. → [004](004-content-discovery.md).
+3. **A3 Spot-1** — Save-as-Collection on the tag-view page itself (`TODO(A3)` in `useCollectionEdit.tsx:1353`). → [004](004-content-discovery.md) / [008](008-collection-admin.md).
+4. **`/user` ↔ `/admin/users/[id]` layout unification** — visual follow-up from 0204. → [008](008-collection-admin.md).
+5. **Client-gallery BCrypt** — P1-4 from the security handoff; reconcile BE shipped-state first. → [003](003-client-gallery-security.md).
+6. **Standing queue**: mobile-admin Phase 3 · `STAGING` collection ([008](008-collection-admin.md)) · CloudFlare Phase 2 ([007](007-security-hardening.md)) · 006 tail (Sentry/CloudWatch, decomposition, property tests) · perf ⛔ backend-blocked · SaveHeart 44px tap target.
+7. **Deferred by design**: A2 dynamic Home · Track D automation (auto-related, CLIP auto-tag — BE ML design doc exists, 0% built) · ABAC vision · liked-images.
 
 **Infra / DevOps:** Cloudflare CDN/edge ([007](superpowers/plans/007-cloudflare-phase2.md) · Todoist `6XQm4Ccw7Ghq2f4G`) · backend startup messages (`6g8xfM6Xv7XRc3gq`) · OAuth/Amplify-Cognito investigation ([009 ABAC](superpowers/specs/009-abac-access-control.md) · `6XjcFJH6W6JhVCgp`).
 **Content / docs:** GitHub main-page README (`6g8xcP35w3Jmj7WH`) · backend README (`6g8xcR63JjC9X62q`). _(frontend README done, PR #111.)_

--- a/docs/007-security-hardening.md
+++ b/docs/007-security-hardening.md
@@ -2,14 +2,14 @@
 
 > Public-endpoint defense, admin-perimeter gaps, and origin protection · 🟢 active
 
-The contact form shipped as the site's first real public API endpoint — DB-backed, rate-limited, with a private admin reader — and it set the template every future public endpoint inherits. The admin perimeter is now closed (0203: the anonymous `/api/admin/**` hole + the unguarded proxy routes + `/metadata`), though that same sweep regressed the deliberately-public `/explore` page behind the login wall. What remains in this chapter is fixing that regression, generalizing the contact-specific rate-limit config before a second public endpoint lands, and the biggest single posture lever: putting CloudFlare in front of the EC2 origin.
+The contact form shipped as the site's first real public API endpoint — DB-backed, rate-limited, with a private admin reader — and it set the template every future public endpoint inherits. The admin perimeter is now closed (0203: the anonymous `/api/admin/**` hole + the unguarded proxy routes + `/metadata`), and the one page that sweep over-gated (`/explore`) is public again as of 2026-07-06. What remains in this chapter is generalizing the contact-specific rate-limit config before a second public endpoint lands, and the biggest single posture lever: putting CloudFlare in front of the EC2 origin.
 
 ## Remaining work (deduped)
 
 - ✅ **Anonymous admin-API authorization hole — CLOSED (2026-07-04, 0203 cycle).** `/api/admin/**` was `permitAll` in every profile (prod's only gate was the transport-level `InternalSecretFilter`), so an anonymous request through the BFF reached admin PII reads and the invite→accept account-takeover chain. Now gated by `hasRole('ADMIN')` behind the `app.admin.enforce-authz` toggle, inside the `InternalSecretFilter` perimeter (two-layer prod defense). Details: [2026-07-04-0203-admin-authz-implementation](superpowers/plans/2026-07-04-0203-admin-authz-implementation.md).
 - ✅ **Unguarded admin routes added to `proxy.ts`** (`all-collections` / `all-images` / `collection/manage/*`) — resolved by 0203 F4, alongside the metadata gate below. Plan [007-proxy-route-gating](superpowers/plans/007-proxy-route-gating.md) archived as superseded.
 - ✅ **`/metadata` gated behind admin auth** — resolved by 0203 F4, same matcher sweep as above.
-- **`/explore` login-walled in prod (regression)** — `/explore` was built deliberately public (`f9cd9c1`, chapter 001), but got swept into the `ezac_session` matcher by 0203 F4 (`9df92d8`). Fix = remove `/explore` from the `proxy.ts` matcher + decide logged-out nav visibility.
+- ✅ **`/explore` login-walled in prod (regression) — FIXED (2026-07-06).** `/explore` was built deliberately public (`f9cd9c1`, chapter 001) but got swept into the `ezac_session` matcher by 0203 F4 (`9df92d8`). Fixed by removing `/explore` from the `proxy.ts` matcher + runtime check (with a do-not-re-add comment), un-gating the MenuDropdown Explore item so logged-out visitors can find the page, and deleting the dead `/collection/:slug/edit` matcher entry (no such route exists — editing is `/[slug]?manage=1`) flagged by the 0203 review. Pinned by tests: `tests/proxy.test.ts` (anonymous prod passthrough + `config.matcher` assertions) and `tests/components/MenuDropdown.test.tsx` (Explore visible logged-out).
 - **0204 impersonation removal — shipped, pending merge.** Admin=root-view model replaces the dev-only "log in as" flow via `/admin/users/[id]`; see [008](008-collection-admin.md) for the full detail.
 - **Generalize the rate-limit config** — the `app.contact.rate-limit-*` props are contact-specific; refactor to a per-path map before adding a 2nd public endpoint.
 - **CloudFlare Phase 2** — orange-cloud the EC2 origin, lock ports to CF ranges, trust `CF-Connecting-IP`, drop `X-Real-IP` injection. Biggest security-posture lever ([007-cloudflare-phase2](superpowers/plans/007-cloudflare-phase2.md)).
@@ -19,15 +19,14 @@ The contact form shipped as the site's first real public API endpoint — DB-bac
 
 ## Sections
 
-| Section                                                                            | Role                     | Status |
-| ---------------------------------------------------------------------------------- | ------------------------ | ------ |
-| [007 · Contact Messages](superpowers/plans/007-contact-messages.md)                | Build record / reference | 📘 ref |
-| [007 · CloudFlare Phase 2](superpowers/plans/007-cloudflare-phase2.md)             | Plan                     | 🟢     |
+| Section                                                                | Role                     | Status |
+| ---------------------------------------------------------------------- | ------------------------ | ------ |
+| [007 · Contact Messages](superpowers/plans/007-contact-messages.md)    | Build record / reference | 📘 ref |
+| [007 · CloudFlare Phase 2](superpowers/plans/007-cloudflare-phase2.md) | Plan                     | 🟢     |
 
 ## Blocked on / open
 
 - Dependabot's 7 frontend vulnerabilities are independent of this chapter's work — track via GitHub Security, fix opportunistically.
-- The `/explore` regression (see above) needs a fix before it can be closed out.
 
 ## Decisions
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -65,13 +65,10 @@ export function proxy(request: NextRequest) {
     pathname.startsWith('/admin/') ||
     pathname === '/collection/manage' ||
     pathname.startsWith('/collection/manage/') ||
-    /\/collection\/.+\/edit$/.test(pathname) ||
     pathname === '/comments' ||
     pathname.startsWith('/comments/') ||
     pathname === '/metadata' ||
     pathname.startsWith('/metadata/') ||
-    pathname === '/explore' ||
-    pathname.startsWith('/explore/') ||
     pathname === '/all-collections' ||
     pathname.startsWith('/all-collections/') ||
     pathname === '/all-images' ||
@@ -102,6 +99,8 @@ export const config = {
     // localhost / → /admin redirect. Including '/' here means the middleware
     // runs on every public home page hit; the rule short-circuits in non-local
     // so the prod cost is a single env check.
+    // /explore is deliberately PUBLIC (taxonomy directory, chapter 001) — do not
+    // add it here; 0203 F4 did and login-walled it in prod.
     '/',
     '/admin',
     '/admin/:path*',
@@ -110,13 +109,10 @@ export const config = {
     '/cdn/:path*',
     '/collection/manage',
     '/collection/manage/:path*',
-    '/collection/:slug/edit',
     '/comments',
     '/comments/:path*',
     '/metadata',
     '/metadata/:path*',
-    '/explore',
-    '/explore/:path*',
     '/all-collections',
     '/all-collections/:path*',
     '/all-images',

--- a/tests/components/MenuDropdown.test.tsx
+++ b/tests/components/MenuDropdown.test.tsx
@@ -132,13 +132,12 @@ describe('MenuDropdown — admin item gating (isAdmin, not isLocalEnvironment)',
     mockPathname = '/some-collection';
   });
 
-  it('shows Explore/Create/Metadata/Comments for an isAdmin principal (prod-shaped: isLocalEnvironment mocked false)', async () => {
+  it('shows Create/Metadata/Comments for an isAdmin principal (prod-shaped: isLocalEnvironment mocked false)', async () => {
     mockMe.mockResolvedValue(adminPrincipal);
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
 
-    expect(await screen.findByRole('button', { name: 'Explore' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Create' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Metadata' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument();
   });
@@ -164,7 +163,7 @@ describe('MenuDropdown — admin item gating (isAdmin, not isLocalEnvironment)',
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 
-  it('hides Explore/Create/Update/Metadata/Comments for a logged-in non-admin principal', async () => {
+  it('hides Create/Update/Metadata/Comments for a logged-in non-admin principal (Explore stays public)', async () => {
     mockMe.mockResolvedValue(principal); // isAdmin: false
 
     render(
@@ -172,14 +171,14 @@ describe('MenuDropdown — admin item gating (isAdmin, not isLocalEnvironment)',
     );
     await screen.findByRole('button', { name: /log out/i }); // settle the me() fetch
 
-    expect(screen.queryByRole('button', { name: 'Explore' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explore' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Metadata' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Comments' })).not.toBeInTheDocument();
   });
 
-  it('hides Explore/Create/Update/Metadata/Comments for an anonymous (logged-out) viewer', async () => {
+  it('hides Create/Update/Metadata/Comments for an anonymous (logged-out) viewer (Explore stays public)', async () => {
     mockMe.mockResolvedValue(null);
 
     render(
@@ -187,18 +186,28 @@ describe('MenuDropdown — admin item gating (isAdmin, not isLocalEnvironment)',
     );
     await screen.findByRole('button', { name: /log in/i }); // settle the me() fetch
 
-    expect(screen.queryByRole('button', { name: 'Explore' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Explore' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Metadata' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Comments' })).not.toBeInTheDocument();
   });
 
+  it('shows Explore for an anonymous viewer and navigates to /explore (public taxonomy directory)', async () => {
+    mockMe.mockResolvedValue(null);
+
+    render(<MenuDropdown isOpen onClose={jest.fn()} />);
+
+    const exploreBtn = await screen.findByRole('button', { name: 'Explore' });
+    fireEvent.click(exploreBtn);
+    expect(mockPush).toHaveBeenCalledWith('/explore');
+  });
+
   it('hides Clear Cache for an isAdmin principal in a prod-shaped environment (isLocalEnvironment mocked false) — stays local-only even for real admins', async () => {
     mockMe.mockResolvedValue(adminPrincipal);
 
     render(<MenuDropdown isOpen onClose={jest.fn()} />);
-    await screen.findByRole('button', { name: 'Explore' }); // settle the me() fetch; other admin items ARE visible
+    await screen.findByRole('button', { name: 'Create' }); // settle the me() fetch; other admin items ARE visible
 
     expect(screen.queryByRole('button', { name: /clear cache/i })).not.toBeInTheDocument();
   });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -7,12 +7,13 @@
  * localhost `/` → `/admin`), the `/cdn` + `/catalog` rules, and the (admin)
  * route-group session gate: in non-local environments every (admin) route
  * requires an `ezac_session` cookie or redirects to `/login`; local passes
- * through.
+ * through. Also pins the public perimeter: `/explore` stays anonymous (0203 F4
+ * regression fix) and the never-routed `/collection/:slug/edit` gate stays dead.
  */
 
 import { NextRequest } from 'next/server';
 
-import { proxy } from '@/proxy';
+import { config, proxy } from '@/proxy';
 
 const ORIGINAL_ENV = process.env;
 
@@ -131,9 +132,6 @@ describe('proxy middleware — (admin) group session gate (non-local)', () => {
     '/metadata/foo',
     '/collection/manage',
     '/collection/manage/foo',
-    '/collection/some-slug/edit',
-    '/explore',
-    '/explore/foo',
   ];
 
   it.each(adminRoutes)('redirects %s → /login when no ezac_session', pathname => {
@@ -158,13 +156,55 @@ describe('proxy middleware — (admin) group passthrough (localhost)', () => {
     '/comments',
     '/metadata',
     '/collection/manage',
-    '/collection/some-slug/edit',
-    '/explore',
   ];
 
   it.each(adminRoutes)('passes %s through on localhost (no session needed)', pathname => {
     const res = proxy(makeRequest(pathname));
     expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+});
+
+describe('proxy middleware — public routes stay public (non-local)', () => {
+  beforeEach(() => setProd());
+
+  // /explore is the deliberately public taxonomy directory (f9cd9c1, chapter 001).
+  // 0203 F4 (9df92d8) regression-gated it behind the ezac_session presence check;
+  // these tests pin the fix: anonymous prod traffic must pass through.
+  it.each(['/explore', '/explore/foo'])('passes %s through anonymously in prod', pathname => {
+    const res = proxy(makeRequest(pathname));
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  // /collection/[slug]/edit has never existed as a route — in-place editing is
+  // /[slug]?manage=1 (manageHref). The middleware must not gate a path the app
+  // 404s anyway.
+  it('passes /collection/some-slug/edit through anonymously in prod (dead gate removed)', () => {
+    const res = proxy(makeRequest('/collection/some-slug/edit'));
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+});
+
+describe('proxy middleware — config.matcher', () => {
+  it('does not match public /explore or the dead /collection/:slug/edit entry', () => {
+    expect(config.matcher).not.toContain('/explore');
+    expect(config.matcher).not.toContain('/explore/:path*');
+    expect(config.matcher).not.toContain('/collection/:slug/edit');
+  });
+
+  it('still matches the (admin) group surfaces', () => {
+    const gated = [
+      '/admin',
+      '/admin/:path*',
+      '/collection/manage',
+      '/collection/manage/:path*',
+      '/comments',
+      '/metadata',
+      '/all-collections',
+      '/all-images',
+    ];
+    for (const entry of gated) {
+      expect(config.matcher).toContain(entry);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Ships the completed work found in the `claude/reverent-hopper-2ccc66` session worktree during today's worktree consolidation pass (commit preserved verbatim, `99749e0`). It resolves the two **minor, non-security observations from the 0203 final review**:

1. **`/explore` was over-gated**: built deliberately public (f9cd9c1, chapter 001 taxonomy directory), but 0203 F4 (9df92d8) added it to the `proxy.ts` `ezac_session` matcher — prod login-walled anonymous visitors (availability, not security). Removed from both the matcher and the runtime `isAdminRoute` check, with a do-not-re-add comment at the matcher.
2. **Dead `/collection/:slug/edit` matcher entry**: no such route exists (in-place editing is `/[slug]?manage=1` via `manageHref`). Removed matcher entry + runtime regex.
3. **MenuDropdown**: Explore item un-gated (was isAdmin-only) so logged-out visitors can reach the public page; returns to its original public-group spot.

Docs: chapter 007 bullet marked fixed; 000-summary updated.

## Verification

- Targeted: `tests/proxy.test.ts` + `tests/components/MenuDropdown.test.tsx` → 61/61 pass (includes new anonymous-prod-passthrough, matcher-membership, and Explore-visibility pins)
- Full suite: **2487/2487 pass**, `tsc --noEmit` clean

## Coexistence with #207

Both touch `proxy.ts` in different regions (#207 edits the docblock bullet at L13; this edits the matcher/runtime check) — they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)