### PR TITLE
fix(auth): passkey enrollment on /user, flow-keyed login errors, invite-failure surfacing

### DIFF
--- a/app/components/Personal/AccountCard.module.scss
+++ b/app/components/Personal/AccountCard.module.scss
@@ -1,0 +1,63 @@
+/* AccountCard — email + passkey (Face / Touch ID) enrollment block on /user.
+   Sits below the personal sections; the heading row mirrors SectionTitleCard's
+   typography and border so the card reads as a sibling of the section stack. */
+
+.card {
+  margin-top: var(--space-8);
+
+  /* Keep the card inset while the content grids above run full-bleed on mobile;
+     reset at the desktop breakpoint where .sections regains its own side padding.
+     Mirrors SectionTitleCard .heading. */
+  padding-inline: var(--page-padding-mobile);
+
+  @media (width >= 768px) {
+    padding-inline: 0;
+  }
+}
+
+.heading {
+  margin: 0;
+  padding: var(--space-4) var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  font-family: var(--font-serif);
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 500;
+  line-height: 1.1;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-2) 0;
+}
+
+.email {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.passkeyRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.enrollButton {
+  flex-shrink: 0;
+}
+
+.success {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+}

--- a/app/components/Personal/AccountCard.tsx
+++ b/app/components/Personal/AccountCard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useId, useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { registerPasskey } from '@/app/lib/api/auth';
+import { ApiError } from '@/app/lib/api/core';
+
+import styles from './AccountCard.module.scss';
+
+export interface AccountCardProps {
+  /** The signed-in principal's email, from the server-resolved `meServer()`. */
+  email: string;
+}
+
+type EnrollPhase = 'idle' | 'pending' | 'success' | 'error';
+
+/**
+ * Map a failed `registerPasskey()` ceremony to user-facing copy. Browser-side
+ * failures are `DOMException`s (`NotAllowedError` = sheet dismissed / timed out;
+ * `SecurityError` = WebAuthn misconfig for this domain); server-side failures are
+ * `ApiError`s, of which only the expired-session 401 gets dedicated wording.
+ */
+function mapEnrollError(err: unknown): string {
+  if (err instanceof DOMException) {
+    if (err.name === 'NotAllowedError') {
+      return "Face / Touch ID wasn't saved — the prompt was closed or timed out. Try again whenever you like.";
+    }
+    if (err.name === 'SecurityError') {
+      return "Face / Touch ID isn't available right now. Please try again later.";
+    }
+  }
+  if (err instanceof ApiError && err.status === 401) {
+    return 'Your session has expired. Sign in again to add Face / Touch ID.';
+  }
+  return "Face / Touch ID couldn't be saved. Please try again.";
+}
+
+/**
+ * "Account" card for the `/user` page: the signed-in email plus a passkey
+ * (Face / Touch ID) enrollment control driving the existing `registerPasskey()`
+ * WebAuthn ceremony, with pending / success / error feedback (never a silent
+ * swallow). Stateless about existing credentials — the backend exposes no
+ * credential-list endpoint yet — so the button is always offered; enrolling the
+ * same authenticator twice is stopped by the ceremony's `excludeCredentials`.
+ */
+export function AccountCard({ email }: AccountCardProps) {
+  const headingId = useId();
+  const [phase, setPhase] = useState<EnrollPhase>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleEnroll = async () => {
+    setError(null);
+    setPhase('pending');
+    try {
+      await registerPasskey();
+      setPhase('success');
+    } catch (error_) {
+      setError(mapEnrollError(error_));
+      setPhase('error');
+    }
+  };
+
+  return (
+    <section className={styles.card} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.heading}>
+        Account
+      </h2>
+      <div className={styles.body}>
+        <p className={styles.email}>{email}</p>
+        <div className={styles.passkeyRow}>
+          <p className={styles.hint}>Sign in faster with Face / Touch ID on this device.</p>
+          <Button
+            type="button"
+            variant="outline"
+            loading={phase === 'pending'}
+            onClick={handleEnroll}
+            className={styles.enrollButton}
+          >
+            Add Face / Touch ID
+          </Button>
+        </div>
+        {phase === 'success' && (
+          <p className={styles.success} role="status">
+            Face / Touch ID added. You can use it the next time you sign in.
+          </p>
+        )}
+        {error && <FormError>{error}</FormError>}
+      </div>
+    </section>
+  );
+}

--- a/app/invite/[token]/InviteForm.tsx
+++ b/app/invite/[token]/InviteForm.tsx
@@ -28,7 +28,10 @@ export interface InviteFormProps {
  *
  * Fields: display name (pre-filled), password, confirm password, and an optional
  * "Enable Face/Touch ID" checkbox. On submit → `acceptInvite` (auto-login via cookie)
- * → optional `registerPasskey` (best-effort; failure does not block redirect) → `/user`.
+ * → optional `registerPasskey` → `/user`. A passkey-enrollment failure never blocks
+ * the created account: instead of redirecting (or silently swallowing), the form
+ * surfaces a warning and swaps the submit button for an explicit continue-to-`/user`
+ * action, since the invite is consumed and re-submitting would 410.
  */
 export default function InviteForm({ token, email, displayName }: InviteFormProps) {
   const router = useRouter();
@@ -38,6 +41,7 @@ export default function InviteForm({ token, email, displayName }: InviteFormProp
   const [confirm, setConfirm] = useState('');
   const [enablePasskey, setEnablePasskey] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [passkeyWarning, setPasskeyWarning] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -74,8 +78,10 @@ export default function InviteForm({ token, email, displayName }: InviteFormProp
         try {
           await registerPasskey();
         } catch {
-          // Passkey enrollment is optional — a failure here should not block
-          // the redirect. The user can enroll later from their account settings.
+          setPasskeyWarning(
+            "Your account was created, but Face / Touch ID couldn't be saved — you can add it later from your account page."
+          );
+          return;
         }
       }
 
@@ -151,10 +157,17 @@ export default function InviteForm({ token, email, displayName }: InviteFormProp
       </label>
 
       {error && <FormError>{error}</FormError>}
+      {passkeyWarning && <FormError>{passkeyWarning}</FormError>}
 
-      <Button type="submit" loading={submitting} className={styles.submitButton}>
-        {submitting ? 'Setting up…' : 'Create Account'}
-      </Button>
+      {passkeyWarning ? (
+        <Button type="button" onClick={() => router.push('/user')} className={styles.submitButton}>
+          Continue to your space
+        </Button>
+      ) : (
+        <Button type="submit" loading={submitting} className={styles.submitButton}>
+          {submitting ? 'Setting up…' : 'Create Account'}
+        </Button>
+      )}
     </form>
   );
 }

--- a/app/invite/[token]/InviteForm.tsx
+++ b/app/invite/[token]/InviteForm.tsx
@@ -31,7 +31,9 @@ export interface InviteFormProps {
  * → optional `registerPasskey` → `/user`. A passkey-enrollment failure never blocks
  * the created account: instead of redirecting (or silently swallowing), the form
  * surfaces a warning and swaps the submit button for an explicit continue-to-`/user`
- * action, since the invite is consumed and re-submitting would 410.
+ * action, since the invite is consumed and re-submitting would 410. After that
+ * failure the form deliberately stays disabled (`submitting` never resets) so the
+ * consumed single-use invite cannot be resubmitted.
  */
 export default function InviteForm({ token, email, displayName }: InviteFormProps) {
   const router = useRouter();

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -85,10 +85,6 @@ export default function LoginForm() {
 
   const handlePasskeySignIn = async () => {
     setError(null);
-    if (!email.trim()) {
-      setError('Enter your email to use Face / Touch ID.');
-      return;
-    }
     try {
       setSubmitting(true);
       await loginWithPasskey(email.trim());

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -12,10 +12,46 @@ import { ApiError } from '@/app/lib/api/core';
 
 import styles from './LoginForm.module.scss';
 
+/** Which sign-in path produced a failure; 401 copy differs per flow. */
+type LoginFlow = 'password' | 'passkey';
+
+/**
+ * Map a sign-in failure to user-facing copy, disambiguating by flow and cause.
+ * Passkey ceremonies fail client-side as `DOMException`s (`NotAllowedError` =
+ * sheet dismissed / no usable passkey; `SecurityError` = WebAuthn misconfig, e.g.
+ * RP id not matching the page domain) and server-side as `ApiError`s. A passkey
+ * 401 is a finish-level rejection, so its copy never mentions passwords; the
+ * password-flow 401 keeps the classic safe wording. 429 is the shared (IP, email)
+ * rate limiter with a 15-minute window, so both flows name the wait. No message
+ * reveals whether an account or credential exists.
+ */
+function mapError(err: unknown, flow: LoginFlow): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) {
+      return flow === 'password'
+        ? 'Incorrect email or password.'
+        : "Passkey sign-in didn't complete. Please try again.";
+    }
+    if (err.status === 429) {
+      return 'Too many attempts. Please wait about 15 minutes before trying again.';
+    }
+  }
+  if (err instanceof DOMException) {
+    if (err.name === 'NotAllowedError') {
+      return 'No passkey was used — sign in with your password, then add Face / Touch ID from your account page.';
+    }
+    if (err.name === 'SecurityError') {
+      return "Passkey sign-in isn't available right now. Please use your password.";
+    }
+  }
+  return 'Something went wrong. Please try again.';
+}
+
 /**
  * Returning-user sign-in form. Email + password drives the break-glass `login()`;
  * the "Face / Touch ID" button drives `loginWithPasskey()` (email-keyed). On
  * success the backend sets the `ezac_session` cookie and we land on `/user`.
+ * Failures render through {@link mapError}, keyed by which flow was attempted.
  */
 export default function LoginForm() {
   const router = useRouter();
@@ -24,14 +60,6 @@ export default function LoginForm() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-
-  const mapError = (err: unknown): string => {
-    if (err instanceof ApiError) {
-      if (err.status === 401) return 'Incorrect email or password.';
-      if (err.status === 429) return 'Too many attempts. Please try again shortly.';
-    }
-    return 'Something went wrong. Please try again.';
-  };
 
   const handlePasswordSignIn = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -50,7 +78,7 @@ export default function LoginForm() {
       router.push('/user');
       router.refresh();
     } catch (error_) {
-      setError(mapError(error_));
+      setError(mapError(error_, 'password'));
       setSubmitting(false);
     }
   };
@@ -67,7 +95,7 @@ export default function LoginForm() {
       router.push('/user');
       router.refresh();
     } catch (error_) {
-      setError(mapError(error_));
+      setError(mapError(error_, 'passkey'));
       setSubmitting(false);
     }
   };

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { MeProvider } from '@/app/components/auth/MeProvider';
 import ContentBlockWithFullScreen from '@/app/components/Content/ContentBlockWithFullScreen';
 import LocationCollections from '@/app/components/LocationPage/LocationCollections';
+import { AccountCard } from '@/app/components/Personal/AccountCard';
 import { CollapsibleSection } from '@/app/components/Personal/CollapsibleSection';
 import { FollowsProvider } from '@/app/components/Personal/FollowsContext';
 import { PersonalContentGrid } from '@/app/components/Personal/PersonalContentGrid';
@@ -41,8 +42,9 @@ function splitUserContent(content: AnyContentModel[] | undefined): {
 /**
  * Session-gated self-only "Your Space" page for the signed-in user. Renders four ordered,
  * collapsible sections — Collections (open), Images (tagged), Saved (bookmarks), Following — each
- * headed by a title card. Anonymous visitors get a 404 (no login surface exists yet — invite /
- * onboarding is a later Phase C slice).
+ * headed by a title card, then an Account card (email + passkey enrollment) below the stack.
+ * Anonymous visitors get a 404; sign-in lives at `/login` (which lands here on success) and
+ * onboarding at the invite-link flow.
  */
 export default async function UserPage() {
   const principal = await meServer();
@@ -132,6 +134,8 @@ export default async function UserPage() {
                 <LocationCollections collections={followedCollections} />
               </FollowsProvider>
             </CollapsibleSection>
+
+            <AccountCard email={principal.email} />
           </div>
         </SavesProvider>
       </MeProvider>

--- a/tests/components/InviteForm.test.tsx
+++ b/tests/components/InviteForm.test.tsx
@@ -3,8 +3,9 @@
  *
  * Mirrors the ClientGalleryGate test style: mock the API helpers
  * (`acceptInvite`, `registerPasskey`) and `useRouter` from next/navigation,
- * then drive the form through validation, the happy path, the non-blocking
- * passkey-failure path, and the expired-token error path.
+ * then drive the form through validation, the happy path, the surfaced
+ * passkey-failure path (warning + explicit continue, no silent swallow), and
+ * the expired-token error path.
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -129,9 +130,9 @@ describe('InviteForm', () => {
     expect(mockRegisterPasskey).not.toHaveBeenCalled();
   });
 
-  it('still redirects to /user when passkey is opted-in but registerPasskey throws', async () => {
+  it('redirects to /user when passkey is opted-in and registerPasskey succeeds', async () => {
     mockAcceptInvite.mockResolvedValue();
-    mockRegisterPasskey.mockRejectedValue(new Error('user cancelled'));
+    mockRegisterPasskey.mockResolvedValue();
 
     renderForm('Jane');
 
@@ -150,6 +151,31 @@ describe('InviteForm', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/user');
     });
+  });
+
+  it('surfaces a warning with a continue action instead of silently redirecting when registerPasskey throws', async () => {
+    mockAcceptInvite.mockResolvedValue();
+    mockRegisterPasskey.mockRejectedValue(new DOMException('user cancelled', 'NotAllowedError'));
+
+    renderForm('Jane');
+
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: 'pw123456' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(CONFIRM_PLACEHOLDER), {
+      target: { value: 'pw123456' },
+    });
+    fireEvent.click(screen.getByLabelText(PASSKEY_LABEL));
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/your account was created/i);
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/add it later from your account page/i);
+    expect(mockPush).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /continue to your space/i }));
+    expect(mockPush).toHaveBeenCalledWith('/user');
   });
 
   it('shows an expired/invalid message and does not redirect on ApiError(410)', async () => {

--- a/tests/components/InviteForm.test.tsx
+++ b/tests/components/InviteForm.test.tsx
@@ -174,7 +174,16 @@ describe('InviteForm', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/add it later from your account page/i);
     expect(mockPush).not.toHaveBeenCalled();
 
+    // The invite is consumed, so the form must not offer a second submission:
+    // the submit button is replaced by Continue and every input stays disabled.
+    expect(screen.queryByRole('button', { name: /create account/i })).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Your name')).toBeDisabled();
+    expect(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER)).toBeDisabled();
+    expect(screen.getByPlaceholderText(CONFIRM_PLACEHOLDER)).toBeDisabled();
+    expect(screen.getByLabelText(PASSKEY_LABEL)).toBeDisabled();
+
     fireEvent.click(screen.getByRole('button', { name: /continue to your space/i }));
+    expect(mockAcceptInvite).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith('/user');
   });
 

--- a/tests/components/LoginForm.test.tsx
+++ b/tests/components/LoginForm.test.tsx
@@ -85,4 +85,62 @@ describe('LoginForm', () => {
     await waitFor(() => expect(mockLoginWithPasskey).toHaveBeenCalledWith('a@b.com'));
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/user'));
   });
+
+  /** Drive the passkey button with a pre-filled email and a rejecting loginWithPasskey. */
+  async function failPasskeySignIn(rejection: unknown): Promise<void> {
+    mockLoginWithPasskey.mockRejectedValue(rejection);
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), {
+      target: { value: 'a@b.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /face \/ touch id/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(mockPush).not.toHaveBeenCalled();
+  }
+
+  it('maps a passkey NotAllowedError to no-passkey guidance, not a generic failure', async () => {
+    await failPasskeySignIn(new DOMException('ceremony dismissed', 'NotAllowedError'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no passkey was used/i);
+    expect(screen.getByRole('alert')).toHaveTextContent(/add face \/ touch id from your account/i);
+  });
+
+  it('maps a passkey SecurityError to an availability message', async () => {
+    await failPasskeySignIn(new DOMException('invalid rp id', 'SecurityError'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/isn't available right now/i);
+  });
+
+  it('maps a passkey 429 to the 15-minute rate-limit message', async () => {
+    await failPasskeySignIn(new ApiError('Too many attempts', 429));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/wait about 15 minutes/i);
+  });
+
+  it('maps a passkey 401 to ceremony copy that never says "password"', async () => {
+    await failPasskeySignIn(new ApiError('Unauthorized', 401));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/passkey sign-in didn't complete/i);
+    expect(screen.getByRole('alert')).not.toHaveTextContent(/password/i);
+  });
+
+  it('maps a password 429 to the 15-minute rate-limit message', async () => {
+    mockLogin.mockRejectedValue(new ApiError('Too many attempts', 429));
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByPlaceholderText(EMAIL_PLACEHOLDER), {
+      target: { value: 'a@b.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(PASSWORD_PLACEHOLDER), {
+      target: { value: 'pw123456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/wait about 15 minutes/i)
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
 });

--- a/tests/components/Personal/AccountCard.test.tsx
+++ b/tests/components/Personal/AccountCard.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for AccountCard — the /user account block with the passkey (Face / Touch ID)
+ * enrollment affordance.
+ *
+ * Mirrors the LoginForm test style: mock `registerPasskey` from the auth API and
+ * drive the button through the pending, success, and per-cause failure states.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { AccountCard } from '@/app/components/Personal/AccountCard';
+import * as authApi from '@/app/lib/api/auth';
+import { ApiError } from '@/app/lib/api/core';
+
+jest.mock('@/app/lib/api/auth', () => ({
+  registerPasskey: jest.fn(),
+}));
+
+const mockRegisterPasskey = authApi.registerPasskey as jest.MockedFunction<
+  typeof authApi.registerPasskey
+>;
+
+const EMAIL = 'client@example.com';
+const ADD_BUTTON = /add face \/ touch id/i;
+
+describe('AccountCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the signed-in email and the enrollment button', () => {
+    render(<AccountCard email={EMAIL} />);
+
+    expect(screen.getByText(EMAIL)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: ADD_BUTTON })).toBeEnabled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('disables the button while the ceremony is pending, then shows success', async () => {
+    let resolveCeremony!: () => void;
+    mockRegisterPasskey.mockReturnValue(
+      new Promise<void>(resolve => {
+        resolveCeremony = resolve;
+      })
+    );
+    render(<AccountCard email={EMAIL} />);
+
+    const button = screen.getByRole('button', { name: ADD_BUTTON });
+    fireEvent.click(button);
+
+    expect(mockRegisterPasskey).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(button).toBeDisabled());
+
+    resolveCeremony();
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/face \/ touch id added/i)
+    );
+    expect(button).toBeEnabled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows dismissal guidance when the browser ceremony throws NotAllowedError', async () => {
+    mockRegisterPasskey.mockRejectedValue(new DOMException('dismissed', 'NotAllowedError'));
+    render(<AccountCard email={EMAIL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: ADD_BUTTON }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/wasn't saved.*try again/i)
+    );
+    expect(screen.getByRole('button', { name: ADD_BUTTON })).toBeEnabled();
+  });
+
+  it('shows an availability message when the ceremony throws SecurityError', async () => {
+    mockRegisterPasskey.mockRejectedValue(new DOMException('bad rp id', 'SecurityError'));
+    render(<AccountCard email={EMAIL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: ADD_BUTTON }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/isn't available right now/i)
+    );
+  });
+
+  it('shows a session message on ApiError 401', async () => {
+    mockRegisterPasskey.mockRejectedValue(new ApiError('Unauthorized', 401));
+    render(<AccountCard email={EMAIL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: ADD_BUTTON }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/session has expired/i)
+    );
+  });
+
+  it('shows a generic failure message for unrecognized errors and clears it on retry', async () => {
+    mockRegisterPasskey.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce();
+    render(<AccountCard email={EMAIL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: ADD_BUTTON }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/couldn't be saved/i));
+
+    fireEvent.click(screen.getByRole('button', { name: ADD_BUTTON }));
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/face \/ touch id added/i)
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

FE half of the 2026-07-06 passkey diagnosis (spike: `docs/spikes/2026-07-06-passkey-login-diagnosis.md`, local book doc — pieces 3+4) plus final-review findings:

- **Passkey enrollment on `/user`** (`3713858`) — new `AccountCard` ("Add Face / Touch ID") reusing the existing `registerPasskey()` ceremony from `app/lib/api/auth.ts`; the BE register endpoints already permit any authenticated session, so this is FE-only. Pending / success / per-cause error states, never a silent failure. Placement per the logged-in flow review §7 (local book doc). Stateless by design for now — an "already enrolled" credential list needs a small BE endpoint (follow-up); same-authenticator duplicates are blocked by the ceremony's `excludeCredentials`. This is the missing enrollment path for the bootstrap-seeded (password-only) admin account.
- **Flow-keyed login errors** (`22f7222`) — `mapError(err, flow)`: password-flow copy unchanged verbatim; the passkey flow now distinguishes ceremony abort/no-credential (`NotAllowedError`), WebAuthn config errors (`SecurityError`), rate-limit 429 (names the ~15-minute shared-limiter window, which also protects password login), and a passkey-401 message. Enumeration-safe — a test pins that passkey-401 copy never mentions "password".
- **Invite enrollment failure surfaced** (`f32457c`) — replaces the silent `catch {}` in `InviteForm`: account creation still succeeds, the user sees a warning ("…you can add it later from your account page") plus an explicit "Continue to your space" button; no auto-redirect, and the consumed single-use invite cannot be resubmitted (fields stay deliberately disabled — docblocked, and test-pinned by `1369430`).
- **Review findings** — dead unreachable empty-email guard removed from `handlePasskeySignIn` (`e146dac`); invite single-submit invariant test (`1369430`).

## Verification

- Full suite: **157 suites / 2,499 tests green**; `tsc --noEmit`, ESLint, Stylelint, Prettier all clean.
- New/extended tests: LoginForm ×5 (per-cause passkey errors, password-429, 401-never-says-password), InviteForm warning path + single-submit pin, AccountCard ×6 (real ceremony states via deferred promises, `role="status"`/`role="alert"` assertions).
- WebAuthn cannot be driven headlessly — after this and the BE counterpart merge + prod env/redeploy, the human E2E is: enroll from `/user` (admin) → log out → passkey login.

## Notes

- Depends on the BE counterpart for passkeys to work end-to-end (attempt-cookie path + prod `WEBAUTHN_*` env): https://github.com/themancalledzac/edens.zac.backend/pull/118
- Known optional hardening (out of scope here): `InviteForm.handleSubmit` has no reentrancy guard — a synthetic `form.submit()` could double-call, but no real user gesture can reach it (inputs disabled, submit control swapped); the UI contract is test-pinned. A one-line `if (submitting) return` is available as follow-up.
- Enrollment success intentionally does not dispatch `AUTH_CHANGED_EVENT` (registration isn't login; session unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
