### PR TITLE
docs(book): index 2026-07-06 design sections

### DIFF
--- a/docs/000-summary.md
+++ b/docs/000-summary.md
@@ -1,6 +1,6 @@
 # 📚 docs/ — The Book
 
-> **Updated 2026-07-06.** The master index of every planning doc, organized as **chapters → sections**. Reconciled against `origin/main` (HEAD `3cb007e`).
+> **Updated 2026-07-07.** The master index of every planning doc, organized as **chapters → sections**. Reconciled against `origin/main` (HEAD `9db8333`).
 >
 > **Structure:** this book (`000`) → **chapter files** (`001`–`009`, each an overview + remaining-work list) → **sections** (the MR-level plans/specs under `superpowers/plans/`, `superpowers/specs/`, `spikes/`). **All go-forward plans live in `superpowers/plans/`.**
 >
@@ -41,7 +41,7 @@ Cookie gate + admin password input shipped. Left: fix the **plaintext password**
 ### [004 · Content Discovery & Filtering](004-content-discovery.md) 🟢 / ⛔
 
 One reusable filter-bar/chip across Search/Location/Person/Tag/Collection; the `/search` route; collection tags; Collection IA. **Unified filter-visibility gate ✅ shipped** (35/35 plan tasks) · **Collection IA A1/A3 ✅ shipped** ([#198](https://github.com/themancalledzac/edens.zac/pull/198)/[#200](https://github.com/themancalledzac/edens.zac/pull/200)/[#199](https://github.com/themancalledzac/edens.zac/pull/199)) — A2 dynamic Home + Track D automation deferred by design. Remaining: auto-tag endpoint + public-page tag display; the `/search` route (⛔ backend); Breadcrumb mount-or-drop; A3 Spot-1.
-**Sections:** [public search page](superpowers/plans/004-public-search-page.md) ⛔ · [location filter bar](superpowers/plans/004-location-filter-bar.md) 🟡 · [collection tags](superpowers/plans/004-collection-tags.md) 🟡 · [collection IA & user-flow (living spec)](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md) 📘 · [menu-dropdown nav & discovery](superpowers/specs/2026-06-10-menu-dropdown-nav-design.md) ✅ _Option A shipped · Option C open_ · [liked images](superpowers/plans/004-liked-images.md) 🗒️
+**Sections:** [public search page](superpowers/plans/004-public-search-page.md) ⛔ · [location filter bar](superpowers/plans/004-location-filter-bar.md) 🟡 · [collection tags](superpowers/plans/004-collection-tags.md) 🟡 · [collection IA & user-flow (living spec)](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md) 📘 · [collections-as-tags design](superpowers/specs/2026-07-06-collections-as-tags-design.md) 📘 _(D1–D12 awaiting review; supersedes IA D7/D8)_ · [menu-dropdown nav & discovery](superpowers/specs/2026-06-10-menu-dropdown-nav-design.md) ✅ _Option A shipped · Option C open_ · [liked images](superpowers/plans/004-liked-images.md) 🗒️
 
 ### [005 · Layout](005-layout.md) 📘 / ✅
 
@@ -61,12 +61,12 @@ Cross-cutting hardening surfaced by the (shipped) contact form. **✅ Admin rout
 ### [008 · Collection / Admin](008-collection-admin.md) ✅ / 🟢
 
 **✅ Consolidated Edit Mode & Mobile-First Admin ([#181](https://github.com/themancalledzac/edens.zac/pull/181), `0179`, merged 2026-06-10)** — the dark `/manage` route collapsed into in-place light edit mode on `/[slug]` (`?manage=1`, local-dev); the 2,027-line **`ManageClient` deleted** for one `useCollectionEdit` hook + one `EditBar`; edit layer dynamically imported (public bundle ships zero admin code). **✅ Admin panel shipped**: comments panel (#197), user management (invite #187, merge UI, email-edit #202), 0203 authz + **0204 root-view model** (impersonation removed, pending merge — cross-ref [007](007-security-hardening.md)). Still open: **`/user` ↔ `/admin/users/[id]` layout unification**, the **`STAGING` system collection** (backend-heavy), + the mobile-first **Phase 3** surface rebuilds.
-**Sections:** [mobile-first admin](superpowers/plans/2026-06-08-mobile-first-admin.md) ✅🟢 _(Phase 3 ongoing)_ · [mobile-first admin design](superpowers/specs/2026-06-08-mobile-first-admin-design.md) 📘 · [staging collection](superpowers/plans/008-staging-collection.md) 🟢 _next_
+**Sections:** [mobile-first admin](superpowers/plans/2026-06-08-mobile-first-admin.md) ✅🟢 _(Phase 3 ongoing)_ · [mobile-first admin design](superpowers/specs/2026-06-08-mobile-first-admin-design.md) 📘 · [staging collection](superpowers/plans/008-staging-collection.md) 🟢 _next_ · [logged-in user-flow review](superpowers/specs/2026-07-06-logged-in-user-flow-review.md) 📘 _(user change-log panel — cross-ref, 009-owned)_
 
 ### [009 · Backend Contract & Auth Vision](009-backend-and-vision.md) 📘 / 🔭
 
-The API-contract reference (still-missing endpoints that block frontend work) + the long-horizon ABAC access-control vision. **✅ Phase C (User Concept) shipped** (2026-06-22 plan; Selects live; Rating control shipped-then-removed `fa5516b`) · **✅ Person→User identity merge shipped** (Phases 1+2 — the `users` table + `is_admin` path that fed 0203). Still-missing: search/locations/lenses/auto-tag endpoints.
-**Sections:** [ABAC access control](superpowers/specs/009-abac-access-control.md) 🔭 · [user concept](superpowers/specs/009-user-concept.md) ✅ _shipped_ _(the original backend-handoff contract doc is archived — absorbed into 009's still-missing list)_
+The API-contract reference (still-missing endpoints that block frontend work) + the long-horizon ABAC access-control vision. **✅ Phase C (User Concept) shipped** (2026-06-22 plan; Selects live; Rating control shipped-then-removed `fa5516b`) · **✅ Person→User identity merge shipped** (Phases 1+2 — the `users` table + `is_admin` path that fed 0203). Still-missing: search/locations/lenses/auto-tag endpoints. **2026-07-06:** passkey login proven never-worked e2e (spike; `0211` fix branches pending) · `gallery_access` is gone (V36) — `user_collection` is the whole access model.
+**Sections:** [ABAC access control](superpowers/specs/009-abac-access-control.md) 🔭 · [user concept](superpowers/specs/009-user-concept.md) ✅ _shipped_ _(the original backend-handoff contract doc is archived — absorbed into 009's still-missing list)_ · [logged-in user-flow review](superpowers/specs/2026-07-06-logged-in-user-flow-review.md) 📘 · [email/SES production posture](superpowers/specs/2026-07-06-email-ses-production.md) 📘 · [passkey login diagnosis](spikes/2026-07-06-passkey-login-diagnosis.md) 📘 _(`0211` fix branches, PRs pending)_
 
 ---
 

--- a/docs/004-content-discovery.md
+++ b/docs/004-content-discovery.md
@@ -8,6 +8,10 @@ This chapter covers the public-facing ways to find images: a future `/search` ro
 
 **A1 — unified tag-view routing** ([#198](https://github.com/themancalledzac/edens.zac/pull/198)/[#200](https://github.com/themancalledzac/edens.zac/pull/200)) shipped `/{slug}` as the single routing surface for both collections and tag-views, MenuDropdown Home/Me entries, and tag chips. **A3 — Save-as-Collection** ([#199](https://github.com/themancalledzac/edens.zac/pull/199)) shipped from the manage-list row, alongside Track C saves/follows and the `/user` redesign. **Deferred by design:** A2 dynamic Home, Track D automation (auto-related, CLIP auto-tag). The living target-model spec is [2026-06-29-collection-ia-and-user-flow-design](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md) — consult it for the full end-state, not just what shipped.
 
+## 📘 Collections-as-tags (design, 2026-07-06)
+
+The proposed next evolution of the Collection IA: the [collections-as-tags design](superpowers/specs/2026-07-06-collections-as-tags-design.md) makes **collections saved tag-combination filters** — a presentation shell (slug / cover / description / `rows_wide`) plus an optional AND-tag query for membership, **materialized into the existing `collection_content` join** (new `source` column; `visible=false` doubles as the curated hide) with event-driven sync + a nightly reconcile. It generalizes — and inverts — the V39 tag→collection promotion: "Save as Collection" gains a live mode. It **supersedes D7/D8 of the [2026-06-29 living spec](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md)**; the rest of that spec stands. Type dispositions: PARENT hubs attach queries in place; CLIENT_GALLERY and HOME stay bespoke. Blog rides the same model: per-day `BLOG` collections keyed by an explicit `collection_date`, ISO-date slugs resolved by the existing `/{slug}` resolver, and a `/blog` stream route. Net-new backend work flagged: the AND-tag query, a BE→FE revalidation client, and a `FIXED` display mode. Decision matrix D1–D12 awaiting Zac's review.
+
 ## Remaining work (deduped)
 
 - Build ONE reusable filter-bar/chip component shared across Search / Location / Person / Tag / Collection — don't rebuild per page.
@@ -22,13 +26,14 @@ This chapter covers the public-facing ways to find images: a future `/search` ro
 
 ## Sections
 
-| Section                                                                  | Role | Status                                             |
-| ------------------------------------------------------------------------ | ---- | -------------------------------------------------- |
-| [Public Search Page](superpowers/plans/004-public-search-page.md)        | plan | ⛔                                                 |
-| [Location Page Filter Bar](superpowers/plans/004-location-filter-bar.md) | plan | 🟡                                                 |
-| [Collection Tags](superpowers/plans/004-collection-tags.md)              | plan | 🟡 (FE Phase 1 shipped; auto-tag + display remain) |
-| [Collection IA & user-flow (living spec)](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md) | spec | 📘 (A1/A3 shipped; A2/Track D deferred)            |
-| [Menu-dropdown nav & discovery](superpowers/specs/2026-06-10-menu-dropdown-nav-design.md) | spec | ✅ Option A shipped · Option C open                |
+| Section                                                                                                       | Role | Status                                                                          |
+| ------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------- |
+| [Public Search Page](superpowers/plans/004-public-search-page.md)                                             | plan | ⛔                                                                              |
+| [Location Page Filter Bar](superpowers/plans/004-location-filter-bar.md)                                      | plan | 🟡                                                                              |
+| [Collection Tags](superpowers/plans/004-collection-tags.md)                                                   | plan | 🟡 (FE Phase 1 shipped; auto-tag + display remain)                              |
+| [Collection IA & user-flow (living spec)](superpowers/specs/2026-06-29-collection-ia-and-user-flow-design.md) | spec | 📘 (A1/A3 shipped; A2/Track D deferred; D7/D8 superseded → collections-as-tags) |
+| [Collections-as-tags (design)](superpowers/specs/2026-07-06-collections-as-tags-design.md)                    | spec | 📘 (D1–D12 awaiting review)                                                     |
+| [Menu-dropdown nav & discovery](superpowers/specs/2026-06-10-menu-dropdown-nav-design.md)                     | spec | ✅ Option A shipped · Option C open                                             |
 
 ## Blocked on / open
 

--- a/docs/008-collection-admin.md
+++ b/docs/008-collection-admin.md
@@ -26,13 +26,15 @@ Full commit-level detail in [previous-work.md](previous-work.md) ("Collections")
 - Exempt Staging from `enforceVisibility()` for admin reads (like Home); keep it invisible on public reads via its own `visible=false` flag.
 - Manage-page badge / indicator for staged (invisible) collections.
 
+**Admin "user change log" panel** 🔭 _(future, cross-ref)_ — the notify-badge / accept / revert / edit review panel designed in the [logged-in user-flow review §4](superpowers/specs/2026-07-06-logged-in-user-flow-review.md) will live on this admin surface; the doc is owned by [009](009-backend-and-vision.md).
+
 ## Sections (active)
 
-| Section                                                                                  | Role | Status                                        |
-| ---------------------------------------------------------------------------------------- | ---- | --------------------------------------------- |
+| Section                                                                                  | Role | Status                                           |
+| ---------------------------------------------------------------------------------------- | ---- | ------------------------------------------------ |
 | [Mobile-first admin](superpowers/plans/2026-06-08-mobile-first-admin.md)                 | plan | ✅ `0179` (Phases 1–2; Phase 3 surfaces ongoing) |
-| [Mobile-first admin — design](superpowers/specs/2026-06-08-mobile-first-admin-design.md) | spec | 📘 north-star (dark design language)          |
-| [008 · Staging Collection](superpowers/plans/008-staging-collection.md)                  | plan | 🟢 next (backend-heavy)                       |
+| [Mobile-first admin — design](superpowers/specs/2026-06-08-mobile-first-admin-design.md) | spec | 📘 north-star (dark design language)             |
+| [008 · Staging Collection](superpowers/plans/008-staging-collection.md)                  | plan | 🟢 next (backend-heavy)                          |
 
 > **Shipped sections** (consolidated-edit-mode plan + spec, manage-consolidation-and-cleanup, parent-column-and-grouped-rows plan + spec, collection-type-drag-and-drop-retype plan + spec) are archived in `_archive/shipped-plans-2026-06-10.tar.gz` — recorded in [previous-work.md](previous-work.md).
 

--- a/docs/009-backend-and-vision.md
+++ b/docs/009-backend-and-vision.md
@@ -14,20 +14,30 @@ This chapter is the bridge to the `edens.zac.backend` repo. The **contract** hal
 
 **ABAC vision — sequenced Foundation → Admin → Client → Tagging:**
 
-- **Phase F · Foundation — SHIPPED** (`0186-auth-foundation`): `app_user`, `user_session`, `gallery_access`, `webauthn_credential`, `SessionAuthenticationFilter`, `/api/auth/me`, DB-backed sessions + passkeys. Ships dormant (no client users yet).
-- **Phase C · Client — SHIPPED**: the [009 · User Concept](superpowers/specs/009-user-concept.md) spec executed via the 2026-06-22 plan — Selects/user pages are live; person↔account FK link and `gallery_access` enforcement (logged-in password bypass) shipped alongside the `/user` synthetic-collection page. **Note:** a Rating control shipped as part of this slice and was then **deliberately removed** (`fa5516b`) — don't restore it without re-litigating why.
+- **Phase F · Foundation — SHIPPED** (`0186-auth-foundation`): `app_user`, `user_session`, `gallery_access`, `webauthn_credential`, `SessionAuthenticationFilter`, `/api/auth/me`, DB-backed sessions + passkeys. Ships dormant (no client users yet). _Since then: `gallery_access` was dropped in V36 (`user_collection` replaced it), and the 2026-07-06 spike below proved passkey login never worked e2e._
+- **Phase C · Client — SHIPPED**: the [009 · User Concept](superpowers/specs/009-user-concept.md) spec executed via the 2026-06-22 plan — Selects/user pages are live; person↔account FK link and `gallery_access` enforcement (logged-in password bypass; carried by `user_collection` since V36) shipped alongside the `/user` synthetic-collection page. **Note:** a Rating control shipped as part of this slice and was then **deliberately removed** (`fa5516b`) — don't restore it without re-litigating why.
 - **Still vision (not approved):** admin MFA (TOTP → passkey, Phase A), client tagging + moderation (Phase T), CloudFront signed URLs. The chapter-003 Phase-2 items roll up here.
 
 **Person→User identity merge — SHIPPED** (Phases 1+2, [#194](https://github.com/themancalledzac/edens.zac/pull/194)/[#195](https://github.com/themancalledzac/edens.zac/pull/195)/[#196](https://github.com/themancalledzac/edens.zac/pull/196)): the backend's `Person` and `User` concepts were unified into a single `users` table — the same identity now carries both "person tagged in photos" and "account with login" semantics, and it's the path that fed the `is_admin` column 0203's authz gate depends on. Two watch-outs mined from the identity-merge handoff (recorded nowhere else in this chapter, so keep them here):
+
 - The `Records.Person(id, name)` DTO shape is a hard constraint — legacy `Person` API consumers expect exactly that shape; don't widen it casually when touching merge-adjacent code.
 - **Never `SELECT *` on `users` for tag queries** — the merged table carries auth-sensitive columns (password/session material) that must not leak into tag/people-list responses.
 
+**2026-07-06 review wave (three new reference docs):**
+
+- **Logged-in user flow — as-built review:** the [logged-in user-flow review](superpowers/specs/2026-07-06-logged-in-user-flow-review.md) inventories every logged-in surface and pins the edit-permission matrix to the 2026-07-06 decision — **user edits mutate canonical values; there is no per-user overlay** — plus a concrete FUTURE `user_change_log` design (admin hub panel: notify badge / accept / revert / edit; the panel itself will live on the [008](008-collection-admin.md) admin surface). Its user-tables review found **`gallery_access` was dropped in V36** (`user_collection` GENERAL|CLIENT is the whole access model) and the **V34 rating-override backend stack is orphaned** (D1 recommends deletion). Also covers group-access UX (bulk-grant over `user_collection` first), email-flow UX, and passkey-enrollment UX. Decisions D1–D8.
+- **Email/SES production posture:** the [email/SES production posture](superpowers/specs/2026-07-06-email-ses-production.md) doc pins that **nothing sends today** (`email.enabled` defaults false; invite links are clipboard-copy; the sole call site is the gallery-password email; the from-address is a non-deliverable placeholder), then lays out the ordered console checklist (domain identity + Easy DKIM in us-west-2, MAIL FROM/SPF, DMARC `p=none`, configuration set + SNS bounce handling, sandbox-exit request text included), code changes C1–C10 (S/M/L-sized), and decisions 1–6.
+- **Passkey login — diagnosed broken e2e (spike):** the [passkey login diagnosis](spikes/2026-07-06-passkey-login-diagnosis.md) verified a 4-layer root cause — the attempt-cookie (`Path=/api/auth/webauthn`) never survives the BFF proxy so login/finish always 401s (**passkeys have never worked end-to-end anywhere**); no enrollment surface exists for password-only accounts; prod serves `rpId=localhost` (compose lacks `WEBAUTHN_*` passthrough); and the shared login limiter compounds it. Fixes implemented on `0211-passkey-login-fixes` (FE: `/user` AccountCard enrollment, flow-keyed login errors, invite-failure surfacing) + `0211-passkey-login-fixes-be` (BE: cookie `Path=/`, compose env plumb) — **PRs pending**. Follow-up: a credentials list/remove backend endpoint for enrollment-state UI.
+
 ## Sections
 
-| Section                                                                   | Role                       | Status      |
-| ------------------------------------------------------------------------- | -------------------------- | ----------- |
-| [009 · ABAC Access Control](superpowers/specs/009-abac-access-control.md) | Long-horizon design        | 🔭 vision   |
-| [009 · User Concept](superpowers/specs/009-user-concept.md)               | Phase-C slice — build spec | ✅ shipped |
+| Section                                                                                  | Role                                       | Status                                |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------- |
+| [009 · ABAC Access Control](superpowers/specs/009-abac-access-control.md)                | Long-horizon design                        | 🔭 vision                             |
+| [009 · User Concept](superpowers/specs/009-user-concept.md)                              | Phase-C slice — build spec                 | ✅ shipped                            |
+| [Logged-in user-flow review](superpowers/specs/2026-07-06-logged-in-user-flow-review.md) | As-built review + `user_change_log` design | 📘 (D1–D8)                            |
+| [Email/SES production posture](superpowers/specs/2026-07-06-email-ses-production.md)     | Go-live checklist + code changes           | 📘 (C1–C10; decisions 1–6)            |
+| [Passkey login diagnosis](spikes/2026-07-06-passkey-login-diagnosis.md)                  | Spike — root cause + fixes                 | 📘 (`0211` fix branches, PRs pending) |
 
 > The original **009 · Backend Handoff** contract doc (2026-03-16) is archived — its confirm/fix asks are long resolved and its endpoint gaps are folded into "Still-missing backend endpoints" above.
 


### PR DESCRIPTION
Indexes the four 2026-07-06/07 design docs into the book (tracked index + chapters only — the section docs themselves are gitignored per the book convention):

- **004** — [collections-as-tags design] (`superpowers/specs/2026-07-06-collections-as-tags-design.md`): collections as saved AND-tag filters materialized into `collection_content`; blog = per-day BLOG collections; supersedes 2026-06-29 D7/D8; decisions D1–D12 awaiting review.
- **009** — [logged-in user-flow review] (`superpowers/specs/2026-07-06-logged-in-user-flow-review.md`): as-built inventory, edit-permission matrix (canonical mutation per the 2026-07-06 decision), FUTURE `user_change_log` design, user-tables review (`gallery_access` dropped in V36; V34 override stack orphaned); decisions D1–D8.
- **009** — [email/SES production posture] (`superpowers/specs/2026-07-06-email-ses-production.md`): nothing sends today; console checklist + code changes C1–C10 + decisions 1–6.
- **009** — [passkey login diagnosis] (`spikes/2026-07-06-passkey-login-diagnosis.md`): 4-layer root cause; fixes on the 0211 branches.
- **008** — one-line cross-ref to the future admin "user change log" panel (doc owned by 009).

Index "Updated" bumped to 2026-07-07, reconcile pin → `9db8333`, plus minimal truth-preserving blurb updates (passkey never worked e2e pre-0211; `gallery_access` carried by `user_collection` since V36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
