### PR TITLE
feat(collections): public permission-scoped /all-collections + home tile + tag filtering (0216)

### DIFF
--- a/app/all-collections/page.tsx
+++ b/app/all-collections/page.tsx
@@ -1,5 +1,7 @@
-// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
-// /api/admin/** (see docs 009). Gating centralized in app/(admin)/layout.tsx via requireAdmin().
+// Public + permission-scoped: the backend widens the synthetic all-collections list
+// from the caller's ezac_session (admin => all; signed-in => LISTED + granted
+// galleries; anonymous => LISTED), so no route-level gate is needed (0216 — was
+// previously in the (admin) group).
 import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
 
 export const dynamic = 'force-dynamic';

--- a/app/lib/api/collections.ts
+++ b/app/lib/api/collections.ts
@@ -116,6 +116,26 @@ export async function getCollectionBySlug(
 }
 
 /**
+ * GET /api/read/collections/all-collections
+ *
+ * Dedicated fetch for the permission-scoped synthetic list. The backend widens the
+ * result set from the caller's `ezac_session` (admin => all visibilities; signed-in
+ * => LISTED + their granted galleries; anonymous => LISTED), and `fetchReadApi`
+ * forwards inbound cookies server-side, so the response is per-viewer. `no-store`
+ * keeps scoped sets out of the shared Next.js data cache — unlike the ISR-cacheable
+ * `getCollectionBySlug` used by public single-collection pages, which must stay
+ * viewer-independent.
+ */
+export async function getScopedAllCollections(size = 500): Promise<CollectionModel> {
+  const result = await fetchReadApi<CollectionModel>(
+    `/collections/all-collections?page=0&size=${size}`,
+    { cache: 'no-store' }
+  );
+  if (result === null) notFound();
+  return result;
+}
+
+/**
  * GET /api/read/collections/location/{slug}
  * Get visible collections for a location, ordered by collection date (newest first)
  */

--- a/app/lib/components/CollectionPageWrapper.tsx
+++ b/app/lib/components/CollectionPageWrapper.tsx
@@ -9,6 +9,7 @@ import { listSavedImageIdsServer } from '@/app/lib/api/personal';
 import { listSelectIdsServer } from '@/app/lib/api/selects';
 import { getUserPage } from '@/app/lib/api/user';
 import { CollectionType } from '@/app/types/Collection';
+import { buildAllCollectionsContentBlock } from '@/app/utils/allCollectionsContentBlock';
 import { buildMeContentBlock } from '@/app/utils/meContentBlock';
 import { resolveSsrViewport } from '@/app/utils/ssrViewport';
 
@@ -60,16 +61,18 @@ export default async function CollectionPageWrapper({
           }
         : fetched;
 
-    // "Me" tile: home page only, logged-in viewer only. Inject the personal parallax
-    // card (links to /user) as the SECOND tile. One extra no-store fetch for logged-in
-    // home views; anonymous home is byte-identical (no fetch, no injection).
+    // Home-only synthetic tiles. Logged-in viewers get the personal "Me" tile as the
+    // SECOND tile (one extra no-store fetch; anonymous home skips that fetch), and
+    // EVERY viewer gets the public "All Collections" tile immediately after it
+    // (index 2 logged-in, index 1 anonymous) linking to the permission-scoped list.
     const collection =
-      slug === 'home' && me && Array.isArray(baseCollection.content)
+      slug === 'home' && Array.isArray(baseCollection.content)
         ? {
             ...baseCollection,
             content: [
               ...baseCollection.content.slice(0, 1),
-              buildMeContentBlock(await getUserPage()),
+              ...(me ? [buildMeContentBlock(await getUserPage())] : []),
+              buildAllCollectionsContentBlock(),
               ...baseCollection.content.slice(1),
             ],
           }

--- a/app/lib/components/CollectionPageWrapper.tsx
+++ b/app/lib/components/CollectionPageWrapper.tsx
@@ -4,7 +4,7 @@ import ClientGalleryGate from '@/app/components/ClientGalleryGate/ClientGalleryG
 import CollectionPage from '@/app/components/ContentCollection/CollectionPage';
 import { LAYOUT } from '@/app/constants';
 import { meServer } from '@/app/lib/api/auth';
-import { getCollectionBySlug } from '@/app/lib/api/collections';
+import { getCollectionBySlug, getScopedAllCollections } from '@/app/lib/api/collections';
 import { listSavedImageIdsServer } from '@/app/lib/api/personal';
 import { listSelectIdsServer } from '@/app/lib/api/selects';
 import { getUserPage } from '@/app/lib/api/user';
@@ -42,8 +42,10 @@ export default async function CollectionPageWrapper({
   }
 
   try {
+    // all-collections is permission-scoped per viewer (session-dependent response), so it
+    // uses the dedicated no-store fetch; every other slug keeps the shared cacheable fetch.
     const [fetched, ssrViewport, me] = await Promise.all([
-      getCollectionBySlug(slug, 0, 500),
+      slug === 'all-collections' ? getScopedAllCollections() : getCollectionBySlug(slug, 0, 500),
       resolveSsrViewport(),
       meServer(),
     ]);

--- a/app/utils/allCollectionsContentBlock.ts
+++ b/app/utils/allCollectionsContentBlock.ts
@@ -1,0 +1,37 @@
+import { type ContentParallaxImageModel } from '@/app/types/Content';
+import { clampParallaxDimensions } from '@/app/utils/contentLayout';
+
+/**
+ * Sentinel id for the synthetic "All Collections" tile. Negative so it never
+ * collides with real content ids; distinct from ME_TILE_ID (-1000) and the -1/-2
+ * header-row ids used by contentLayout.ts.
+ */
+export const ALL_COLLECTIONS_TILE_ID = -1001;
+
+/**
+ * Build the synthetic "All Collections" tile injected into the home grid right
+ * after the Me tile (or as the second tile for anonymous viewers). Links to
+ * /all-collections, which the backend permission-scopes per viewer. Empty
+ * imageUrl -> the renderer's placeholder card. Mirrors buildMeContentBlock.
+ */
+export function buildAllCollectionsContentBlock(): ContentParallaxImageModel {
+  const { imageWidth, imageHeight } = clampParallaxDimensions();
+  return {
+    contentType: 'IMAGE',
+    enableParallax: true,
+    id: ALL_COLLECTIONS_TILE_ID,
+    title: 'All Collections',
+    slug: 'all-collections',
+    description: null,
+    imageUrl: '',
+    overlayText: 'All Collections',
+    alt: 'Browse all collections',
+    imageWidth,
+    imageHeight,
+    width: imageWidth,
+    height: imageHeight,
+    orderIndex: 1,
+    visible: true,
+    locations: [],
+  };
+}

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -822,12 +822,54 @@ export function hasAnyActiveFilter(filterState: FilterState): boolean {
 }
 
 /**
+ * Whether a COLLECTION-ref block satisfies the collection-applicable criteria.
+ *
+ * A collection tile carries only the dimensions the backend aggregates onto it
+ * (tags/people/locations) plus its own rating — it has no camera/lens/film/date
+ * of its own. Image-only criteria are therefore NOT applied here (they never
+ * hide a collection tile), so toggling e.g. a film filter on a mixed page leaves
+ * collection tiles in place. On a collection-dominant page (e.g. /all-collections)
+ * the toolbar only surfaces the tag/people/location/rating dimensions anyway.
+ *
+ * @param ref - The collection-ref block
+ * @param criteria - Filter criteria (from {@link buildCollectionCriteria})
+ */
+export function collectionRefMatchesCriteria(
+  ref: ContentCollectionModel,
+  criteria: ContentFilterCriteria
+): boolean {
+  if (criteria.minRating !== undefined && (ref.rating ?? 0) < criteria.minRating) {
+    return false;
+  }
+
+  if (criteria.tags && criteria.tags.length > 0) {
+    const tagNames = ref.tags?.map(t => t.name.toLowerCase()) ?? [];
+    const matcher = criteria.tagMatchMode === 'AND' ? 'every' : 'some';
+    if (!criteria.tags[matcher](tag => tagNames.includes(tag.toLowerCase()))) return false;
+  }
+
+  if (criteria.people && criteria.people.length > 0) {
+    const personNames = ref.people?.map(p => p.name.toLowerCase()) ?? [];
+    const matcher = criteria.peopleMatchMode === 'AND' ? 'every' : 'some';
+    if (!criteria.people[matcher](name => personNames.includes(name.toLowerCase()))) return false;
+  }
+
+  if (criteria.locations && criteria.locations.length > 0) {
+    const locationNames = ref.locations?.map(l => l.name.toLowerCase()) ?? [];
+    if (!criteria.locations.some(loc => locationNames.includes(loc.toLowerCase()))) return false;
+  }
+
+  return true;
+}
+
+/**
  * Apply the collection page's filters to its content.
  *
- * Filters only images by `criteria`, applies the lens-type post-filter (images
- * with an unparseable focalLength are kept so a lens-type chip never silently
- * hides them), then reattaches: non-image content passes through unchanged and
- * images survive only if their id is in the filtered set.
+ * Filters images by `criteria` (plus the lens-type post-filter — images with an
+ * unparseable focalLength are kept so a lens-type chip never silently hides them),
+ * and filters COLLECTION-ref tiles by their own tags/people/locations/rating (see
+ * {@link collectionRefMatchesCriteria}) so tag filtering works on collection-dominant
+ * pages like /all-collections. Any other non-image block passes through unchanged.
  *
  * @param allContent - The full content array (images + non-image blocks)
  * @param allImages - The image subset of `allContent`
@@ -852,8 +894,12 @@ export function applyCollectionFilters(
   }
 
   const filteredImageIds = new Set(filtered.map(img => img.id));
-  // Keep non-image content as-is, only filter images
-  return allContent.filter(item => !isImageContent(item) || filteredImageIds.has(item.id));
+  return allContent.filter(item => {
+    if (isImageContent(item)) return filteredImageIds.has(item.id);
+    if (isCollectionRef(item)) return collectionRefMatchesCriteria(item, criteria);
+    // Other non-image blocks (text, panels) are structural — never filtered out.
+    return true;
+  });
 }
 
 /**

--- a/proxy.ts
+++ b/proxy.ts
@@ -69,8 +69,6 @@ export function proxy(request: NextRequest) {
     pathname.startsWith('/comments/') ||
     pathname === '/metadata' ||
     pathname.startsWith('/metadata/') ||
-    pathname === '/all-collections' ||
-    pathname.startsWith('/all-collections/') ||
     pathname === '/all-images' ||
     pathname.startsWith('/all-images/');
 
@@ -101,6 +99,8 @@ export const config = {
     // so the prod cost is a single env check.
     // /explore is deliberately PUBLIC (taxonomy directory, chapter 001) — do not
     // add it here; 0203 F4 did and login-walled it in prod.
+    // /all-collections is PUBLIC as of 0216 — the backend permission-scopes the
+    // list from the ezac_session, so no route-level gate belongs here either.
     '/',
     '/admin',
     '/admin/:path*',
@@ -113,8 +113,6 @@ export const config = {
     '/comments/:path*',
     '/metadata',
     '/metadata/:path*',
-    '/all-collections',
-    '/all-collections/:path*',
     '/all-images',
     '/all-images/:path*',
   ],

--- a/tests/lib/api/collections.scoped.test.ts
+++ b/tests/lib/api/collections.scoped.test.ts
@@ -1,0 +1,32 @@
+import { getScopedAllCollections } from '@/app/lib/api/collections';
+import * as core from '@/app/lib/api/core';
+
+jest.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+
+jest.mock('@/app/lib/api/core', () => {
+  const actual = jest.requireActual('@/app/lib/api/core');
+  return { ...actual, fetchReadApi: jest.fn() };
+});
+
+const mockFetchReadApi = core.fetchReadApi as jest.MockedFunction<typeof core.fetchReadApi>;
+
+describe('getScopedAllCollections', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches the synthetic all-collections slug with cache: no-store', async () => {
+    mockFetchReadApi.mockResolvedValue({ id: 1, slug: 'all-collections' });
+    await getScopedAllCollections();
+    expect(mockFetchReadApi).toHaveBeenCalledWith('/collections/all-collections?page=0&size=500', {
+      cache: 'no-store',
+    });
+  });
+
+  it('throws notFound when the backend returns null', async () => {
+    mockFetchReadApi.mockResolvedValue(null);
+    await expect(getScopedAllCollections()).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});

--- a/tests/lib/components/CollectionPageWrapper.allCollectionsTile.test.tsx
+++ b/tests/lib/components/CollectionPageWrapper.allCollectionsTile.test.tsx
@@ -1,17 +1,21 @@
-import CollectionPage from '@/app/components/ContentCollection/CollectionPage';
 import * as collectionsApi from '@/app/lib/api/collections';
 import CollectionPageWrapper from '@/app/lib/components/CollectionPageWrapper';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
 import { CollectionVisibility } from '@/app/types/CollectionVisibility';
+import { ALL_COLLECTIONS_TILE_ID } from '@/app/utils/allCollectionsContentBlock';
 import { ME_TILE_ID } from '@/app/utils/meContentBlock';
 
 const mockMeServer = jest.fn();
 const mockGetUserPage = jest.fn();
 
-jest.mock('@/app/lib/api/collections', () => ({ getCollectionBySlug: jest.fn() }));
+jest.mock('@/app/lib/api/collections', () => ({
+  getCollectionBySlug: jest.fn(),
+  getScopedAllCollections: jest.fn(),
+}));
 jest.mock('@/app/lib/api/auth', () => ({ meServer: () => mockMeServer() }));
 jest.mock('@/app/lib/api/user', () => ({ getUserPage: () => mockGetUserPage() }));
 jest.mock('@/app/lib/api/selects', () => ({ listSelectIdsServer: jest.fn(async () => []) }));
+jest.mock('@/app/lib/api/personal', () => ({ listSavedImageIdsServer: jest.fn(async () => []) }));
 jest.mock('next/navigation', () => ({
   notFound: () => {
     throw new Error('NEXT_NOT_FOUND');
@@ -30,6 +34,10 @@ jest.mock('@/app/utils/ssrViewport', () => ({
 const mockGetCollectionBySlug = collectionsApi.getCollectionBySlug as jest.MockedFunction<
   typeof collectionsApi.getCollectionBySlug
 >;
+const mockGetScopedAllCollections =
+  collectionsApi.getScopedAllCollections as jest.MockedFunction<
+    typeof collectionsApi.getScopedAllCollections
+  >;
 
 function homeCollection(overrides: Partial<CollectionModel> = {}): CollectionModel {
   return {
@@ -51,43 +59,12 @@ function homeCollection(overrides: Partial<CollectionModel> = {}): CollectionMod
   };
 }
 
-describe('CollectionPageWrapper — Me tile injection', () => {
+describe('CollectionPageWrapper — All-Collections tile injection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('injects the Me tile at index 1 of home content for a logged-in viewer', async () => {
-    mockMeServer.mockResolvedValue({
-      email: 'a@b.com',
-      isAdmin: false,
-      mfaSatisfied: true,
-      galleries: [],
-    });
-    mockGetUserPage.mockResolvedValue({
-      ...homeCollection(),
-      coverImage: {
-        id: 7,
-        contentType: 'IMAGE',
-        orderIndex: 0,
-        imageUrl: 'https://cdn/x.jpg',
-        imageWidth: 1600,
-        imageHeight: 1000,
-        locations: [],
-      },
-    });
-    mockGetCollectionBySlug.mockResolvedValue(homeCollection());
-
-    const element = await CollectionPageWrapper({ slug: 'home' });
-
-    expect(element.type).toBe(CollectionPage);
-    const content = element.props.collection.content;
-    // 4 = cover + Me tile + All-Collections tile (0216) + remaining home block.
-    expect(content).toHaveLength(4);
-    expect(content[1].id).toBe(ME_TILE_ID);
-    expect(content[1].slug).toBe('user');
-  });
-
-  it('injects a placeholder Me tile when getUserPage() returns null for a logged-in viewer', async () => {
+  it('injects the All-Collections tile at index 2, after the Me tile, for a logged-in viewer', async () => {
     mockMeServer.mockResolvedValue({
       email: 'a@b.com',
       isAdmin: false,
@@ -102,35 +79,39 @@ describe('CollectionPageWrapper — Me tile injection', () => {
     const content = element.props.collection.content;
     expect(content).toHaveLength(4);
     expect(content[1].id).toBe(ME_TILE_ID);
-    expect(content[1].imageUrl).toBe('');
+    expect(content[2].id).toBe(ALL_COLLECTIONS_TILE_ID);
+    expect(content[2].slug).toBe('all-collections');
   });
 
-  it('does NOT inject the Me tile for an anonymous home viewer', async () => {
+  it('injects the All-Collections tile at index 1 for an anonymous viewer (no Me tile)', async () => {
     mockMeServer.mockResolvedValue(null);
     mockGetCollectionBySlug.mockResolvedValue(homeCollection());
 
     const element = await CollectionPageWrapper({ slug: 'home' });
 
     const content = element.props.collection.content;
-    // 3 = cover + All-Collections tile (shown to everyone, 0216) + remaining block.
     expect(content).toHaveLength(3);
+    expect(content[1].id).toBe(ALL_COLLECTIONS_TILE_ID);
     expect(content.some((b: { id: number }) => b.id === ME_TILE_ID)).toBe(false);
-    expect(mockGetUserPage).not.toHaveBeenCalled();
   });
 
-  it('does NOT inject the Me tile on a non-home slug even when logged in', async () => {
-    mockMeServer.mockResolvedValue({
-      email: 'a@b.com',
-      isAdmin: false,
-      mfaSatisfied: true,
-      galleries: [],
-    });
+  it('does NOT inject the tile on non-home slugs', async () => {
+    mockMeServer.mockResolvedValue(null);
     mockGetCollectionBySlug.mockResolvedValue(homeCollection({ slug: 'portfolio' }));
 
     const element = await CollectionPageWrapper({ slug: 'portfolio' });
 
     const content = element.props.collection.content;
-    expect(content.some((b: { id: number }) => b.id === ME_TILE_ID)).toBe(false);
-    expect(mockGetUserPage).not.toHaveBeenCalled();
+    expect(content.some((b: { id: number }) => b.id === ALL_COLLECTIONS_TILE_ID)).toBe(false);
+  });
+
+  it('uses the scoped no-store fetch for the all-collections slug', async () => {
+    mockMeServer.mockResolvedValue(null);
+    mockGetScopedAllCollections.mockResolvedValue(homeCollection({ slug: 'all-collections' }));
+
+    await CollectionPageWrapper({ slug: 'all-collections' });
+
+    expect(mockGetScopedAllCollections).toHaveBeenCalled();
+    expect(mockGetCollectionBySlug).not.toHaveBeenCalled();
   });
 });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -122,8 +122,6 @@ describe('proxy middleware — (admin) group session gate (non-local)', () => {
   const adminRoutes = [
     '/admin',
     '/admin/users/1',
-    '/all-collections',
-    '/all-collections/foo',
     '/all-images',
     '/all-images/foo',
     '/comments',
@@ -151,7 +149,6 @@ describe('proxy middleware — (admin) group passthrough (localhost)', () => {
 
   const adminRoutes = [
     '/admin',
-    '/all-collections',
     '/all-images',
     '/comments',
     '/metadata',
@@ -182,6 +179,16 @@ describe('proxy middleware — public routes stay public (non-local)', () => {
     const res = proxy(makeRequest('/collection/some-slug/edit'));
     expect(res.headers.get('x-middleware-next')).toBe('1');
   });
+
+  // 0216: /all-collections is public + permission-scoped — the backend widens the
+  // list from the ezac_session, so anonymous prod traffic must pass through.
+  it.each(['/all-collections', '/all-collections/foo'])(
+    'passes %s through anonymously in prod (permission-scoped page)',
+    pathname => {
+      const res = proxy(makeRequest(pathname));
+      expect(res.headers.get('x-middleware-next')).toBe('1');
+    }
+  );
 });
 
 describe('proxy middleware — config.matcher', () => {
@@ -189,6 +196,8 @@ describe('proxy middleware — config.matcher', () => {
     expect(config.matcher).not.toContain('/explore');
     expect(config.matcher).not.toContain('/explore/:path*');
     expect(config.matcher).not.toContain('/collection/:slug/edit');
+    expect(config.matcher).not.toContain('/all-collections');
+    expect(config.matcher).not.toContain('/all-collections/:path*');
   });
 
   it('still matches the (admin) group surfaces', () => {
@@ -199,7 +208,6 @@ describe('proxy middleware — config.matcher', () => {
       '/collection/manage/:path*',
       '/comments',
       '/metadata',
-      '/all-collections',
       '/all-images',
     ];
     for (const entry of gated) {

--- a/tests/utils/allCollectionsContentBlock.test.ts
+++ b/tests/utils/allCollectionsContentBlock.test.ts
@@ -1,0 +1,24 @@
+import {
+  ALL_COLLECTIONS_TILE_ID,
+  buildAllCollectionsContentBlock,
+} from '@/app/utils/allCollectionsContentBlock';
+import { ME_TILE_ID } from '@/app/utils/meContentBlock';
+
+describe('buildAllCollectionsContentBlock', () => {
+  it('builds a parallax placeholder tile linking to /all-collections', () => {
+    const tile = buildAllCollectionsContentBlock();
+    expect(tile.contentType).toBe('IMAGE');
+    expect(tile.enableParallax).toBe(true);
+    expect(tile.id).toBe(ALL_COLLECTIONS_TILE_ID);
+    expect(tile.slug).toBe('all-collections');
+    expect(tile.overlayText).toBe('All Collections');
+    expect(tile.imageUrl).toBe('');
+    expect(tile.visible).toBe(true);
+  });
+
+  it('uses a sentinel id distinct from the Me tile and header-row ids', () => {
+    expect(ALL_COLLECTIONS_TILE_ID).toBeLessThan(0);
+    expect(ALL_COLLECTIONS_TILE_ID).not.toBe(ME_TILE_ID);
+    expect([-1, -2]).not.toContain(ALL_COLLECTIONS_TILE_ID);
+  });
+});

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -11,6 +11,7 @@ import {
   buildCollectionCriteria,
   buildLocationCriteria,
   canFilter,
+  collectionRefMatchesCriteria,
   computeFilterCounts,
   computeFilterVisibility,
   type ContentFilterCriteria,
@@ -1272,6 +1273,72 @@ describe('applyCollectionFilters', () => {
     const result = applyCollectionFilters(allContent, images, { minRating: 5 }, ['telephoto']);
     // rating 5 → images 1 & 3; telephoto post-filter keeps image 3 (unparseable) only (image 1 is wide)
     expect(result.map(c => c.id)).toEqual([100, 3]);
+  });
+
+  it('filters COLLECTION-ref tiles by their tags (collection-dominant page)', () => {
+    const italy = makeCollectionRef({
+      id: 2001,
+      tags: [{ id: 1, name: 'Italy', slug: 'italy' }],
+    });
+    const iceland = makeCollectionRef({
+      id: 2002,
+      tags: [{ id: 2, name: 'Iceland', slug: 'iceland' }],
+    });
+    const refs: AnyContentModel[] = [italy, iceland];
+
+    const result = applyCollectionFilters(refs, [], { tags: ['Italy'], tagMatchMode: 'AND' }, []);
+
+    expect(result.map(c => c.id)).toEqual([2001]);
+  });
+
+  it('keeps COLLECTION-ref tiles that carry no matching tag out of the result', () => {
+    const tagged = makeCollectionRef({ id: 3001, tags: [{ id: 1, name: 'Italy', slug: 'italy' }] });
+    const untagged = makeCollectionRef({ id: 3002, tags: [] });
+    const refs: AnyContentModel[] = [tagged, untagged];
+
+    const result = applyCollectionFilters(refs, [], { tags: ['Italy'] }, []);
+
+    expect(result.map(c => c.id)).toEqual([3001]);
+  });
+
+  it('does not drop COLLECTION-ref tiles for image-only criteria (e.g. lens)', () => {
+    const ref = makeCollectionRef({ id: 4001, tags: [{ id: 1, name: 'Italy', slug: 'italy' }] });
+    // A lens criterion is image-only; a collection tile must not be hidden by it.
+    const result = applyCollectionFilters([ref], [], { lenses: ['Nikon 50mm'] }, []);
+
+    expect(result.map(c => c.id)).toEqual([4001]);
+  });
+});
+
+describe('collectionRefMatchesCriteria', () => {
+  it('matches on tags with AND mode (all required)', () => {
+    const ref = makeCollectionRef({
+      tags: [
+        { id: 1, name: 'Italy', slug: 'italy' },
+        { id: 2, name: 'Mountains', slug: 'mountains' },
+      ],
+    });
+    expect(
+      collectionRefMatchesCriteria(ref, { tags: ['Italy', 'Mountains'], tagMatchMode: 'AND' })
+    ).toBe(true);
+    expect(
+      collectionRefMatchesCriteria(ref, { tags: ['Italy', 'Iceland'], tagMatchMode: 'AND' })
+    ).toBe(false);
+  });
+
+  it('matches on tags with OR mode (any)', () => {
+    const ref = makeCollectionRef({ tags: [{ id: 1, name: 'Italy', slug: 'italy' }] });
+    expect(collectionRefMatchesCriteria(ref, { tags: ['Italy', 'Iceland'] })).toBe(true);
+  });
+
+  it('respects minRating', () => {
+    const ref = makeCollectionRef({ rating: 3 });
+    expect(collectionRefMatchesCriteria(ref, { minRating: 4 })).toBe(false);
+    expect(collectionRefMatchesCriteria(ref, { minRating: 3 })).toBe(true);
+  });
+
+  it('returns true when no collection-applicable criteria are set', () => {
+    expect(collectionRefMatchesCriteria(makeCollectionRef(), {})).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
Frontend half of the permission-scoped collections feature (backend: `edens.zac.backend` PR from `0216-collections-filter-api-be`; spec: backend `docs/superpowers/specs/2026-07-15-permission-scoped-collections-design.md`).

- **`/all-collections` is now public**: moved out of the `(admin)` route group and removed from the proxy session gate + matcher. The backend permission-scopes the list from `ezac_session` (admin => all; signed-in => LISTED + granted galleries; anonymous => LISTED). Note: the page drops the admin dark-surface layout — it renders like other public pages now.
- **Dedicated no-store fetch** `getScopedAllCollections()`: per-viewer responses never enter the shared Next data cache; `fetchReadApi` already forwards inbound cookies server-side (incl. through the BFF proxy). The shared ISR-cacheable `getCollectionBySlug` is untouched.
- **Home tile**: every home viewer gets an "All Collections" parallax placeholder tile (sentinel id -1001) — index 2 behind the Me tile when logged in, index 1 anonymous — linking to `/all-collections`.
- (Base commit, pre-existing on branch) client-side tag filtering of collection-ref tiles on collection-dominant pages.

## Testing
- New: scoped-fetch tests (no-store + notFound), tile util tests, wrapper injection tests (logged-in index 2 / anonymous index 1 / non-home untouched / scoped fetch dispatch).
- Updated: proxy tests pin `/all-collections` as public in prod; me-tile tests account for the extra home tile.
- `jest`: **2511 passed**; `tsc --noEmit` clean; eslint clean on changed files; stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)