### PR TITLE
fix(download): navigate for fullscreen image download (S3 302 bypass)

### DIFF
--- a/app/components/ClientGalleryDownload/FullScreenDownloadButton.tsx
+++ b/app/components/ClientGalleryDownload/FullScreenDownloadButton.tsx
@@ -12,68 +12,49 @@ interface FullScreenDownloadButtonProps {
 
 /**
  * Download control for the fullscreen viewer on CLIENT_GALLERY images. Tapping the icon expands a
- * Web / Full quality picker and streams the chosen file via a blob download (auth flows through the
+ * Web / Full quality picker; choosing a format navigates to the download URL (auth flows through the
  * `same-origin` gallery cookie). This is the single-image counterpart to the gallery's "Select →
  * Download" flow — the per-grid-image overlay was removed so a tap on the grid always opens
  * fullscreen.
+ *
+ * Navigation (not `fetch`+blob) is deliberate: the backend redirects (302) to a presigned S3 URL to
+ * bypass the Amplify 5.72 MB response cap, and a `fetch` following that cross-origin redirect would
+ * be blocked by S3 CORS. A top-level navigation follows the redirect and downloads with no such
+ * restriction — the `Content-Disposition: attachment` response downloads without leaving the page.
  */
 export default function FullScreenDownloadButton({ imageId }: FullScreenDownloadButtonProps) {
   const [expanded, setExpanded] = useState(false);
   const [downloading, setDownloading] = useState<DownloadFormat | null>(null);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Collapse the picker whenever the viewer moves to a different image.
   useEffect(() => {
     setExpanded(false);
-    setErrorMsg(null);
   }, [imageId]);
 
   useEffect(() => {
     return () => {
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
     };
   }, []);
 
   const handleToggle = useCallback((e: MouseEvent) => {
     e.stopPropagation();
     setExpanded(prev => !prev);
-    setErrorMsg(null);
   }, []);
 
   const handleFormatDownload = useCallback(
-    async (e: MouseEvent, format: DownloadFormat) => {
+    (e: MouseEvent, format: DownloadFormat) => {
       e.stopPropagation();
       setDownloading(format);
-      setErrorMsg(null);
-
-      let blobUrl: string | null = null;
-      try {
-        const res = await fetch(downloadImageUrl(imageId, format), { credentials: 'include' });
-        if (!res.ok) {
-          const msg =
-            format === 'original' ? 'Original not available for this image' : 'Download failed';
-          setErrorMsg(msg);
-          if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
-          errorTimerRef.current = setTimeout(() => {
-            setErrorMsg(null);
-            errorTimerRef.current = null;
-          }, 3000);
-          return;
-        }
-        const blob = await res.blob();
-        blobUrl = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = blobUrl;
-        a.download = '';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        setExpanded(false);
-      } finally {
-        if (blobUrl) URL.revokeObjectURL(blobUrl);
+      // The response is `Content-Disposition: attachment`, so this downloads without navigating away.
+      window.location.href = downloadImageUrl(imageId, format);
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => {
         setDownloading(null);
-      }
+        setExpanded(false);
+        resetTimerRef.current = null;
+      }, 4000);
     },
     [imageId]
   );
@@ -103,11 +84,6 @@ export default function FullScreenDownloadButton({ imageId }: FullScreenDownload
           >
             {downloading === 'original' ? '…' : 'Full'}
           </button>
-          {errorMsg && (
-            <span role="alert" aria-live="assertive" className={styles.errorLabel}>
-              {errorMsg}
-            </span>
-          )}
         </div>
       ) : (
         <button

--- a/tests/components/FullScreenDownloadButton.test.tsx
+++ b/tests/components/FullScreenDownloadButton.test.tsx
@@ -1,68 +1,32 @@
 /**
- * Tests for FullScreenDownloadButton (renamed from ImageDownloadOverlay).
+ * Tests for FullScreenDownloadButton.
  *
  * Verifies the fullscreen-viewer per-image download flow:
  *  - Click icon → reveals Web/Full picker (stops click bubbling to the viewer).
- *  - Picking a format calls `fetch()` with credentials, builds a blob URL, and
- *    triggers a programmatic `<a download>` click (then revokes the blob URL).
- *  - Failed `original` fetch (404) shows an error that auto-clears after 3s
- *    without throwing, and never creates a blob URL.
+ *  - Picking a format navigates to the download URL (`window.location.href`). Navigation — not
+ *    `fetch`+blob — is required because the backend 302-redirects to a presigned S3 URL to bypass
+ *    the Amplify response-size cap, and a cross-origin `fetch` following that redirect would be
+ *    blocked by S3 CORS.
  *  - The picker collapses when the viewer moves to a different image (imageId change).
- *
- * Ported from the deleted ImageDownloadOverlay.test.tsx; the Esc/outside-click
- * collapse cases were replaced with the new imageId-change collapse behavior.
  */
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import FullScreenDownloadButton from '@/app/components/ClientGalleryDownload/FullScreenDownloadButton';
 import { downloadImageUrl } from '@/app/lib/api/downloads';
 
 describe('FullScreenDownloadButton', () => {
-  const originalCreate = URL.createObjectURL;
-  const originalRevoke = URL.revokeObjectURL;
-  const originalFetch = (global as unknown as { fetch?: typeof fetch }).fetch;
-  let createObjectUrlMock: jest.Mock;
-  let revokeObjectUrlMock: jest.Mock;
+  const originalLocation = window.location;
 
   beforeEach(() => {
-    createObjectUrlMock = jest.fn(() => 'blob:fake-url');
-    revokeObjectUrlMock = jest.fn();
-    (URL as unknown as { createObjectURL: jest.Mock }).createObjectURL = createObjectUrlMock;
-    (URL as unknown as { revokeObjectURL: jest.Mock }).revokeObjectURL = revokeObjectUrlMock;
+    // jsdom's location.href is not assignable; swap in a plain object we can read back.
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: { href: string } }).location = { href: '' };
   });
 
   afterEach(() => {
-    (URL as unknown as { createObjectURL: typeof originalCreate }).createObjectURL = originalCreate;
-    (URL as unknown as { revokeObjectURL: typeof originalRevoke }).revokeObjectURL = originalRevoke;
-    if (originalFetch === undefined) {
-      delete (global as unknown as { fetch?: typeof fetch }).fetch;
-    } else {
-      (global as unknown as { fetch: typeof fetch }).fetch = originalFetch;
-    }
-    jest.restoreAllMocks();
+    (window as unknown as { location: Location }).location = originalLocation;
   });
-
-  const stubFetchOk = (): jest.Mock => {
-    const blob = new Blob(['fake bytes'], { type: 'image/webp' });
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      blob: () => Promise.resolve(blob),
-    } as Response);
-    (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
-    return fetchMock;
-  };
-
-  const stubFetch404 = (): jest.Mock => {
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      blob: () => Promise.resolve(new Blob()),
-    } as Response);
-    (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
-    return fetchMock;
-  };
 
   it('renders a download icon with an accessible label in the idle state', () => {
     render(<FullScreenDownloadButton imageId={42} />);
@@ -77,66 +41,20 @@ describe('FullScreenDownloadButton', () => {
     expect(screen.getByRole('button', { name: /full-size/i })).toBeInTheDocument();
   });
 
-  it('fetches the web URL with credentials when "Web" is picked', async () => {
-    const fetchMock = stubFetchOk();
+  it('navigates to the web download URL when "Web" is picked', () => {
     render(<FullScreenDownloadButton imageId={42} />);
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
     fireEvent.click(screen.getByRole('button', { name: /web-optimized/i }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-    expect(fetchMock).toHaveBeenCalledWith(downloadImageUrl(42, 'web'), {
-      credentials: 'include',
-    });
-    await waitFor(() => expect(createObjectUrlMock).toHaveBeenCalled());
-    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:fake-url');
+    expect(window.location.href).toBe(downloadImageUrl(42, 'web'));
   });
 
-  it('fetches the original URL when "Full Size" is picked', async () => {
-    const fetchMock = stubFetchOk();
+  it('navigates to the original download URL when "Full Size" is picked', () => {
     render(<FullScreenDownloadButton imageId={9001} />);
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
     fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-    expect(fetchMock).toHaveBeenCalledWith(downloadImageUrl(9001, 'original'), {
-      credentials: 'include',
-    });
-  });
-
-  it('shows an error message when "Full Size" fetch returns 404', async () => {
-    stubFetch404();
-    render(<FullScreenDownloadButton imageId={42} />);
-    fireEvent.click(screen.getByRole('button', { name: /download image/i }));
-    fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
-
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent(/original not available/i);
-    // Did not create a blob URL on the failure path.
-    expect(createObjectUrlMock).not.toHaveBeenCalled();
-  });
-
-  it('auto-clears the error after 3 seconds', async () => {
-    jest.useFakeTimers();
-    try {
-      stubFetch404();
-      render(<FullScreenDownloadButton imageId={42} />);
-      fireEvent.click(screen.getByRole('button', { name: /download image/i }));
-      fireEvent.click(screen.getByRole('button', { name: /full-size/i }));
-
-      // Drain the pending fetch + state updates.
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      expect(screen.getByRole('alert')).toBeInTheDocument();
-
-      act(() => {
-        jest.advanceTimersByTime(3000);
-      });
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    } finally {
-      jest.useRealTimers();
-    }
+    expect(window.location.href).toBe(downloadImageUrl(9001, 'original'));
   });
 
   it('stops icon click from bubbling to a parent fullscreen handler', () => {
@@ -156,7 +74,6 @@ describe('FullScreenDownloadButton', () => {
     fireEvent.click(screen.getByRole('button', { name: /download image/i }));
     expect(screen.getByRole('button', { name: /web-optimized/i })).toBeInTheDocument();
 
-    // Navigating to a new image should collapse back to the idle icon.
     rerender(<FullScreenDownloadButton imageId={43} />);
 
     expect(screen.queryByRole('button', { name: /web-optimized/i })).not.toBeInTheDocument();


### PR DESCRIPTION
## Why

Companion to backend themancalledzac/edens.zac.backend#122, which fixes the client-reported `413 Content Too Large` on downloads by 302-redirecting to a presigned S3 URL (bypassing the AWS Amplify 5.72 MB response cap).

The fullscreen single-image download button used `fetch()`+blob with `credentials: 'include'`. Following the backend's 302 to a **cross-origin S3 URL** would be blocked by CORS (and `credentials: 'include'` can't be satisfied by S3 CORS). Left as-is, this backend change would **regress the currently-working web fullscreen download**.

## Change

Switch `FullScreenDownloadButton` from `fetch`+blob to `window.location.href` navigation — exactly what the collection "Select → Download" flow (`ClientGalleryDownload`) already does. A top-level navigation follows the 302 to S3 and downloads via `Content-Disposition: attachment` **without leaving the page** and with no CORS restriction.

- Backward-compatible: navigating to the same proxy URL works with a streaming backend too, so this is safe to deploy first.
- Drops the inline `fetch`-based error state (the rare "no original" case now surfaces as the backend's normal error response, consistent with the ZIP flow).

## Tests

`FullScreenDownloadButton.test.tsx` rewritten to assert navigation to the correct download URL for Web/Full. `tsc` clean, ESLint clean, 6/6 tests pass.

## Deploy order

Deploy this **before** the backend PR to avoid a regression window on the fullscreen web download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)