### PR TITLE
feat(layout): normalize under-filled row width with blank spacers

### DIFF
--- a/app/components/Content/BoxRenderer.module.scss
+++ b/app/components/Content/BoxRenderer.module.scss
@@ -18,6 +18,10 @@
   }
 }
 
+.blankSpacer {
+  flex-shrink: 0;
+}
+
 .missingImage {
   display: flex;
   align-items: center;

--- a/app/components/Content/BoxRenderer.tsx
+++ b/app/components/Content/BoxRenderer.tsx
@@ -4,7 +4,7 @@ import { type ReorderMove } from '@/app/components/ContentCollection/edit/collec
 import type { ViewableContent } from '@/app/types/Content';
 import { type CollectionContentRendererProps } from '@/app/types/ContentRenderer';
 import { determineContentRendererProps } from '@/app/utils/contentRendererUtils';
-import { isPanelContent } from '@/app/utils/contentTypeGuards';
+import { isBlankContent, isPanelContent } from '@/app/utils/contentTypeGuards';
 import { logger } from '@/app/utils/logger';
 import { type BoxTree } from '@/app/utils/rowCombination';
 
@@ -76,6 +76,16 @@ export function BoxRenderer({
         `no size entry for content ID ${tree.content.id} — image will not render`
       );
       return <div className={styles.missingImage}>Image unavailable</div>;
+    }
+
+    if (isBlankContent(tree.content)) {
+      return (
+        <div
+          className={styles.blankSpacer}
+          style={{ width: size.width, height: size.height }}
+          aria-hidden
+        />
+      );
     }
 
     if (isPanelContent(tree.content)) {

--- a/app/components/Content/componentUtils.ts
+++ b/app/components/Content/componentUtils.ts
@@ -13,6 +13,7 @@ import {
   processContentForDisplay,
   type RowWithPatternAndSizes,
 } from '@/app/utils/contentLayout';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
 import { logger } from '@/app/utils/logger';
 import { type BoxTree } from '@/app/utils/rowCombination';
 
@@ -103,6 +104,13 @@ export function buildContentRows(
  * Index of the first row containing content hidden in the current collection (drives the
  * "Non-Visible Content" separator). Returns -1 when there's no such row, or when the only hidden
  * content sits in row 0 with no visible content alongside it.
+ *
+ * Both checks below exclude {@link isBlankContent} items: a BLANK is a synthetic spacer the layout
+ * engine pads under-filled rows with (see `padRowToWidth` in `rowCombination.ts`), never real
+ * content, and must never itself count as "visible" or "hidden" content for this decision. It sets
+ * `visible: true` for an unrelated reason (so it doesn't trip `hasNonVisible` on its own), and that
+ * field alone isn't a signal this function should read as "there is visible content here" — hence
+ * the explicit filter rather than relying on the blank's `visible` value by coincidence.
  */
 export function computeFirstNonVisibleRowIndex(
   rows: RowWithPatternAndSizes[],
@@ -115,13 +123,17 @@ export function computeFirstNonVisibleRowIndex(
     if (!row) continue;
 
     const hasNonVisible = row.items.some(
-      item => !isContentVisibleInCollection(item.content, currentCollectionId)
+      item =>
+        !isBlankContent(item.content) &&
+        !isContentVisibleInCollection(item.content, currentCollectionId)
     );
 
     if (hasNonVisible) {
       if (i > 0) return i;
-      const hasVisible = row.items.some(item =>
-        isContentVisibleInCollection(item.content, currentCollectionId)
+      const hasVisible = row.items.some(
+        item =>
+          !isBlankContent(item.content) &&
+          isContentVisibleInCollection(item.content, currentCollectionId)
       );
       return hasVisible ? i : -1;
     }

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -26,7 +26,7 @@ import type {
 } from './Metadata';
 
 /** Content type discriminator - maps to backend Content contentType field */
-export type ContentType = 'IMAGE' | 'TEXT' | 'GIF' | 'COLLECTION' | 'PANEL';
+export type ContentType = 'IMAGE' | 'TEXT' | 'GIF' | 'COLLECTION' | 'PANEL' | 'BLANK';
 
 /**
  * Base Content interface - all content models extend this
@@ -252,6 +252,24 @@ export interface ContentPanelModel extends Content {
 }
 
 /**
+ * Blank spacer — a client-only synthetic block with no backend counterpart.
+ *
+ * Injected by the layout engine into an under-filled row's BoxTree so the real
+ * items render at their honest proportional share of the row instead of being
+ * scaled up to full width. Carries no media and is inert everywhere except
+ * sizing and rendering: every positive type guard returns false for it.
+ *
+ * `width`/`height` encode the required aspect ratio (`width = blankAR`,
+ * `height = 1`), which `getContentDimensions` picks up via its generic
+ * width/height fallback.
+ */
+export interface ContentBlankModel extends Content {
+  contentType: 'BLANK';
+  width: number;
+  height: number;
+}
+
+/**
  * Union type of all supported content models
  * Use this for type-safe rendering and processing
  */
@@ -261,7 +279,8 @@ export type AnyContentModel =
   | ContentTextModel
   | ContentGifModel
   | ContentCollectionModel
-  | ContentPanelModel;
+  | ContentPanelModel
+  | ContentBlankModel;
 
 /**
  * Content blocks that participate in the click-to-fullscreen viewer: still images, parallax

--- a/app/utils/contentTypeGuards.ts
+++ b/app/utils/contentTypeGuards.ts
@@ -7,6 +7,7 @@
 import { CollectionType } from '@/app/types/Collection';
 import {
   type Content,
+  type ContentBlankModel,
   type ContentCollectionModel,
   type ContentGifModel,
   type ContentImageModel,
@@ -51,6 +52,14 @@ export function isContentCollection(block: Content): block is ContentCollectionM
  */
 export function isPanelContent(block: Content): block is ContentPanelModel {
   return block.contentType === 'PANEL';
+}
+
+/**
+ * Type guard to check if a Content is a ContentBlankModel — the synthetic
+ * spacer injected into under-filled rows. Always false for backend content.
+ */
+export function isBlankContent(block: Content): block is ContentBlankModel {
+  return block.contentType === 'BLANK';
 }
 
 /**

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -19,7 +19,7 @@
  */
 
 import { EXTREMENESS_RAMP_START } from '@/app/constants';
-import type { AnyContentModel } from '@/app/types/Content';
+import type { AnyContentModel, ContentBlankModel } from '@/app/types/Content';
 import {
   getArExtremeness,
   getEffectiveRating,
@@ -264,6 +264,86 @@ export function isSoloHero(item: AnyContentModel, rowWidth: number): boolean {
   if (rowWidth <= 2) return false;
   if (getArExtremeness(getAspectRatio(item)) < EXTREMENESS_RAMP_START) return false;
   return getWidthCost(item) / rowWidth >= HERO_SOLO_WIDTH_FRACTION;
+}
+
+// =============================================================================
+// BLANK PADDING
+// =============================================================================
+
+/**
+ * Id space for synthetic blank spacers. Blank ids count DOWN from this base
+ * (`BLANK_ID_BASE - rowIndex`), far below any real content id, so they never
+ * collide with backend content in a sizesMap or a React key.
+ */
+export const BLANK_ID_BASE = -1_000_000;
+
+/**
+ * Build a blank spacer leaf with the given aspect ratio.
+ *
+ * The AR is encoded as `width = ar, height = 1` — `getContentDimensions`'
+ * generic width/height fallback reads it straight back, so the blank sizes
+ * through the same path as a real leaf with no special-casing.
+ */
+export function createBlankLeaf(ar: number, id: number): BoxTree {
+  const blank: ContentBlankModel = {
+    id,
+    contentType: 'BLANK',
+    orderIndex: 0,
+    // Must be true: isContentVisibleInCollection treats `visible === false` as
+    // hidden, which would falsely trip the "Non-Visible Content" separator.
+    visible: true,
+    width: ar,
+    height: 1,
+  };
+  return { type: 'leaf', content: blank };
+}
+
+/**
+ * Pad an under-filled row with a single left-aligned blank spacer.
+ *
+ * A row whose real items carry total width-cost `S` inside budget `Wr` is
+ * under-filled when `S / Wr < MIN_FILL_RATIO`. Left as-is, the engine scales
+ * those items up to the full page width — one lonely image becomes a
+ * full-width hero regardless of its rating. Instead we add a blank right
+ * sibling of AR `r · gap / S`, making the combined row AR `r · Wr / S`, so the
+ * real subtree occupies exactly `S / Wr` of the width: its honest share.
+ *
+ * The blank is always a HORIZONTAL sibling, so it renders at the real
+ * subtree's own height and absorbs leftover width only — it never stacks
+ * below an image. The real subtree is nested untouched, so every item keeps
+ * its natural aspect ratio and internal composition.
+ *
+ * Padding is viewport-relative — `rowWidth` is the caller's own budget — so a
+ * higher-rated item, carrying more width-cost, naturally fills more of the row.
+ *
+ * Skipped for a solo hero: an extreme-AR panorama's full-width row is
+ * intentional (see {@link isSoloHero}), not an accident of under-fill.
+ *
+ * @param row - Finalized row (its `components` are real items only)
+ * @param rowWidth - Row width budget for this viewport
+ * @param rowIndex - Row's index, which seeds the blank's deterministic id
+ * @returns The row padded, or unchanged when it is complete or a solo hero
+ */
+export function padRowToWidth(row: RowResult, rowWidth: number, rowIndex: number): RowResult {
+  const S = getTotalCV(row.components);
+  if (S <= 0) return row;
+  if (S / rowWidth >= MIN_FILL_RATIO) return row;
+  if (row.components.length === 1 && isSoloHero(row.components[0]!, rowWidth)) return row;
+
+  const r = calculateBoxTreeAspectRatio(row.boxTree);
+  if (r <= 0) return row;
+
+  const gap = rowWidth - S;
+  const blankAR = (r * gap) / S;
+
+  return {
+    components: row.components,
+    boxTree: {
+      type: 'combined',
+      direction: 'horizontal',
+      children: [row.boxTree, createBlankLeaf(blankAR, BLANK_ID_BASE - rowIndex)],
+    },
+  };
 }
 
 /**
@@ -525,7 +605,7 @@ export function buildRows(
     }
   }
 
-  return rows;
+  return rows.map((row, rowIndex) => padRowToWidth(row, rowWidth, rowIndex));
 }
 
 // =============================================================================

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -271,96 +271,62 @@ export function isSoloHero(item: AnyContentModel, rowWidth: number): boolean {
 // =============================================================================
 
 /**
- * Id space for synthetic blank spacers. Blank ids count DOWN from this base
+ * Base for synthetic blank-spacer ids. Blanks count down from here
  * (`BLANK_ID_BASE - rowIndex`), far below any real content id, so they never
- * collide with backend content in a sizesMap or a React key.
+ * collide in a sizesMap or a React key.
  */
 export const BLANK_ID_BASE = -1_000_000;
 
 /**
- * Build a blank spacer leaf with the given aspect ratio.
- *
- * The AR is encoded as `width = ar, height = 1` — `getContentDimensions`'
- * generic width/height fallback reads it straight back, so the blank sizes
- * through the same path as a real leaf with no special-casing.
+ * Build a blank spacer leaf. The aspect ratio is encoded as width/height so the
+ * blank sizes through the same `getContentDimensions` path as a real leaf.
+ * `visible` must stay true, or `isContentVisibleInCollection` would trip the
+ * "Non-Visible Content" separator.
  */
-function createBlankLeaf(ar: number, id: number): BoxTree {
+function createBlankLeaf(aspectRatio: number, id: number): BoxTree {
   const blank: ContentBlankModel = {
     id,
     contentType: 'BLANK',
     orderIndex: 0,
-    // Must be true: isContentVisibleInCollection treats `visible === false` as
-    // hidden, which would falsely trip the "Non-Visible Content" separator.
     visible: true,
-    width: ar,
+    width: aspectRatio,
     height: 1,
   };
   return { type: 'leaf', content: blank };
 }
 
 /**
- * Pad an under-filled row with a single trailing blank spacer, left-aligning
- * the real content.
+ * Pad an under-filled row with a trailing blank spacer so its real content
+ * keeps its honest share of the width instead of being scaled up to full page
+ * width (one lonely image becoming a full-width hero).
  *
- * A row whose real items carry total width-cost `S` inside budget `Wr` is
- * under-filled when `S / Wr < MIN_FILL_RATIO`. Left as-is, the engine scales
- * those items up to the full page width — one lonely image becomes a
- * full-width hero regardless of its rating. Instead we add a blank right
- * sibling of AR `r · gap / S`, making the combined row AR `r · Wr / S`, so the
- * real subtree takes its honest share of the width rather than all of it.
+ * A row is under-filled when its real width-cost is below MIN_FILL_RATIO of the
+ * budget. We append a horizontal blank sibling sized to absorb the leftover
+ * width; the real subtree is nested untouched, so every item keeps its aspect
+ * ratio. Padding is viewport-relative, so a higher-rated item fills more of the
+ * row. Solo heroes are skipped -- their full-width row is intentional.
  *
- * That share is exactly `S / Wr` only in the gap-free case. Production renders
- * with a real CSS gap (see `contentLayout`'s `effectiveGap`), and because the
- * wrapper is a horizontal node the renderer inserts one gap between the real
- * subtree and the blank — so at rendered width `W` the real share is
- * `(W − gap) / W × S / Wr`, approaching the identity as `W` grows.
- *
- * The blank is always a HORIZONTAL sibling, so it renders at the real
- * subtree's own height and absorbs leftover width only — it never stacks
- * below an image. The real subtree is nested untouched, so every item keeps
- * its natural aspect ratio and internal composition.
- *
- * Padding is viewport-relative — `rowWidth` is the caller's own budget — so a
- * higher-rated item, carrying more width-cost, naturally fills more of the row.
- *
- * Skipped for a solo hero: an extreme-AR panorama's full-width row is
- * intentional (see {@link isSoloHero}), not an accident of under-fill.
- *
- * @param row - Finalized row (its `components` are real items only)
- * @param rowWidth - Row width budget for this viewport
- * @param rowIndex - Row's index, which seeds the blank's deterministic id
- * @returns The row padded, or unchanged when it is complete or a solo hero
+ * Guards return the row unchanged when width-cost is zero/NaN or the row's
+ * aspect ratio is non-positive (degenerate zero-width content).
  */
 function padRowToWidth(row: RowResult, rowWidth: number, rowIndex: number): RowResult {
-  const S = getTotalCV(row.components);
-  // Not a reachable input case — Hv = √(P·AR) is strictly positive (BASE_WEIGHT
-  // >= 1.0, and getAspectRatio clamps to 1.0) — but guards the `r * gap / S`
-  // division below. Written as `!(S > 0)` so NaN is caught too: it would slip
-  // through every comparison guard here and yield a NaN blank AR.
-  if (!(S > 0)) return row;
-  if (S / rowWidth >= MIN_FILL_RATIO) return row;
-  // Mirrors the solo-hero promotion buildRows already applied when emitting this
-  // row: a hero's full-width row is deliberate, so it must not be padded back
-  // down. The two decisions are consistent only by invariant — if you add a gate
-  // to the hero-emission path in buildRows, mirror it here.
+  const realWidthCost = getTotalCV(row.components);
+  if (!(realWidthCost > 0)) return row;
+  if (realWidthCost / rowWidth >= MIN_FILL_RATIO) return row;
   if (row.components.length === 1 && isSoloHero(row.components[0]!, rowWidth)) return row;
 
-  const r = calculateBoxTreeAspectRatio(row.boxTree);
-  // Reachable, despite S > 0 above: calculateBoxTreeAspectRatio reads
-  // getContentDimensions raw, while getWidthCost routes through getAspectRatio's
-  // `width <= 0 → 1.0` clamp. Degenerate content (width: 0) therefore yields
-  // r = 0 with S > 0. Not dead code — leave it in place.
-  if (r <= 0) return row;
+  const realAspectRatio = calculateBoxTreeAspectRatio(row.boxTree);
+  if (realAspectRatio <= 0) return row;
 
-  const gap = rowWidth - S;
-  const blankAR = (r * gap) / S;
+  const leftoverWidth = rowWidth - realWidthCost;
+  const blankAspectRatio = (realAspectRatio * leftoverWidth) / realWidthCost;
 
   return {
     ...row,
     boxTree: {
       type: 'combined',
       direction: 'horizontal',
-      children: [row.boxTree, createBlankLeaf(blankAR, BLANK_ID_BASE - rowIndex)],
+      children: [row.boxTree, createBlankLeaf(blankAspectRatio, BLANK_ID_BASE - rowIndex)],
     },
   };
 }

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -284,7 +284,7 @@ export const BLANK_ID_BASE = -1_000_000;
  * generic width/height fallback reads it straight back, so the blank sizes
  * through the same path as a real leaf with no special-casing.
  */
-export function createBlankLeaf(ar: number, id: number): BoxTree {
+function createBlankLeaf(ar: number, id: number): BoxTree {
   const blank: ContentBlankModel = {
     id,
     contentType: 'BLANK',
@@ -299,14 +299,21 @@ export function createBlankLeaf(ar: number, id: number): BoxTree {
 }
 
 /**
- * Pad an under-filled row with a single left-aligned blank spacer.
+ * Pad an under-filled row with a single trailing blank spacer, left-aligning
+ * the real content.
  *
  * A row whose real items carry total width-cost `S` inside budget `Wr` is
  * under-filled when `S / Wr < MIN_FILL_RATIO`. Left as-is, the engine scales
  * those items up to the full page width — one lonely image becomes a
  * full-width hero regardless of its rating. Instead we add a blank right
  * sibling of AR `r · gap / S`, making the combined row AR `r · Wr / S`, so the
- * real subtree occupies exactly `S / Wr` of the width: its honest share.
+ * real subtree takes its honest share of the width rather than all of it.
+ *
+ * That share is exactly `S / Wr` only in the gap-free case. Production renders
+ * with a real CSS gap (see `contentLayout`'s `effectiveGap`), and because the
+ * wrapper is a horizontal node the renderer inserts one gap between the real
+ * subtree and the blank — so at rendered width `W` the real share is
+ * `(W − gap) / W × S / Wr`, approaching the identity as `W` grows.
  *
  * The blank is always a HORIZONTAL sibling, so it renders at the real
  * subtree's own height and absorbs leftover width only — it never stacks
@@ -324,20 +331,32 @@ export function createBlankLeaf(ar: number, id: number): BoxTree {
  * @param rowIndex - Row's index, which seeds the blank's deterministic id
  * @returns The row padded, or unchanged when it is complete or a solo hero
  */
-export function padRowToWidth(row: RowResult, rowWidth: number, rowIndex: number): RowResult {
+function padRowToWidth(row: RowResult, rowWidth: number, rowIndex: number): RowResult {
   const S = getTotalCV(row.components);
-  if (S <= 0) return row;
+  // Not a reachable input case — Hv = √(P·AR) is strictly positive (BASE_WEIGHT
+  // >= 1.0, and getAspectRatio clamps to 1.0) — but guards the `r * gap / S`
+  // division below. Written as `!(S > 0)` so NaN is caught too: it would slip
+  // through every comparison guard here and yield a NaN blank AR.
+  if (!(S > 0)) return row;
   if (S / rowWidth >= MIN_FILL_RATIO) return row;
+  // Mirrors the solo-hero promotion buildRows already applied when emitting this
+  // row: a hero's full-width row is deliberate, so it must not be padded back
+  // down. The two decisions are consistent only by invariant — if you add a gate
+  // to the hero-emission path in buildRows, mirror it here.
   if (row.components.length === 1 && isSoloHero(row.components[0]!, rowWidth)) return row;
 
   const r = calculateBoxTreeAspectRatio(row.boxTree);
+  // Reachable, despite S > 0 above: calculateBoxTreeAspectRatio reads
+  // getContentDimensions raw, while getWidthCost routes through getAspectRatio's
+  // `width <= 0 → 1.0` clamp. Degenerate content (width: 0) therefore yields
+  // r = 0 with S > 0. Not dead code — leave it in place.
   if (r <= 0) return row;
 
   const gap = rowWidth - S;
   const blankAR = (r * gap) / S;
 
   return {
-    components: row.components,
+    ...row,
     boxTree: {
       type: 'combined',
       direction: 'horizontal',

--- a/tests/components/Content/BoxRenderer.test.tsx
+++ b/tests/components/Content/BoxRenderer.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+
+import { render } from '@testing-library/react';
+
+import { BoxRenderer } from '@/app/components/Content/BoxRenderer';
+import type { ContentBlankModel } from '@/app/types/Content';
+import { createImageContent } from '@/tests/fixtures/contentFixtures';
+
+jest.mock('@/app/components/Content/CollectionContentRenderer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="real-content" />,
+}));
+
+describe('BoxRenderer leaf branches', () => {
+  it('renders a blank leaf as an aria-hidden spacer at the allocated size', () => {
+    const blank: ContentBlankModel = {
+      id: -1,
+      contentType: 'BLANK',
+      orderIndex: 0,
+      width: 320,
+      height: 180,
+    };
+    const sizes = new Map([[blank.id, { width: 320, height: 180 }]]);
+    const { container } = render(
+      <BoxRenderer tree={{ type: 'leaf', content: blank }} sizes={sizes} isMobile={false} />
+    );
+    const spacer = container.firstChild as HTMLElement;
+    expect(spacer).toHaveAttribute('aria-hidden');
+    expect(spacer).toHaveStyle({ width: '320px', height: '180px' });
+  });
+
+  it('still renders a real image leaf normally', () => {
+    const image = createImageContent(1);
+    const sizes = new Map([[image.id, { width: 400, height: 300 }]]);
+    const { container } = render(
+      <BoxRenderer tree={{ type: 'leaf', content: image }} sizes={sizes} isMobile={false} />
+    );
+    expect(container.querySelector('[data-testid="real-content"]')).toBeInTheDocument();
+  });
+});

--- a/tests/components/Content/BoxRenderer.test.tsx
+++ b/tests/components/Content/BoxRenderer.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 
 import { BoxRenderer } from '@/app/components/Content/BoxRenderer';
 import type { ContentBlankModel } from '@/app/types/Content';
+import { BLANK_ID_BASE } from '@/app/utils/rowCombination';
 import { createImageContent } from '@/tests/fixtures/contentFixtures';
 
 jest.mock('@/app/components/Content/CollectionContentRenderer', () => ({
@@ -14,9 +15,10 @@ jest.mock('@/app/components/Content/CollectionContentRenderer', () => ({
 describe('BoxRenderer leaf branches', () => {
   it('renders a blank leaf as an aria-hidden spacer at the allocated size', () => {
     const blank: ContentBlankModel = {
-      id: -1,
+      id: BLANK_ID_BASE,
       contentType: 'BLANK',
       orderIndex: 0,
+      visible: true,
       width: 320,
       height: 180,
     };

--- a/tests/components/Content/componentUtils.test.ts
+++ b/tests/components/Content/componentUtils.test.ts
@@ -12,7 +12,11 @@ import {
   resolveEffectiveViewport,
 } from '@/app/components/Content/componentUtils';
 import { type ViewportDimensions } from '@/app/hooks/useViewport';
-import { type CalculatedContentSize, type RowWithPatternAndSizes } from '@/app/utils/contentLayout';
+import {
+  type CalculatedContentSize,
+  processContentForDisplay,
+  type RowWithPatternAndSizes,
+} from '@/app/utils/contentLayout';
 import { createImageContent, createTextContent } from '@/tests/fixtures/contentFixtures';
 
 const TOL = 64;
@@ -174,6 +178,16 @@ describe('computeFirstNonVisibleRowIndex', () => {
 
   it('returns -1 when everything is visible', () => {
     const rows = [row([sizeItem(1)]), row([sizeItem(2)])];
+    expect(computeFirstNonVisibleRowIndex(rows, 7)).toBe(-1);
+  });
+
+  it('returns -1 for a row-0 hidden solo image padded with a blank spacer', () => {
+    // A single hidden, under-filled image gets a synthetic BLANK spacer appended by
+    // padRowToWidth (rowCombination.ts) so it renders at its honest width instead of
+    // scaling up to full width. The blank sets `visible: true` and flows into
+    // row.items — it must not count as "visible content" in the row-0 tiebreak, or a
+    // row whose only real content is hidden wrongly reports a Non-Visible row 0.
+    const rows = processContentForDisplay([createImageContent(1, { visible: false })], 1200, 4);
     expect(computeFirstNonVisibleRowIndex(rows, 7)).toBe(-1);
   });
 });

--- a/tests/fixtures/boxTreeHelpers.ts
+++ b/tests/fixtures/boxTreeHelpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Test helpers for inspecting buildRows' blank width-padding wrapper.
+ *
+ * An under-filled row (fill < MIN_FILL_RATIO) is wrapped by padRowToWidth as
+ * `H(realSubtree, blankLeaf)` so its items render at their honest width share
+ * rather than being scaled up to the full page width. Both helpers here are the
+ * inspection/inverse side of that one wrapper, so they live together — if the
+ * wrapper shape changes, this is the single place to update.
+ */
+
+import type { ContentBlankModel } from '@/app/types/Content';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
+import type { BoxTree } from '@/app/utils/rowCombination';
+
+/**
+ * Strip the blank width-padding wrapper, returning the real items' subtree.
+ *
+ * The exact inverse of padRowToWidth: it unwraps only when the right child is
+ * genuinely a blank leaf, so a real horizontal pair passes through untouched.
+ * Use it in tests that assert how the REAL items compose — padding leaves that
+ * composition untouched. The wrapper itself is covered by
+ * rowCombination.blankPadding.test.ts.
+ */
+export function realTree(tree: BoxTree): BoxTree {
+  if (tree.type === 'combined') {
+    const right = tree.children[1];
+    if (right.type === 'leaf' && isBlankContent(right.content)) {
+      return tree.children[0];
+    }
+  }
+  return tree;
+}
+
+/** Collect every blank leaf in a BoxTree, in traversal order. */
+export function collectBlanks(tree: BoxTree): ContentBlankModel[] {
+  if (tree.type === 'leaf') {
+    return isBlankContent(tree.content) ? [tree.content] : [];
+  }
+  return [...collectBlanks(tree.children[0]), ...collectBlanks(tree.children[1])];
+}

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -20,6 +20,7 @@ import {
   processContentForDisplay,
   type RowWithPatternAndSizes,
 } from '@/app/utils/contentLayout';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
 import {
   createCollectionContent,
   createCollectionModel,
@@ -1398,8 +1399,13 @@ describe('processContentForDisplay', () => {
         }
       }
 
-      // All input items should appear exactly once across all rows
-      const allIds = result.flatMap(row => row.items.map(item => item.content.id));
+      // All input items should appear exactly once across all rows. Blank
+      // spacers are excluded: buildRows pads under-filled rows with a synthetic
+      // blank leaf, which is layout scaffolding rather than input content.
+      const allIds = result
+        .flatMap(row => row.items)
+        .filter(item => !isBlankContent(item.content))
+        .map(item => item.content.id);
       const inputIds = content.map(c => c.id);
       expect(allIds.sort()).toEqual(inputIds.sort());
     });

--- a/tests/utils/rowCombination.blankPadding.test.ts
+++ b/tests/utils/rowCombination.blankPadding.test.ts
@@ -8,9 +8,9 @@ import { LAYOUT } from '@/app/constants';
 import type { ContentBlankModel } from '@/app/types/Content';
 import { getWidthCost } from '@/app/utils/contentRatingUtils';
 import { isBlankContent } from '@/app/utils/contentTypeGuards';
-import type { BoxTree } from '@/app/utils/rowCombination';
 import { BLANK_ID_BASE, buildRows, MIN_FILL_RATIO } from '@/app/utils/rowCombination';
 import { calculateSizesFromBoxTree } from '@/app/utils/rowStructureAlgorithm';
+import { collectBlanks } from '@/tests/fixtures/boxTreeHelpers';
 import {
   createHorizontalImage,
   createPanorama,
@@ -18,14 +18,6 @@ import {
 } from '@/tests/fixtures/contentFixtures';
 
 const DESKTOP = LAYOUT.desktopSlotWidth; // 8
-
-/** Collect every blank leaf in a BoxTree, in traversal order. */
-function collectBlanks(tree: BoxTree): ContentBlankModel[] {
-  if (tree.type === 'leaf') {
-    return isBlankContent(tree.content) ? [tree.content] : [];
-  }
-  return [...collectBlanks(tree.children[0]), ...collectBlanks(tree.children[1])];
-}
 
 describe('isBlankContent', () => {
   it('returns true for a BLANK block', () => {
@@ -80,6 +72,24 @@ describe('buildRows blank padding', () => {
     const expectedShare = getWidthCost(item) / DESKTOP; // 1.3333 / 8 = 0.1667
     expect(realWidth / 1000).toBeCloseTo(expectedShare, 5);
     expect(expectedShare).toBeCloseTo(0.1667, 3);
+  });
+
+  it('renders the real item at its gap-adjusted share at the production gap', () => {
+    // The gap=0 test above pins the pure padding math; this pins what a user
+    // actually sees. The wrapper is a horizontal node, so the renderer inserts
+    // one gridGap between the real subtree and the blank, and the real share
+    // becomes (W - gap) / W * S/Wr rather than the exact S/Wr identity.
+    const item = createHorizontalImage(1, 0);
+    const rows = buildRows([item], DESKTOP);
+
+    const W = 1000;
+    const sizes = calculateSizesFromBoxTree(rows[0]!.boxTree, W, LAYOUT.gridGap, DESKTOP);
+    const realWidth = sizes.find(s => s.content.id === 1)!.width;
+
+    const expectedShare = ((W - LAYOUT.gridGap) / W) * (getWidthCost(item) / DESKTOP);
+    expect(realWidth / W).toBeCloseTo(expectedShare, 5);
+    // Still nowhere near the full-width hero the unpadded engine produced.
+    expect(realWidth / W).toBeLessThan(0.17);
   });
 
   it('keeps the row height equal to the real item height (blank never stacks below)', () => {

--- a/tests/utils/rowCombination.blankPadding.test.ts
+++ b/tests/utils/rowCombination.blankPadding.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit tests for blank-spacer row-width normalization.
+ * Covers the BLANK content type, its guard, and padRowToWidth's math,
+ * threshold, solo-hero skip, and id determinism.
+ */
+
+import type { ContentBlankModel } from '@/app/types/Content';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
+import { createHorizontalImage } from '@/tests/fixtures/contentFixtures';
+
+describe('isBlankContent', () => {
+  it('returns true for a BLANK block', () => {
+    const blank: ContentBlankModel = {
+      id: -1_000_000,
+      contentType: 'BLANK',
+      orderIndex: 0,
+      visible: true,
+      width: 8.8889,
+      height: 1,
+    };
+    expect(isBlankContent(blank)).toBe(true);
+  });
+
+  it('returns false for a real image', () => {
+    expect(isBlankContent(createHorizontalImage(1, 3))).toBe(false);
+  });
+});

--- a/tests/utils/rowCombination.blankPadding.test.ts
+++ b/tests/utils/rowCombination.blankPadding.test.ts
@@ -4,14 +4,33 @@
  * threshold, solo-hero skip, and id determinism.
  */
 
+import { LAYOUT } from '@/app/constants';
 import type { ContentBlankModel } from '@/app/types/Content';
+import { getWidthCost } from '@/app/utils/contentRatingUtils';
 import { isBlankContent } from '@/app/utils/contentTypeGuards';
-import { createHorizontalImage } from '@/tests/fixtures/contentFixtures';
+import type { BoxTree } from '@/app/utils/rowCombination';
+import { BLANK_ID_BASE, buildRows, MIN_FILL_RATIO } from '@/app/utils/rowCombination';
+import { calculateSizesFromBoxTree } from '@/app/utils/rowStructureAlgorithm';
+import {
+  createHorizontalImage,
+  createPanorama,
+  createVerticalImage,
+} from '@/tests/fixtures/contentFixtures';
+
+const DESKTOP = LAYOUT.desktopSlotWidth; // 8
+
+/** Collect every blank leaf in a BoxTree, in traversal order. */
+function collectBlanks(tree: BoxTree): ContentBlankModel[] {
+  if (tree.type === 'leaf') {
+    return isBlankContent(tree.content) ? [tree.content] : [];
+  }
+  return [...collectBlanks(tree.children[0]), ...collectBlanks(tree.children[1])];
+}
 
 describe('isBlankContent', () => {
   it('returns true for a BLANK block', () => {
     const blank: ContentBlankModel = {
-      id: -1_000_000,
+      id: BLANK_ID_BASE,
       contentType: 'BLANK',
       orderIndex: 0,
       visible: true,
@@ -23,5 +42,129 @@ describe('isBlankContent', () => {
 
   it('returns false for a real image', () => {
     expect(isBlankContent(createHorizontalImage(1, 3))).toBe(false);
+  });
+});
+
+describe('buildRows blank padding', () => {
+  it('pads an under-filled single-item row with one blank right sibling', () => {
+    const rows = buildRows([createHorizontalImage(1, 0)], DESKTOP);
+
+    expect(rows).toHaveLength(1);
+    const tree = rows[0]!.boxTree;
+    expect(tree.type).toBe('combined');
+    if (tree.type !== 'combined') throw new Error('expected combined');
+    expect(tree.direction).toBe('horizontal');
+    expect(tree.children[0].type).toBe('leaf');
+
+    const right = tree.children[1];
+    expect(right.type).toBe('leaf');
+    if (right.type !== 'leaf') throw new Error('expected leaf');
+    expect(isBlankContent(right.content)).toBe(true);
+  });
+
+  it('keeps row.components real-only — the blank lives in boxTree alone', () => {
+    const rows = buildRows([createHorizontalImage(1, 0)], DESKTOP);
+
+    expect(rows[0]!.components).toHaveLength(1);
+    expect(rows[0]!.components[0]!.id).toBe(1);
+  });
+
+  it('renders the real item at its natural proportional share S/rowWidth', () => {
+    const item = createHorizontalImage(1, 0);
+    const rows = buildRows([item], DESKTOP);
+
+    // gap=0 isolates the padding math from CSS gap subtraction
+    const sizes = calculateSizesFromBoxTree(rows[0]!.boxTree, 1000, 0, DESKTOP);
+    const realWidth = sizes.find(s => s.content.id === 1)!.width;
+
+    const expectedShare = getWidthCost(item) / DESKTOP; // 1.3333 / 8 = 0.1667
+    expect(realWidth / 1000).toBeCloseTo(expectedShare, 5);
+    expect(expectedShare).toBeCloseTo(0.1667, 3);
+  });
+
+  it('keeps the row height equal to the real item height (blank never stacks below)', () => {
+    const item = createHorizontalImage(1, 0);
+    const rows = buildRows([item], DESKTOP);
+
+    const sizes = calculateSizesFromBoxTree(rows[0]!.boxTree, 1000, 0, DESKTOP);
+    const real = sizes.find(s => s.content.id === 1)!;
+    const blank = sizes.find(s => isBlankContent(s.content))!;
+
+    // Horizontal siblings render at equal heights — the blank takes the
+    // image's height rather than adding empty space below it.
+    expect(blank.height).toBeCloseTo(real.height, 5);
+    // And the image keeps its natural AR — never cropped or distorted.
+    expect(real.width / real.height).toBeCloseTo(1920 / 1080, 5);
+  });
+
+  it('gives the blank an aspect ratio of r * gap / S', () => {
+    const item = createHorizontalImage(1, 0);
+    const rows = buildRows([item], DESKTOP);
+
+    const tree = rows[0]!.boxTree;
+    if (tree.type !== 'combined') throw new Error('expected combined');
+    const right = tree.children[1];
+    if (right.type !== 'leaf') throw new Error('expected leaf');
+    const blank = right.content as ContentBlankModel;
+
+    const r = 1920 / 1080;
+    const S = getWidthCost(item);
+    const expectedBlankAR = (r * (DESKTOP - S)) / S; // 8.8889
+    expect(blank.width / blank.height).toBeCloseTo(expectedBlankAR, 4);
+  });
+
+  it('does not pad a complete row', () => {
+    // Four 3-star horizontals: Hv 2.1082 each, total 8.43, fill 1.054 — complete
+    const items = [1, 2, 3, 4].map(id => createHorizontalImage(id, 3));
+    const rows = buildRows(items, DESKTOP);
+
+    const totalHv = items.reduce((sum, i) => sum + getWidthCost(i), 0);
+    expect(totalHv / DESKTOP).toBeGreaterThanOrEqual(MIN_FILL_RATIO);
+
+    const blanks = collectBlanks(rows[0]!.boxTree);
+    expect(blanks).toHaveLength(0);
+  });
+
+  it('does not pad a solo-hero row (extreme-AR panorama keeps full width)', () => {
+    const rows = buildRows([createPanorama(1, 5)], DESKTOP);
+
+    // Hv 5.4772 / 8 = 0.685 — under-filled, but solo-hero must stay full-width
+    expect(getWidthCost(createPanorama(1, 5)) / DESKTOP).toBeLessThan(MIN_FILL_RATIO);
+    expect(rows[0]!.boxTree.type).toBe('leaf');
+  });
+
+  it('assigns deterministic, unique, stable blank ids across rows', () => {
+    // Greedy fill normally strands only the LAST row, so to get two padded rows
+    // we need MAX_ROW_IMAGES to close rows early: 24 0-star verticals (Hv 0.75)
+    // at a high-density rowWidth 16 pack 12 per row — S 9.0, fill 0.563 — so
+    // both rows close at the item cap while still under-filled.
+    const items = Array.from({ length: 24 }, (_, i) => createVerticalImage(i + 1, 0));
+    const first = buildRows(items, 16).flatMap(r => collectBlanks(r.boxTree));
+    const second = buildRows(items, 16).flatMap(r => collectBlanks(r.boxTree));
+
+    // Guard the assertions below are meaningful — uniqueness is vacuous at n<2
+    expect(first.length).toBeGreaterThanOrEqual(2);
+
+    const ids = first.map(b => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toBeLessThanOrEqual(BLANK_ID_BASE);
+    // Same input → same ids → stable React keys across renders
+    expect(second.map(b => b.id)).toEqual(ids);
+  });
+
+  it('pads a multi-item under-filled row without touching its internal composition', () => {
+    // Two 0-star horizontals: total Hv 2.667, fill 0.333 — under-filled
+    const items = [createHorizontalImage(1, 0), createHorizontalImage(2, 0)];
+    const rows = buildRows(items, DESKTOP);
+
+    const blanks = collectBlanks(rows[0]!.boxTree);
+    expect(blanks).toHaveLength(1);
+
+    const sizes = calculateSizesFromBoxTree(rows[0]!.boxTree, 1000, 0, DESKTOP);
+    const realTotal = sizes
+      .filter(s => !isBlankContent(s.content))
+      .reduce((sum, s) => sum + s.width, 0);
+    const expectedShare = items.reduce((sum, i) => sum + getWidthCost(i), 0) / DESKTOP;
+    expect(realTotal / 1000).toBeCloseTo(expectedShare, 5);
   });
 });

--- a/tests/utils/rowCombination.characterization.test.ts
+++ b/tests/utils/rowCombination.characterization.test.ts
@@ -10,11 +10,10 @@
  *
  * Rows that under-fill their width budget are padded by buildRows with a blank
  * spacer (see {@link realTree}); these tests characterize the composition of the
- * real items, so they unwrap it.
+ * real items, so they unwrap it. Test 24 characterizes the wrapper itself.
  */
 
 import { LAYOUT } from '@/app/constants';
-import { isBlankContent } from '@/app/utils/contentTypeGuards';
 import {
   acToBoxTree,
   type BoxTree,
@@ -27,31 +26,12 @@ import {
   toImageType,
   vStack,
 } from '@/app/utils/rowCombination';
+import { realTree } from '@/tests/fixtures/boxTreeHelpers';
 import { H, V } from '@/tests/fixtures/contentFixtures';
 
 // ===================== Helpers =====================
 
 const DESKTOP = LAYOUT.desktopSlotWidth; // 8
-
-/**
- * Strip buildRows' blank width-padding wrapper, returning the real items' subtree.
- *
- * An under-filled row (fill < MIN_FILL_RATIO) is wrapped as
- * `H(realSubtree, blankLeaf)` so its items render at their honest width share
- * rather than being scaled up to full page width. The wrapper is characterized
- * on its own below ("blank width-padding wrapper") and covered in depth by
- * rowCombination.blankPadding.test.ts; every other test here is about how the
- * REAL items compose, which padding leaves untouched.
- */
-function realTree(tree: BoxTree): BoxTree {
-  if (tree.type === 'combined') {
-    const right = tree.children[1];
-    if (right.type === 'leaf' && isBlankContent(right.content)) {
-      return tree.children[0];
-    }
-  }
-  return tree;
-}
 
 /** Extract the item IDs from a row's components, preserving order */
 function rowIds(row: RowResult): number[] {
@@ -482,24 +462,15 @@ describe('buildRows characterization', () => {
   });
 
   // ---------------------------------------------------------------
-  // Test 24: blank width-padding wrapper — characterizes the padding that
-  // every test above unwraps via realTree(). A single H5★ carries Hv 2.98,
-  // only 37% of the rw=8 budget, so buildRows wraps it rather than letting
-  // calculateSizesFromBoxTree stretch it to the full page width.
+  // Test 24: blank width-padding wrapper — the raw shape every test above
+  // hides behind realTree(). A single H5★ carries Hv 2.98, only 37% of the
+  // rw=8 budget, so buildRows wraps it with a trailing blank rather than
+  // letting calculateSizesFromBoxTree stretch it to the full page width.
   // ---------------------------------------------------------------
   it('24: under-filled row → real subtree wrapped with a blank right sibling', () => {
     const rows = buildRows([H(1, 5)], DESKTOP);
 
-    const tree = rows[0]!.boxTree;
-    expect(tree.type).toBe('combined');
-    if (tree.type !== 'combined') throw new Error('expected combined');
-    expect(tree.direction).toBe('horizontal');
-    expect(boxTreeShape(tree.children[0])).toBe('L(1)');
-
-    const right = tree.children[1];
-    expect(right.type).toBe('leaf');
-    if (right.type !== 'leaf') throw new Error('expected leaf');
-    expect(isBlankContent(right.content)).toBe(true);
+    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(-1000000))');
     // components stay real-only — the blank exists only in the boxTree
     expect(rowIds(rows[0]!)).toEqual([1]);
   });

--- a/tests/utils/rowCombination.characterization.test.ts
+++ b/tests/utils/rowCombination.characterization.test.ts
@@ -7,9 +7,14 @@
  * - Number of rows returned
  * - components array per row (which items, in what order)
  * - boxTree structure per row (full tree shape)
+ *
+ * Rows that under-fill their width budget are padded by buildRows with a blank
+ * spacer (see {@link realTree}); these tests characterize the composition of the
+ * real items, so they unwrap it.
  */
 
 import { LAYOUT } from '@/app/constants';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
 import {
   acToBoxTree,
   type BoxTree,
@@ -27,6 +32,26 @@ import { H, V } from '@/tests/fixtures/contentFixtures';
 // ===================== Helpers =====================
 
 const DESKTOP = LAYOUT.desktopSlotWidth; // 8
+
+/**
+ * Strip buildRows' blank width-padding wrapper, returning the real items' subtree.
+ *
+ * An under-filled row (fill < MIN_FILL_RATIO) is wrapped as
+ * `H(realSubtree, blankLeaf)` so its items render at their honest width share
+ * rather than being scaled up to full page width. The wrapper is characterized
+ * on its own below ("blank width-padding wrapper") and covered in depth by
+ * rowCombination.blankPadding.test.ts; every other test here is about how the
+ * REAL items compose, which padding leaves untouched.
+ */
+function realTree(tree: BoxTree): BoxTree {
+  if (tree.type === 'combined') {
+    const right = tree.children[1];
+    if (right.type === 'leaf' && isBlankContent(right.content)) {
+      return tree.children[0];
+    }
+  }
+  return tree;
+}
 
 /** Extract the item IDs from a row's components, preserving order */
 function rowIds(row: RowResult): number[] {
@@ -62,8 +87,8 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1]);
-    expect(rows[0]!.boxTree.type).toBe('leaf');
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('L(1)');
+    expect(realTree(rows[0]!.boxTree).type).toBe('leaf');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('L(1)');
   });
 
   // ---------------------------------------------------------------
@@ -77,7 +102,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(2))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),L(2))');
   });
 
   // ---------------------------------------------------------------
@@ -91,7 +116,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(2))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),L(2))');
   });
 
   // ---------------------------------------------------------------
@@ -104,7 +129,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(2))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),L(2))');
   });
 
   // ---------------------------------------------------------------
@@ -123,7 +148,7 @@ describe('buildRows characterization', () => {
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
     // main | H(V1, V1) — the two equal V1★ paired side by side (equal area)
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),H(L(2),L(3)))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),H(L(2),L(3)))');
   });
 
   // ---------------------------------------------------------------
@@ -136,7 +161,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(2))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),L(2))');
   });
 
   // ---------------------------------------------------------------
@@ -187,7 +212,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),V(L(2),H(L(3),L(4))))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),V(L(2),H(L(3),L(4))))');
   });
 
   // ---------------------------------------------------------------
@@ -206,7 +231,7 @@ describe('buildRows characterization', () => {
     // All 3 in one row → H(leaf-V1, H(V2, H5)) — the 5★ horizontal is the biggest
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),H(L(2),L(3)))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),H(L(2),L(3)))');
   });
 
   // ---------------------------------------------------------------
@@ -224,7 +249,7 @@ describe('buildRows characterization', () => {
 
     // Builds: H( V3★, H( V1★, V(V1★,V1★) ) ) — the top-rated V3★ takes the left
     // slot as a single leaf; the three V1★ nest on the right.
-    const tree = rows[0]!.boxTree;
+    const tree = realTree(rows[0]!.boxTree);
     expect(tree.type).toBe('combined');
     if (tree.type === 'combined') {
       expect(tree.direction).toBe('horizontal');
@@ -298,7 +323,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1]);
-    expect(rows[0]!.boxTree.type).toBe('leaf');
+    expect(realTree(rows[0]!.boxTree).type).toBe('leaf');
   });
 
   // ---------------------------------------------------------------
@@ -353,7 +378,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3, 4]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),V(L(2),V(L(3),L(4))))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),V(L(2),V(L(3),L(4))))');
   });
 
   // ---------------------------------------------------------------
@@ -365,7 +390,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),L(2))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),L(2))');
   });
 
   // ---------------------------------------------------------------
@@ -377,7 +402,7 @@ describe('buildRows characterization', () => {
 
     expect(rows).toHaveLength(1);
     expect(rowIds(rows[0]!)).toEqual([1, 2, 3]);
-    expect(boxTreeShape(rows[0]!.boxTree)).toBe('H(L(1),V(L(2),L(3)))');
+    expect(boxTreeShape(realTree(rows[0]!.boxTree))).toBe('H(L(1),V(L(2),L(3)))');
   });
 
   // ---------------------------------------------------------------
@@ -449,11 +474,34 @@ describe('buildRows characterization', () => {
 
     for (const row of rows) {
       const componentIds = rowIds(row);
-      const leafIds = boxTreeLeafIds(row.boxTree);
+      const leafIds = boxTreeLeafIds(realTree(row.boxTree));
       // BoxTree leaves should contain exactly the same items as components
       // (order may differ for a 2×2 nested shape, but content should match)
       expect(leafIds.sort((a, b) => a - b)).toEqual(componentIds.sort((a, b) => a - b));
     }
+  });
+
+  // ---------------------------------------------------------------
+  // Test 24: blank width-padding wrapper — characterizes the padding that
+  // every test above unwraps via realTree(). A single H5★ carries Hv 2.98,
+  // only 37% of the rw=8 budget, so buildRows wraps it rather than letting
+  // calculateSizesFromBoxTree stretch it to the full page width.
+  // ---------------------------------------------------------------
+  it('24: under-filled row → real subtree wrapped with a blank right sibling', () => {
+    const rows = buildRows([H(1, 5)], DESKTOP);
+
+    const tree = rows[0]!.boxTree;
+    expect(tree.type).toBe('combined');
+    if (tree.type !== 'combined') throw new Error('expected combined');
+    expect(tree.direction).toBe('horizontal');
+    expect(boxTreeShape(tree.children[0])).toBe('L(1)');
+
+    const right = tree.children[1];
+    expect(right.type).toBe('leaf');
+    if (right.type !== 'leaf') throw new Error('expected leaf');
+    expect(isBlankContent(right.content)).toBe(true);
+    // components stay real-only — the blank exists only in the boxTree
+    expect(rowIds(rows[0]!)).toEqual([1]);
   });
 });
 

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -6,8 +6,7 @@
 import { DENSITY_ROW_WIDTH_MULTIPLIER, LAYOUT } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import { getProminence, getWidthCost } from '@/app/utils/contentRatingUtils';
-import { isBlankContent } from '@/app/utils/contentTypeGuards';
-import type { BoxTree, ImageType, RowResult } from '@/app/utils/rowCombination';
+import type { ImageType, RowResult } from '@/app/utils/rowCombination';
 import {
   acToBoxTree,
   buildAtomic,
@@ -28,6 +27,7 @@ import {
   calculateBoxTreeAspectRatio,
   calculateSizesFromBoxTree,
 } from '@/app/utils/rowStructureAlgorithm';
+import { realTree } from '@/tests/fixtures/boxTreeHelpers';
 import {
   createCollectionContent,
   createGifContent,
@@ -42,24 +42,6 @@ import {
 // ===================== Constants =====================
 
 const DESKTOP = LAYOUT.desktopSlotWidth; // 8
-
-/**
- * Strip buildRows' blank width-padding wrapper, returning the real items' subtree.
- *
- * An under-filled row (fill < MIN_FILL_RATIO) is wrapped as
- * `H(realSubtree, blankLeaf)` so its items render at their honest width share.
- * These tests assert how the REAL items compose, which padding leaves untouched;
- * the wrapper itself is covered by rowCombination.blankPadding.test.ts.
- */
-function realTree(tree: BoxTree): BoxTree {
-  if (tree.type === 'combined') {
-    const right = tree.children[1];
-    if (right.type === 'leaf' && isBlankContent(right.content)) {
-      return tree.children[0];
-    }
-  }
-  return tree;
-}
 
 // getOrientation deleted — toImageType handles orientation inline
 

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -6,7 +6,8 @@
 import { DENSITY_ROW_WIDTH_MULTIPLIER, LAYOUT } from '@/app/constants';
 import type { AnyContentModel } from '@/app/types/Content';
 import { getProminence, getWidthCost } from '@/app/utils/contentRatingUtils';
-import type { ImageType, RowResult } from '@/app/utils/rowCombination';
+import { isBlankContent } from '@/app/utils/contentTypeGuards';
+import type { BoxTree, ImageType, RowResult } from '@/app/utils/rowCombination';
 import {
   acToBoxTree,
   buildAtomic,
@@ -41,6 +42,24 @@ import {
 // ===================== Constants =====================
 
 const DESKTOP = LAYOUT.desktopSlotWidth; // 8
+
+/**
+ * Strip buildRows' blank width-padding wrapper, returning the real items' subtree.
+ *
+ * An under-filled row (fill < MIN_FILL_RATIO) is wrapped as
+ * `H(realSubtree, blankLeaf)` so its items render at their honest width share.
+ * These tests assert how the REAL items compose, which padding leaves untouched;
+ * the wrapper itself is covered by rowCombination.blankPadding.test.ts.
+ */
+function realTree(tree: BoxTree): BoxTree {
+  if (tree.type === 'combined') {
+    const right = tree.children[1];
+    if (right.type === 'leaf' && isBlankContent(right.content)) {
+      return tree.children[0];
+    }
+  }
+  return tree;
+}
 
 // getOrientation deleted — toImageType handles orientation inline
 
@@ -675,15 +694,17 @@ describe('buildRows', () => {
   });
 
   describe('boxTree generation', () => {
-    it('should generate a leaf boxTree for hero pattern', () => {
+    it('should generate a single leaf, blank-padded, for a lone H5*', () => {
+      // A normal landscape (AR 1.78) fails isSoloHero's extremeness gate, so it is
+      // NOT a full-width hero: Hv 2.98 fills only 60% of rw=5, and the row is
+      // padded to hold it at that share rather than stretching it to full width.
       const h5 = createHorizontalImage(1, 5);
       const rows = buildRows([h5], 5);
 
       expect(rows).toHaveLength(1);
-      const boxTree = rows[0]?.boxTree;
-      expect(boxTree).toBeDefined();
-      expect(boxTree?.type).toBe('leaf');
-      if (boxTree?.type === 'leaf') {
+      const boxTree = realTree(rows[0]!.boxTree);
+      expect(boxTree.type).toBe('leaf');
+      if (boxTree.type === 'leaf') {
         expect(boxTree.content.id).toBe(h5.id);
       }
     });
@@ -697,9 +718,8 @@ describe('buildRows', () => {
 
       // At rw=8, 3.5+3.5=7.0, fill=87.5% < 90% → best-fit pairs them
       expect(rows).toHaveLength(1);
-      const boxTree = rows[0]?.boxTree;
-      expect(boxTree).toBeDefined();
-      expect(boxTree?.type).toBe('combined');
+      const boxTree = realTree(rows[0]!.boxTree);
+      expect(boxTree.type).toBe('combined');
       if (boxTree?.type === 'combined') {
         expect(boxTree.direction).toBe('horizontal');
         expect(boxTree.children).toHaveLength(2);
@@ -721,10 +741,9 @@ describe('buildRows', () => {
       const rows = buildRows([h4, v3_1, v3_2], DESKTOP);
 
       expect(rows).toHaveLength(1);
-      const boxTree = rows[0]?.boxTree;
-      expect(boxTree).toBeDefined();
-      expect(boxTree?.type).toBe('combined');
-      if (boxTree?.type === 'combined') {
+      const boxTree = realTree(rows[0]!.boxTree);
+      expect(boxTree.type).toBe('combined');
+      if (boxTree.type === 'combined') {
         expect(boxTree.direction).toBe('horizontal');
         // Left child: main image (leaf)
         expect(boxTree.children[0]?.type).toBe('leaf');
@@ -778,10 +797,9 @@ describe('buildRows', () => {
       const rows = buildRows([h3_1, h3_2, h3_3], DESKTOP);
 
       expect(rows).toHaveLength(1);
-      const boxTree = rows[0]?.boxTree;
-      expect(boxTree).toBeDefined();
-      expect(boxTree?.type).toBe('combined');
-      if (boxTree?.type === 'combined') {
+      const boxTree = realTree(rows[0]!.boxTree);
+      expect(boxTree.type).toBe('combined');
+      if (boxTree.type === 'combined') {
         expect(boxTree.direction).toBe('horizontal');
         // Builds: H[ h3_1, V[h3_2, h3_3] ] — leaf on the left, vertical pair right.
         // Left child: leaf (h3_1)


### PR DESCRIPTION
## Summary

Stops under-filled rows from scaling their items up to full page width. When a row's real items carry total width-cost `S` below `MIN_FILL_RATIO` (0.9) of the row budget `Wr`, the layout engine now appends a synthetic blank spacer as a **horizontal** right sibling, so the real items render at their honest proportional share `S/Wr` of the width instead of one lonely low-rated image becoming a full-width hero.

- **`BLANK` content type** — a client-only synthetic `contentType: 'BLANK'` (`ContentBlankModel`) + `isBlankContent` guard. It rides the existing leaf rails: `width`/`height` encode the blank's aspect ratio, read back by `getContentDimensions`' generic fallback, so no new plumbing in the size pipeline.
- **Padding post-pass** — `buildRows` wraps each under-filled row's `BoxTree` as `{combined, horizontal, [realTree, blankLeaf(r × (Wr−S)/S)]}`. Because `calculateSizesFromBoxTree` solves horizontal nodes for equal child heights, the blank takes the real content's height and absorbs only leftover **width** — the row height equals the image's own height, and no image's slot AR is ever distorted (honours the standing no-crop rule). Solo-hero panoramas are skipped and keep their full-width rows.
- **Renderer** — `BoxRenderer` renders a blank leaf as an `aria-hidden`, transparent `.blankSpacer` div at its allocated size.

`row.components` stays real-only (blank lives in `boxTree`/`items` only), so the blank is inert to fullscreen, reorder, download-gating, and content filtering.

## Behavior notes

- **Viewport-relative.** A lone 0★ landscape renders at ~17% width on desktop (`rowWidth 8`) and ~44% on mobile (`rowWidth 3`); a 5★ fills the row and gets no blank. This is the intended "no half-width cap" design.
- A lone small image produces a **short row** — height equal to that image, empty space beside it, never below it.

## Review found a real bug (fixed)

The final cross-cutting review caught a defect the design spec got wrong: `computeFirstNonVisibleRowIndex` (admin "Non-Visible Content" separator). The blank sets `visible: true` to stay out of the "hidden" check — but that made it count as *visible content* in the row-0 tiebreak, so a row 0 whose only real content is hidden returned `0` instead of `-1`, rendering a spurious separator. Fixed by excluding blanks from both checks (`137a4a5`), with a regression test through the real `processContentForDisplay`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite: **162 suites / 2531 tests** pass (baseline was 161/2528; +3 net new tests, 17 pre-existing layout tests updated to expect the padded shape for genuinely under-filled rows — all fills independently recomputed < 0.9)
- [x] Unit coverage at the production CSS gap, not just the gap-free identity
- [ ] **Browser verification NOT done** — could not run: Turbopack rejects the worktree's symlinked `node_modules`, and the Spring Boot backend + PostgreSQL were not running, so no content renders locally. Widths are confirmed by unit tests against the real sizing engine but not by eye on a live page. Recommend a visual pass on `/user` (single-item Collections/Images) and a collection's trailing row before relying on this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Supersedes #215, which GitHub auto-closed when its non-conventional branch name `claude/row-width-normalization-5feddf` was renamed to `0217-row-width-normalization`. Same commits, same content._
