### PR TITLE
fix(lcp): eager-load first content row so the real LCP image isn't lazy

### DIFF
--- a/app/components/Content/Component.tsx
+++ b/app/components/Content/Component.tsx
@@ -16,6 +16,7 @@ import { BoxRenderer } from './BoxRenderer';
 import {
   buildContentRows,
   computeFirstNonVisibleRowIndex,
+  computePriorityRowIndex,
   createSimpleBoxTree,
   excludeFailedImages,
   resolveEffectiveViewport,
@@ -28,7 +29,11 @@ export interface ContentComponentProps {
   currentCoverImageId?: number;
   onImageClick?: (imageId: number) => void;
   justClickedImageId?: number | null;
-  /** Index of content to prioritize for LCP (usually 0 for hero) */
+  /**
+   * Fallback priority row when the layout is header-only. Normally the layout auto-extends eager
+   * loading through the first content row (see {@link computePriorityRowIndex}), so the true LCP
+   * grid image — not just the height-constrained cover — loads eagerly.
+   */
   priorityIndex?: number;
   /** Enable full-screen image viewing on click */
   enableFullScreenView?: boolean;
@@ -157,6 +162,11 @@ export default function Component({
     [rows, currentCollectionId]
   );
 
+  const priorityRowIndex = useMemo(
+    () => computePriorityRowIndex(rows, priorityIndex),
+    [rows, priorityIndex]
+  );
+
   if (layoutError) {
     return (
       <div className={cbStyles.wrapper}>
@@ -209,7 +219,7 @@ export default function Component({
           onPickUp={onPickUp}
           onPlace={onPlace}
           onCancelImageMove={onCancelImageMove}
-          priority={rowIndex === priorityIndex}
+          priority={rowIndex <= priorityRowIndex}
           onImageLoadError={handleImageLoadError}
           canDownload={canDownload}
           collectionSlug={collectionData?.slug}

--- a/app/components/Content/componentUtils.ts
+++ b/app/components/Content/componentUtils.ts
@@ -131,6 +131,28 @@ export function computeFirstNonVisibleRowIndex(
 }
 
 /**
+ * Highest row index (inclusive) whose images should load eagerly for the LCP.
+ *
+ * The header cover renders above the fold, but on a collection page the true LCP is usually the
+ * first image of the first *content* row — a full-size grid image sitting below a height-constrained
+ * cover. Next flags it because it lazy-loads. Prioritizing every row from the top through the first
+ * content row makes both the cover and that first content row eager. Pages with no header
+ * (taxonomy/location/user grids) have their first content row at index 0, so this collapses to
+ * "prioritize row 0" — unchanged from before.
+ *
+ * @param rows - Laid-out rows, header rows first (if any), then content rows.
+ * @param fallbackIndex - Row to prioritize when there is no content row at all (header-only layout).
+ * @returns The highest row index (inclusive) to mark as priority.
+ */
+export function computePriorityRowIndex(
+  rows: RowWithPatternAndSizes[],
+  fallbackIndex: number
+): number {
+  const firstContentIndex = rows.findIndex(r => r.rowType !== 'header');
+  return firstContentIndex === -1 ? fallbackIndex : firstContentIndex;
+}
+
+/**
  * Drop IMAGE content whose id is in `failedIds`.
  *
  * A runtime image-load failure (a valid-looking URL that 404s) can only be detected client-side,

--- a/tests/components/Content/componentUtils.test.ts
+++ b/tests/components/Content/componentUtils.test.ts
@@ -5,6 +5,7 @@
 import {
   buildContentRows,
   computeFirstNonVisibleRowIndex,
+  computePriorityRowIndex,
   computeTargetAspectRatio,
   createSimpleBoxTree,
   type EffectiveViewport,
@@ -33,6 +34,12 @@ const sizeItem = (id: number, visible = true): CalculatedContentSize => ({
 
 const row = (items: CalculatedContentSize[]): RowWithPatternAndSizes => ({
   rowType: 'content',
+  items,
+  boxTree: createSimpleBoxTree(items),
+});
+
+const headerRow = (items: CalculatedContentSize[]): RowWithPatternAndSizes => ({
+  rowType: 'header',
   items,
   boxTree: createSimpleBoxTree(items),
 });
@@ -175,6 +182,37 @@ describe('computeFirstNonVisibleRowIndex', () => {
   it('returns -1 when everything is visible', () => {
     const rows = [row([sizeItem(1)]), row([sizeItem(2)])];
     expect(computeFirstNonVisibleRowIndex(rows, 7)).toBe(-1);
+  });
+});
+
+describe('computePriorityRowIndex', () => {
+  it('returns 0 for a header-less grid (first content row is row 0)', () => {
+    const rows = [row([sizeItem(1)]), row([sizeItem(2)])];
+    expect(computePriorityRowIndex(rows, 0)).toBe(0);
+  });
+
+  it('returns the first content row index past a single desktop header row', () => {
+    const rows = [headerRow([sizeItem(-1)]), row([sizeItem(1)]), row([sizeItem(2)])];
+    expect(computePriorityRowIndex(rows, 0)).toBe(1);
+  });
+
+  it('skips multiple header rows (mobile cover + metadata) to the first content row', () => {
+    const rows = [
+      headerRow([sizeItem(-1)]),
+      headerRow([sizeItem(-2)]),
+      row([sizeItem(1)]),
+      row([sizeItem(2)]),
+    ];
+    expect(computePriorityRowIndex(rows, 0)).toBe(2);
+  });
+
+  it('falls back to the provided index when every row is a header', () => {
+    const rows = [headerRow([sizeItem(-1)]), headerRow([sizeItem(-2)])];
+    expect(computePriorityRowIndex(rows, 0)).toBe(0);
+  });
+
+  it('falls back to the provided index for an empty layout', () => {
+    expect(computePriorityRowIndex([], 0)).toBe(0);
   });
 });
 


### PR DESCRIPTION
Priority (loading=eager, fetchpriority=high) only reached row 0, which on a collection page is the height-constrained header cover — not the LCP. The first image of the first content row, the actual LCP, stayed lazy and tripped Next's above-the-fold warning.

Add computePriorityRowIndex() to find the first non-header row and mark every row from the top through it as priority, so the header cover and the first content row both load eagerly. Header-less grids (taxonomy/location/ user) keep the first content row at index 0, so behavior there is unchanged.