### PR TITLE
feat(admin): role-management UI (create/grant/assign) + repoint user …

### DIFF
--- a/app/(admin)/admin/roles/RolesPageClient.tsx
+++ b/app/(admin)/admin/roles/RolesPageClient.tsx
@@ -100,5 +100,3 @@ export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] 
     </div>
   );
 }
-
-export default RolesPageClient;

--- a/app/(admin)/admin/roles/RolesPageClient.tsx
+++ b/app/(admin)/admin/roles/RolesPageClient.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { type FormEvent, useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { Field } from '@/app/components/ui/Field/Field';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { Input } from '@/app/components/ui/Field/Input';
+import { ApiError } from '@/app/lib/api/core';
+import { createRole, listRoles } from '@/app/lib/api/roles';
+import { type RoleKind, type RoleSummary } from '@/app/types/Role';
+
+import styles from './roles.module.scss';
+
+/**
+ * Admin roles list + create form. A user joins roles to inherit their per-collection grants
+ * (managed on each role's detail page). SHARED roles are admin-curated; PERSONAL roles were
+ * auto-created per user by the access migration and are read-mostly.
+ */
+export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] }) {
+  const [roles, setRoles] = useState<RoleSummary[]>(initialRoles);
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<RoleKind>('SHARED');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError('Role name is required.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await createRole({ name: name.trim(), kind });
+      setRoles(await listRoles());
+      setName('');
+    } catch (error_) {
+      setError(
+        error_ instanceof ApiError && error_.status === 409
+          ? 'A role with that name already exists.'
+          : 'Failed to create role. Please try again.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <Link href="/admin" className={styles.back}>
+          &lt;- Admin
+        </Link>
+        <h1 className={styles.title}>Roles</h1>
+      </div>
+
+      <form onSubmit={handleCreate} className={styles.createForm}>
+        <Field label="New role name" htmlFor="role-name">
+          <Input
+            id="role-name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="power"
+            autoComplete="off"
+            disabled={submitting}
+          />
+        </Field>
+        <Field label="Type" htmlFor="role-kind">
+          <select
+            id="role-kind"
+            className={styles.select}
+            value={kind}
+            onChange={e => setKind(e.target.value as RoleKind)}
+            disabled={submitting}
+          >
+            <option value="SHARED">Shared</option>
+            <option value="PERSONAL">Personal</option>
+          </select>
+        </Field>
+        <Button type="submit" loading={submitting}>
+          {submitting ? 'Creating...' : 'Create role'}
+        </Button>
+        {error && <FormError>{error}</FormError>}
+      </form>
+
+      <ul className={styles.roleList}>
+        {roles.length === 0 && <li className={styles.empty}>No roles yet.</li>}
+        {roles.map(r => (
+          <li key={r.id} className={styles.roleRow}>
+            <Link href={`/admin/roles/${r.id}`} className={styles.roleLink}>
+              <span className={styles.roleName}>{r.name}</span>
+              <span className={styles.kindBadge}>{r.kind}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default RolesPageClient;

--- a/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
+++ b/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
@@ -204,5 +204,3 @@ export function RoleDetailClient({ initialRole }: { initialRole: RoleDetail }) {
     </div>
   );
 }
-
-export default RoleDetailClient;

--- a/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
+++ b/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { getAllCollectionsAdmin } from '@/app/lib/api/collections';
+import {
+  addRoleMember,
+  deleteRole,
+  getRole,
+  removeRoleGrant,
+  removeRoleMember,
+  setRoleGrant,
+} from '@/app/lib/api/roles';
+import { listUsers } from '@/app/lib/api/users';
+import { type CollectionModel } from '@/app/types/Collection';
+import { type AccessLevel, type RoleDetail } from '@/app/types/Role';
+import { type AdminUserSummary } from '@/app/types/User';
+
+import styles from '../roles.module.scss';
+
+/**
+ * Role detail editor: a role's members (users who inherit its grants) and its per-collection grants
+ * (GENERAL = view; CLIENT = download/tag/star). Collection and user pickers are loaded client-side;
+ * every mutation re-fetches the role so the view stays authoritative.
+ */
+export function RoleDetailClient({ initialRole }: { initialRole: RoleDetail }) {
+  const router = useRouter();
+  const [role, setRole] = useState<RoleDetail>(initialRole);
+  const [collections, setCollections] = useState<CollectionModel[]>([]);
+  const [users, setUsers] = useState<AdminUserSummary[]>([]);
+  const [addCollectionId, setAddCollectionId] = useState('');
+  const [addLevel, setAddLevel] = useState<AccessLevel>('GENERAL');
+  const [addUserId, setAddUserId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAllCollectionsAdmin()
+      .then(setCollections)
+      .catch(() => setCollections([]));
+    listUsers()
+      .then(setUsers)
+      .catch(() => setUsers([]));
+  }, []);
+
+  async function refresh() {
+    const fresh = await getRole(role.id);
+    if (fresh) setRole(fresh);
+  }
+
+  const grantedIds = new Set(role.collections.map(c => c.collectionId));
+  const memberIds = new Set(role.members.map(m => m.userId));
+  const grantableCollections = collections.filter(
+    c => typeof c.id === 'number' && !grantedIds.has(c.id)
+  );
+  const addableUsers = users.filter(u => u.status !== 'PERSON' && !memberIds.has(u.id));
+
+  async function run(action: () => Promise<void>, failMessage: string) {
+    setError(null);
+    try {
+      await action();
+      await refresh();
+    } catch {
+      setError(failMessage);
+    }
+  }
+
+  const onAddGrant = () =>
+    addCollectionId &&
+    run(
+      () => setRoleGrant(role.id, Number(addCollectionId), addLevel).then(() => setAddCollectionId('')),
+      'Failed to add the collection grant.'
+    );
+
+  const onChangeLevel = (collectionId: number, level: AccessLevel) =>
+    run(() => setRoleGrant(role.id, collectionId, level), 'Failed to change the access level.');
+
+  const onRemoveGrant = (collectionId: number) =>
+    run(() => removeRoleGrant(role.id, collectionId), 'Failed to remove the grant.');
+
+  const onAddMember = () =>
+    addUserId &&
+    run(
+      () => addRoleMember(role.id, Number(addUserId)).then(() => setAddUserId('')),
+      'Failed to add the member.'
+    );
+
+  const onRemoveMember = (userId: number) =>
+    run(() => removeRoleMember(role.id, userId), 'Failed to remove the member.');
+
+  async function onDeleteRole() {
+    if (!window.confirm(`Delete role "${role.name}"? Everyone in it loses that access.`)) return;
+    setError(null);
+    try {
+      await deleteRole(role.id);
+      router.push('/admin/roles');
+    } catch {
+      setError('Failed to delete the role.');
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <Link href="/admin/roles" className={styles.back}>
+          &lt;- Roles
+        </Link>
+        <div className={styles.titleRow}>
+          <h1 className={styles.title}>
+            {role.name} <span className={styles.kindBadge}>{role.kind}</span>
+          </h1>
+          <Button variant="danger" size="sm" onClick={onDeleteRole}>
+            Delete role
+          </Button>
+        </div>
+      </div>
+
+      {error && <FormError>{error}</FormError>}
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionHeading}>Collections</h2>
+        {role.collections.length === 0 && (
+          <p className={styles.empty}>No collections granted yet.</p>
+        )}
+        {role.collections.map(c => (
+          <div key={c.collectionId} className={styles.row}>
+            <span className={styles.rowName}>{c.title}</span>
+            <select
+              className={styles.select}
+              value={c.level}
+              onChange={e => onChangeLevel(c.collectionId, e.target.value as AccessLevel)}
+            >
+              <option value="GENERAL">General (view)</option>
+              <option value="CLIENT">Client (download/tag/star)</option>
+            </select>
+            <Button variant="ghost" size="sm" onClick={() => onRemoveGrant(c.collectionId)}>
+              Remove
+            </Button>
+          </div>
+        ))}
+        {grantableCollections.length > 0 && (
+          <div className={styles.addRow}>
+            <select
+              className={`${styles.select} ${styles.grow}`}
+              value={addCollectionId}
+              onChange={e => setAddCollectionId(e.target.value)}
+            >
+              <option value="">Add a collection...</option>
+              {grantableCollections.map(c => (
+                <option key={c.id} value={c.id}>
+                  {c.title}
+                </option>
+              ))}
+            </select>
+            <select
+              className={styles.select}
+              value={addLevel}
+              onChange={e => setAddLevel(e.target.value as AccessLevel)}
+            >
+              <option value="GENERAL">General</option>
+              <option value="CLIENT">Client</option>
+            </select>
+            <Button variant="ghost" size="sm" onClick={onAddGrant} disabled={!addCollectionId}>
+              Add
+            </Button>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionHeading}>Members</h2>
+        {role.members.length === 0 && <p className={styles.empty}>No members yet.</p>}
+        {role.members.map(m => (
+          <div key={m.userId} className={styles.row}>
+            <span className={styles.rowName}>{m.email ?? m.name ?? `User #${m.userId}`}</span>
+            <Button variant="ghost" size="sm" onClick={() => onRemoveMember(m.userId)}>
+              Remove
+            </Button>
+          </div>
+        ))}
+        {addableUsers.length > 0 && (
+          <div className={styles.addRow}>
+            <select
+              className={`${styles.select} ${styles.grow}`}
+              value={addUserId}
+              onChange={e => setAddUserId(e.target.value)}
+            >
+              <option value="">Add a member...</option>
+              {addableUsers.map(u => (
+                <option key={u.id} value={u.id}>
+                  {u.email ?? u.displayName ?? `User #${u.id}`}
+                </option>
+              ))}
+            </select>
+            <Button variant="ghost" size="sm" onClick={onAddMember} disabled={!addUserId}>
+              Add
+            </Button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default RoleDetailClient;

--- a/app/(admin)/admin/roles/[roleId]/page.tsx
+++ b/app/(admin)/admin/roles/[roleId]/page.tsx
@@ -1,0 +1,30 @@
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (gating centralized in app/(admin)/layout.tsx via requireAdmin()).
+import { notFound } from 'next/navigation';
+
+import { PageShell } from '@/app/components/ui/PageShell/PageShell';
+import { getRole } from '@/app/lib/api/roles';
+
+import { RoleDetailClient } from './RoleDetailClient';
+
+export const dynamic = 'force-dynamic';
+
+/** Admin role detail — edit a role's members and its per-collection grants. */
+export default async function AdminRoleDetailPage({
+  params,
+}: {
+  params: Promise<{ roleId: string }>;
+}) {
+  const { roleId } = await params;
+  const id = Number(roleId);
+  if (!Number.isInteger(id)) notFound();
+
+  const role = await getRole(id).catch(() => null);
+  if (!role) notFound();
+
+  return (
+    <PageShell pageType="collectionsCollection">
+      <RoleDetailClient initialRole={role} />
+    </PageShell>
+  );
+}

--- a/app/(admin)/admin/roles/page.tsx
+++ b/app/(admin)/admin/roles/page.tsx
@@ -1,0 +1,18 @@
+// Admin = authenticated admin principal: the backend enforces hasRole('ADMIN') on
+// /api/admin/** (gating centralized in app/(admin)/layout.tsx via requireAdmin()).
+import { PageShell } from '@/app/components/ui/PageShell/PageShell';
+import { listRoles } from '@/app/lib/api/roles';
+
+import { RolesPageClient } from './RolesPageClient';
+
+export const dynamic = 'force-dynamic';
+
+/** Admin roles hub — list every role and create new ones. Grants + members live on the detail page. */
+export default async function AdminRolesPage() {
+  const roles = await listRoles().catch(() => []);
+  return (
+    <PageShell pageType="collectionsCollection">
+      <RolesPageClient initialRoles={roles} />
+    </PageShell>
+  );
+}

--- a/app/(admin)/admin/roles/roles.module.scss
+++ b/app/(admin)/admin/roles/roles.module.scss
@@ -1,0 +1,156 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.back {
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.title {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+}
+
+.createForm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+}
+
+.select {
+  font-family: inherit;
+  font-size: var(--text-sm);
+  height: var(--menu-item-height);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-color: var(--color-fg);
+  }
+}
+
+.roleList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.roleRow {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+}
+
+.roleLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  text-decoration: none;
+  color: var(--color-fg);
+
+  &:hover {
+    background-color: var(--color-bg-subtle, rgb(127, 127, 127, 0.08));
+  }
+}
+
+.roleName {
+  font-weight: 500;
+}
+
+.kindBadge {
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  color: var(--color-fg-muted, var(--color-fg));
+}
+
+.empty {
+  font-size: var(--text-sm);
+  color: var(--color-fg-muted, var(--color-fg));
+  opacity: 0.75;
+}
+
+// ---- detail ----
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+}
+
+.sectionHeading {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.rowName {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.addRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.grow {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}

--- a/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/app/components/MenuDropdown/MenuDropdown.tsx
@@ -118,6 +118,10 @@ export function MenuDropdown({
       router.push('/comments');
       onClose();
     },
+    roles: () => {
+      router.push('/admin/roles');
+      onClose();
+    },
     instagram: () => {
       window.open('https://instagram.com/themancalledzac', '_blank', 'noopener,noreferrer');
       onClose();
@@ -323,6 +327,18 @@ export function MenuDropdown({
               onClick={handleNavigation.comments}
             >
               <span className={styles.dropdownMenuOptions}>Comments</span>
+            </button>
+          </div>
+        )}
+
+        {isAdmin && (
+          <div className={styles.dropdownMenuItem}>
+            <button
+              type="button"
+              className={styles.dropdownMenuButton}
+              onClick={handleNavigation.roles}
+            >
+              <span className={styles.dropdownMenuOptions}>Roles</span>
             </button>
           </div>
         )}

--- a/app/components/UserForm/UserForm.module.scss
+++ b/app/components/UserForm/UserForm.module.scss
@@ -86,3 +86,14 @@
     }
   }
 }
+
+.manageRolesLink {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/components/UserForm/UserForm.tsx
+++ b/app/components/UserForm/UserForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { type FormEvent, useEffect, useState } from 'react';
 
 import { InviteLinkResult } from '@/app/components/InviteLinkResult/InviteLinkResult';
@@ -10,14 +11,13 @@ import { Input } from '@/app/components/ui/Field/Input';
 import { Textarea } from '@/app/components/ui/Field/Textarea';
 import { ApiError } from '@/app/lib/api/core';
 import {
-  type AdminUserCollection,
-  createUser,
-  listUserCollections,
-  removeUserCollection,
-  setUserCollectionRole,
-  updateUser,
-} from '@/app/lib/api/users';
-import { type CollectionRole } from '@/app/types/Auth';
+  addUserToRole,
+  listRoles,
+  listUserRoles,
+  removeUserFromRole,
+} from '@/app/lib/api/roles';
+import { createUser, updateUser } from '@/app/lib/api/users';
+import { type RoleSummary, type UserRoleRow } from '@/app/types/Role';
 import { type AdminUserSummary, type UserStatus } from '@/app/types/User';
 
 import styles from './UserForm.module.scss';
@@ -45,26 +45,42 @@ export function UserForm(props: UserFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
-  const [collections, setCollections] = useState<AdminUserCollection[]>([]);
+  const [userRoles, setUserRoles] = useState<UserRoleRow[]>([]);
+  const [allRoles, setAllRoles] = useState<RoleSummary[]>([]);
+  const [addRoleId, setAddRoleId] = useState<string>('');
   const editUserId = editUser?.id ?? null;
 
   useEffect(() => {
     if (editUserId !== null) {
-      listUserCollections(editUserId)
-        .then(setCollections)
-        .catch(() => setCollections([]));
+      listUserRoles(editUserId)
+        .then(setUserRoles)
+        .catch(() => setUserRoles([]));
+      listRoles()
+        .then(setAllRoles)
+        .catch(() => setAllRoles([]));
     }
   }, [editUserId]);
 
-  async function changeRole(collectionId: number, value: 'none' | CollectionRole) {
+  const availableRoles = allRoles.filter(r => !userRoles.some(ur => ur.roleId === r.id));
+
+  async function addRole() {
+    if (editUserId === null || !addRoleId) return;
+    try {
+      await addUserToRole(editUserId, Number(addRoleId));
+      setUserRoles(await listUserRoles(editUserId));
+      setAddRoleId('');
+    } catch {
+      setError('Failed to add role. Please try again.');
+    }
+  }
+
+  async function removeRole(roleId: number) {
     if (editUserId === null) return;
     try {
-      await (value === 'none'
-        ? removeUserCollection(editUserId, collectionId)
-        : setUserCollectionRole(editUserId, collectionId, value));
-      setCollections(await listUserCollections(editUserId));
+      await removeUserFromRole(editUserId, roleId);
+      setUserRoles(await listUserRoles(editUserId));
     } catch {
-      setError('Failed to update gallery access. Please try again.');
+      setError('Failed to remove role. Please try again.');
     }
   }
 
@@ -194,25 +210,42 @@ export function UserForm(props: UserFormProps) {
 
       {isEdit && (
         <section className={styles.collections}>
-          <h3 className={styles.collectionsHeading}>Gallery access</h3>
-          {collections.length === 0 && (
-            <p className={styles.collectionsEmpty}>No associated collections.</p>
+          <h3 className={styles.collectionsHeading}>Roles</h3>
+          {userRoles.length === 0 && (
+            <p className={styles.collectionsEmpty}>Not in any roles yet.</p>
           )}
-          {collections.map(c => (
-            <label key={c.collectionId} className={styles.collectionRow}>
-              <span>{c.title}</span>
-              <select
-                value={c.role ?? 'none'}
-                onChange={e =>
-                  changeRole(c.collectionId, e.target.value as 'none' | CollectionRole)
-                }
-              >
-                <option value="none">No access</option>
-                <option value="GENERAL">General (view)</option>
-                <option value="CLIENT">Client (download/tag)</option>
-              </select>
-            </label>
+          {userRoles.map(r => (
+            <div key={r.roleId} className={styles.collectionRow}>
+              <span>{r.name}</span>
+              <Button variant="ghost" size="sm" type="button" onClick={() => removeRole(r.roleId)}>
+                Remove
+              </Button>
+            </div>
           ))}
+          {availableRoles.length > 0 && (
+            <div className={styles.collectionRow}>
+              <select value={addRoleId} onChange={e => setAddRoleId(e.target.value)}>
+                <option value="">Add to role...</option>
+                {availableRoles.map(r => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </select>
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                onClick={addRole}
+                disabled={!addRoleId}
+              >
+                Add
+              </Button>
+            </div>
+          )}
+          <Link href="/admin/roles" className={styles.manageRolesLink}>
+            Manage roles and grants
+          </Link>
         </section>
       )}
 

--- a/app/lib/api/roles.ts
+++ b/app/lib/api/roles.ts
@@ -1,0 +1,83 @@
+/**
+ * Roles API — admin role management (`/api/admin/roles`) plus the user-side membership calls
+ * (`/api/admin/users/{id}/roles`). All go through the admin BFF perimeter via the `fetchAdmin*`
+ * helpers. Replaces the removed per-user `/users/{id}/collections` grant calls: access is now
+ * granted on a role and inherited by the users who join it.
+ */
+
+import {
+  fetchAdminDeleteApi,
+  fetchAdminGetApi,
+  fetchAdminPostJsonApi,
+  fetchAdminPutJsonApi,
+} from '@/app/lib/api/core';
+import {
+  type AccessLevel,
+  type CreateRoleRequest,
+  type RoleDetail,
+  type RoleSummary,
+  type UserRoleRow,
+} from '@/app/types/Role';
+
+const BASE = '/roles';
+
+/** List all roles (SHARED before PERSONAL, then by name). `[]` when the endpoint yields no body. */
+export async function listRoles(): Promise<RoleSummary[]> {
+  return (await fetchAdminGetApi<RoleSummary[]>(BASE)) ?? [];
+}
+
+/** Role detail — members + collection grants. `null` on 404 (mapped from an empty body). */
+export async function getRole(roleId: number): Promise<RoleDetail | null> {
+  return await fetchAdminGetApi<RoleDetail>(`${BASE}/${roleId}`);
+}
+
+/** Create a role. Returns the created summary (HTTP 201); throws `ApiError(409)` on a duplicate name. */
+export async function createRole(body: CreateRoleRequest): Promise<RoleSummary | null> {
+  return await fetchAdminPostJsonApi<RoleSummary>(BASE, body);
+}
+
+/** Delete a role (cascades its members + grants). */
+export async function deleteRole(roleId: number): Promise<void> {
+  await fetchAdminDeleteApi<void>(`${BASE}/${roleId}`);
+}
+
+/** Grant a collection to a role at a level (upsert — creates or promotes/demotes). */
+export async function setRoleGrant(
+  roleId: number,
+  collectionId: number,
+  level: AccessLevel
+): Promise<void> {
+  await fetchAdminPutJsonApi<void>(`${BASE}/${roleId}/collections/${collectionId}`, { level });
+}
+
+/** Revoke a role's grant on a collection. */
+export async function removeRoleGrant(roleId: number, collectionId: number): Promise<void> {
+  await fetchAdminDeleteApi<void>(`${BASE}/${roleId}/collections/${collectionId}`);
+}
+
+/** Add a user to a role (idempotent). */
+export async function addRoleMember(roleId: number, userId: number): Promise<void> {
+  await fetchAdminPutJsonApi<void>(`${BASE}/${roleId}/members/${userId}`, {});
+}
+
+/** Remove a user from a role. */
+export async function removeRoleMember(roleId: number, userId: number): Promise<void> {
+  await fetchAdminDeleteApi<void>(`${BASE}/${roleId}/members/${userId}`);
+}
+
+// ---- user-side membership (admin user-detail screen) ----
+
+/** The roles a user belongs to (`GET /api/admin/users/{id}/roles`). */
+export async function listUserRoles(userId: number): Promise<UserRoleRow[]> {
+  return (await fetchAdminGetApi<UserRoleRow[]>(`/users/${userId}/roles`)) ?? [];
+}
+
+/** Add a user to a role from the user-detail screen (idempotent). */
+export async function addUserToRole(userId: number, roleId: number): Promise<void> {
+  await fetchAdminPutJsonApi<void>(`/users/${userId}/roles/${roleId}`, {});
+}
+
+/** Remove a user from a role from the user-detail screen. */
+export async function removeUserFromRole(userId: number, roleId: number): Promise<void> {
+  await fetchAdminDeleteApi<void>(`/users/${userId}/roles/${roleId}`);
+}

--- a/app/lib/api/users.ts
+++ b/app/lib/api/users.ts
@@ -11,14 +11,11 @@
 
 import {
   ApiError,
-  fetchAdminDeleteApi,
   fetchAdminGetApi,
   fetchAdminPatchJsonApi,
   fetchAdminPostJsonApi,
-  fetchAdminPutJsonApi,
   getApiBaseUrl,
 } from '@/app/lib/api/core';
-import { type CollectionRole } from '@/app/types/Auth';
 import { type CollectionModel } from '@/app/types/Collection';
 import {
   type AcceptInviteRequest,
@@ -30,12 +27,6 @@ import {
   type UserCreateRequest,
   type UserUpdateRequest,
 } from '@/app/types/User';
-
-export interface AdminUserCollection {
-  collectionId: number;
-  title: string;
-  role: CollectionRole | null;
-}
 
 /**
  * Create a new invited user via the admin endpoint.
@@ -132,34 +123,6 @@ export async function getInvitePreview(token: string): Promise<InvitePreview | n
   const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) return null;
   return (await res.json()) as InvitePreview;
-}
-
-/**
- * List all collections associated with a user (tagged or member), with current role.
- * Role is null when the user is tagged only (no membership / no access).
- */
-export async function listUserCollections(userId: number): Promise<AdminUserCollection[]> {
-  const result = await fetchAdminGetApi<AdminUserCollection[]>(`/users/${userId}/collections`);
-  return result ?? [];
-}
-
-/**
- * Set the user's membership role on a collection (GENERAL or CLIENT).
- * Upserts — creates or updates the existing row.
- */
-export async function setUserCollectionRole(
-  userId: number,
-  collectionId: number,
-  role: CollectionRole
-): Promise<void> {
-  await fetchAdminPutJsonApi<void>(`/users/${userId}/collections/${collectionId}`, { role });
-}
-
-/**
- * Remove the user's membership on a collection entirely (no access).
- */
-export async function removeUserCollection(userId: number, collectionId: number): Promise<void> {
-  await fetchAdminDeleteApi<void>(`/users/${userId}/collections/${collectionId}`);
 }
 
 /**

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -1,0 +1,57 @@
+/**
+ * Role-based access types — mirror the backend RBAC contract (AdminRoleController + the
+ * reshaped `/api/admin/users/{id}/roles` membership endpoints). A user joins roles; a role holds
+ * per-collection grants; effective access is the union across a user's roles, CLIENT beating
+ * GENERAL.
+ */
+
+import { type CollectionRole } from '@/app/types/Auth';
+
+/** Access a role grants on a collection. GENERAL = view-only; CLIENT = download + tag + star. */
+export type AccessLevel = CollectionRole;
+
+/** How a role came to exist. PERSONAL = auto-migrated per-user default; SHARED = admin-curated. */
+export type RoleKind = 'PERSONAL' | 'SHARED';
+
+/** A role in the admin list (`GET /api/admin/roles`). */
+export interface RoleSummary {
+  id: number;
+  name: string;
+  kind: RoleKind;
+}
+
+/** One member of a role (`RoleDetail.members`). `email`/`name` are null for tag-only identities. */
+export interface RoleMemberRow {
+  userId: number;
+  email: string | null;
+  name: string | null;
+}
+
+/** One collection a role grants (`RoleDetail.collections`). */
+export interface RoleCollectionRow {
+  collectionId: number;
+  title: string;
+  level: AccessLevel;
+}
+
+/** Full role detail (`GET /api/admin/roles/{roleId}`). */
+export interface RoleDetail {
+  id: number;
+  name: string;
+  kind: RoleKind;
+  members: RoleMemberRow[];
+  collections: RoleCollectionRow[];
+}
+
+/** One role a user belongs to (`GET /api/admin/users/{id}/roles`). */
+export interface UserRoleRow {
+  roleId: number;
+  name: string;
+  kind: RoleKind;
+}
+
+/** Body for `POST /api/admin/roles`. `kind` defaults to SHARED server-side when omitted. */
+export interface CreateRoleRequest {
+  name: string;
+  kind?: RoleKind;
+}

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -24,8 +24,8 @@ jest.mock('@/app/lib/api/users', () => ({
 jest.mock('@/app/lib/api/roles', () => ({
   listUserRoles: jest.fn().mockResolvedValue([]),
   listRoles: jest.fn().mockResolvedValue([]),
-  addUserToRole: jest.fn().mockResolvedValue(),
-  removeUserFromRole: jest.fn().mockResolvedValue(),
+  addUserToRole: jest.fn().mockResolvedValue(undefined),
+  removeUserFromRole: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockCreateUser = usersApi.createUser as jest.MockedFunction<typeof usersApi.createUser>;

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -12,24 +12,30 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { UserForm } from '@/app/components/UserForm/UserForm';
 import { ApiError } from '@/app/lib/api/core';
+import * as rolesApi from '@/app/lib/api/roles';
 import * as usersApi from '@/app/lib/api/users';
 import { type AdminUserSummary } from '@/app/types/User';
 
 jest.mock('@/app/lib/api/users', () => ({
   createUser: jest.fn(),
   updateUser: jest.fn(),
-  listUserCollections: jest.fn().mockResolvedValue([]),
-  setUserCollectionRole: jest.fn().mockResolvedValue(null),
-  removeUserCollection: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/app/lib/api/roles', () => ({
+  listUserRoles: jest.fn().mockResolvedValue([]),
+  listRoles: jest.fn().mockResolvedValue([]),
+  addUserToRole: jest.fn().mockResolvedValue(),
+  removeUserFromRole: jest.fn().mockResolvedValue(),
 }));
 
 const mockCreateUser = usersApi.createUser as jest.MockedFunction<typeof usersApi.createUser>;
 const mockUpdateUser = usersApi.updateUser as jest.MockedFunction<typeof usersApi.updateUser>;
-const mockListUserCollections = usersApi.listUserCollections as jest.MockedFunction<
-  typeof usersApi.listUserCollections
+const mockListUserRoles = rolesApi.listUserRoles as jest.MockedFunction<
+  typeof rolesApi.listUserRoles
 >;
-const mockSetUserCollectionRole = usersApi.setUserCollectionRole as jest.MockedFunction<
-  typeof usersApi.setUserCollectionRole
+const mockListRoles = rolesApi.listRoles as jest.MockedFunction<typeof rolesApi.listRoles>;
+const mockAddUserToRole = rolesApi.addUserToRole as jest.MockedFunction<
+  typeof rolesApi.addUserToRole
 >;
 
 // jsdom does not implement navigator.clipboard — stub it (InviteLinkResult uses it).
@@ -203,29 +209,26 @@ describe('UserForm', () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
-    it('collection role select calls setUserCollectionRole and refreshes the list', async () => {
-      mockListUserCollections.mockResolvedValue([
-        { collectionId: 20, title: 'Portraits', role: null },
-      ]);
-      mockSetUserCollectionRole.mockResolvedValue();
+    it('adding a role calls addUserToRole and refreshes the membership list', async () => {
+      mockListUserRoles.mockResolvedValue([]);
+      mockListRoles.mockResolvedValue([{ id: 3, name: 'power', kind: 'SHARED' }]);
+      mockAddUserToRole.mockResolvedValue();
 
       render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
 
-      // Wait for the collection row to appear (also silences the act() warning).
+      // Wait for the add-role dropdown to be populated from listRoles (silences act() warning).
       await waitFor(() => {
-        expect(screen.getByText('Portraits')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'power' })).toBeInTheDocument();
       });
 
-      // After the row renders, listUserCollections returns the updated state on refresh.
-      mockListUserCollections.mockResolvedValue([
-        { collectionId: 20, title: 'Portraits', role: 'CLIENT' },
-      ]);
+      // After adding, the refresh reads back the joined role.
+      mockListUserRoles.mockResolvedValue([{ roleId: 3, name: 'power', kind: 'SHARED' }]);
 
-      const collectionSelect = screen.getByDisplayValue('No access');
-      fireEvent.change(collectionSelect, { target: { value: 'CLIENT' } });
+      fireEvent.change(screen.getByDisplayValue('Add to role...'), { target: { value: '3' } });
+      fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
 
       await waitFor(() => {
-        expect(mockSetUserCollectionRole).toHaveBeenCalledWith(8, 20, 'CLIENT');
+        expect(mockAddUserToRole).toHaveBeenCalledWith(8, 3);
       });
     });
   });

--- a/tests/components/UserManagementPanel.test.tsx
+++ b/tests/components/UserManagementPanel.test.tsx
@@ -22,9 +22,14 @@ jest.mock('@/app/lib/api/users', () => ({
   createUser: jest.fn(),
   updateUser: jest.fn(),
   regenerateInvite: jest.fn(),
-  listUserCollections: jest.fn().mockResolvedValue([]),
-  setUserCollectionRole: jest.fn().mockResolvedValue(null),
-  removeUserCollection: jest.fn().mockResolvedValue(null),
+}));
+
+// The edit form (UserForm) now reads role membership, not per-user collection grants.
+jest.mock('@/app/lib/api/roles', () => ({
+  listUserRoles: jest.fn().mockResolvedValue([]),
+  listRoles: jest.fn().mockResolvedValue([]),
+  addUserToRole: jest.fn().mockResolvedValue(undefined),
+  removeUserFromRole: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockListUsers = usersApi.listUsers as jest.MockedFunction<typeof usersApi.listUsers>;

--- a/tests/lib/api/roles.test.ts
+++ b/tests/lib/api/roles.test.ts
@@ -1,0 +1,128 @@
+/** @jest-environment node */
+/**
+ * Unit tests for roles.ts — verifies URL construction and request shape for the admin role
+ * management calls and the user-side membership calls. Core fetch helpers are mocked.
+ */
+
+import { ApiError } from '@/app/lib/api/core';
+import {
+  addRoleMember,
+  addUserToRole,
+  createRole,
+  deleteRole,
+  getRole,
+  listRoles,
+  listUserRoles,
+  removeRoleGrant,
+  removeRoleMember,
+  removeUserFromRole,
+  setRoleGrant,
+} from '@/app/lib/api/roles';
+
+jest.mock('@/app/lib/api/core', () => ({
+  ...jest.requireActual('@/app/lib/api/core'),
+  fetchAdminGetApi: jest.fn(),
+  fetchAdminPostJsonApi: jest.fn(),
+  fetchAdminPutJsonApi: jest.fn(),
+  fetchAdminDeleteApi: jest.fn(),
+}));
+
+import * as core from '@/app/lib/api/core';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('listRoles', () => {
+  it('GETs /roles and returns the array', async () => {
+    const roles = [{ id: 1, name: 'power', kind: 'SHARED' }];
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(roles);
+    expect(await listRoles()).toEqual(roles);
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/roles');
+  });
+
+  it('returns [] when the endpoint yields no body', async () => {
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(null);
+    expect(await listRoles()).toEqual([]);
+  });
+});
+
+describe('getRole', () => {
+  it('GETs /roles/{id} and returns the detail', async () => {
+    const detail = { id: 1, name: 'power', kind: 'SHARED', members: [], collections: [] };
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(detail);
+    expect(await getRole(1)).toEqual(detail);
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/roles/1');
+  });
+});
+
+describe('createRole', () => {
+  it('POSTs /roles with the body', async () => {
+    const created = { id: 9, name: 'power', kind: 'SHARED' };
+    (core.fetchAdminPostJsonApi as jest.Mock).mockResolvedValue(created);
+    expect(await createRole({ name: 'power', kind: 'SHARED' })).toEqual(created);
+    expect(core.fetchAdminPostJsonApi).toHaveBeenCalledWith('/roles', {
+      name: 'power',
+      kind: 'SHARED',
+    });
+  });
+
+  it('propagates ApiError(409) on a duplicate name', async () => {
+    (core.fetchAdminPostJsonApi as jest.Mock).mockRejectedValue(new ApiError('Conflict', 409));
+    await expect(createRole({ name: 'power' })).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe('deleteRole', () => {
+  it('DELETEs /roles/{id}', async () => {
+    (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
+    await deleteRole(9);
+    expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/roles/9');
+  });
+});
+
+describe('collection grants', () => {
+  it('setRoleGrant PUTs /roles/{id}/collections/{cid} with the level', async () => {
+    (core.fetchAdminPutJsonApi as jest.Mock).mockResolvedValue(null);
+    await setRoleGrant(1, 20, 'CLIENT');
+    expect(core.fetchAdminPutJsonApi).toHaveBeenCalledWith('/roles/1/collections/20', {
+      level: 'CLIENT',
+    });
+  });
+
+  it('removeRoleGrant DELETEs /roles/{id}/collections/{cid}', async () => {
+    (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
+    await removeRoleGrant(1, 20);
+    expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/roles/1/collections/20');
+  });
+});
+
+describe('membership', () => {
+  it('addRoleMember PUTs /roles/{id}/members/{uid}', async () => {
+    (core.fetchAdminPutJsonApi as jest.Mock).mockResolvedValue(null);
+    await addRoleMember(1, 3);
+    expect(core.fetchAdminPutJsonApi).toHaveBeenCalledWith('/roles/1/members/3', {});
+  });
+
+  it('removeRoleMember DELETEs /roles/{id}/members/{uid}', async () => {
+    (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
+    await removeRoleMember(1, 3);
+    expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/roles/1/members/3');
+  });
+
+  it('listUserRoles GETs /users/{id}/roles', async () => {
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue([]);
+    expect(await listUserRoles(3)).toEqual([]);
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/users/3/roles');
+  });
+
+  it('addUserToRole PUTs /users/{id}/roles/{roleId}', async () => {
+    (core.fetchAdminPutJsonApi as jest.Mock).mockResolvedValue(null);
+    await addUserToRole(3, 1);
+    expect(core.fetchAdminPutJsonApi).toHaveBeenCalledWith('/users/3/roles/1', {});
+  });
+
+  it('removeUserFromRole DELETEs /users/{id}/roles/{roleId}', async () => {
+    (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
+    await removeUserFromRole(3, 1);
+    expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/users/3/roles/1');
+  });
+});

--- a/tests/lib/api/users.test.ts
+++ b/tests/lib/api/users.test.ts
@@ -14,12 +14,9 @@ import {
   getInvitePreview,
   getMergePreview,
   getUserPageById,
-  listUserCollections,
   listUsers,
   mergeUser,
   regenerateInvite,
-  removeUserCollection,
-  setUserCollectionRole,
   updateUser,
 } from '@/app/lib/api/users';
 import {
@@ -289,71 +286,6 @@ describe('updateUser', () => {
     (core.fetchAdminPatchJsonApi as jest.Mock).mockRejectedValue(new ApiError('Not Found', 404));
 
     await expect(updateUser(999, body)).rejects.toMatchObject({ name: 'ApiError', status: 404 });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// listUserCollections
-// ---------------------------------------------------------------------------
-
-describe('listUserCollections', () => {
-  it('delegates to fetchAdminGetApi(/users/{id}/collections) and returns the array', async () => {
-    const rows = [
-      { collectionId: 10, title: 'Wedding 2024', role: 'CLIENT' },
-      { collectionId: 11, title: 'Portraits', role: null },
-    ];
-    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(rows);
-
-    const result = await listUserCollections(5);
-
-    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/users/5/collections');
-    expect(result).toEqual(rows);
-  });
-
-  it('returns [] when the endpoint yields no body', async () => {
-    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(null);
-
-    expect(await listUserCollections(5)).toEqual([]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// setUserCollectionRole
-// ---------------------------------------------------------------------------
-
-describe('setUserCollectionRole', () => {
-  it('PUTs to /users/{id}/collections/{cid} with the role body', async () => {
-    (core.fetchAdminPutJsonApi as jest.Mock).mockResolvedValue(null);
-
-    await setUserCollectionRole(5, 10, 'CLIENT');
-
-    expect(core.fetchAdminPutJsonApi).toHaveBeenCalledWith('/users/5/collections/10', {
-      role: 'CLIENT',
-    });
-  });
-
-  it('works for GENERAL role', async () => {
-    (core.fetchAdminPutJsonApi as jest.Mock).mockResolvedValue(null);
-
-    await setUserCollectionRole(5, 10, 'GENERAL');
-
-    expect(core.fetchAdminPutJsonApi).toHaveBeenCalledWith('/users/5/collections/10', {
-      role: 'GENERAL',
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// removeUserCollection
-// ---------------------------------------------------------------------------
-
-describe('removeUserCollection', () => {
-  it('DELETEs /users/{id}/collections/{cid}', async () => {
-    (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
-
-    await removeUserCollection(5, 10);
-
-    expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/users/5/collections/10');
   });
 });
 


### PR DESCRIPTION
…screen

The RBAC backend swap removed /api/admin/users/{id}/collections in favor of roles, leaving UserForm calling dead routes. This adds the frontend companion:

- app/lib/api/roles.ts + app/types/Role.ts wrap the /api/admin/roles CRUD, collection grants, membership, and the /users/{id}/roles calls.
- /admin/roles: list + create roles; /admin/roles/[roleId]: edit a role's collection grants (GENERAL/CLIENT) and members. Reached via the admin menu.
- UserForm's dead "gallery access" section is repointed to a Roles section (join/leave roles); the removed *UserCollection* API functions are deleted.

Frontend-only; all backend endpoints already exist. Type-check, lint, build, and 2544 jest tests green (roles API + UserForm role-flow covered).