### PR TITLE
feat(admin): collection edit roles-access section

### DIFF
--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
@@ -1,0 +1,84 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: bold;
+  color: var(--color-fg);
+}
+
+.fieldHint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.empty {
+  font-size: var(--text-sm);
+  color: var(--color-fg-muted, var(--color-fg));
+  opacity: 0.75;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.rowName {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kindBadge {
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  color: var(--color-fg-muted, var(--color-fg));
+}
+
+.select {
+  font-family: inherit;
+  font-size: var(--text-sm);
+  height: var(--menu-item-height);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-color: var(--color-fg);
+  }
+}
+
+.addRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.createRow {
+  align-items: flex-end;
+}
+
+.grow {
+  flex: 1 1 auto;
+  min-width: 0;
+}

--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { Field } from '@/app/components/ui/Field/Field';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { Input } from '@/app/components/ui/Field/Input';
+import { ApiError } from '@/app/lib/api/core';
+import {
+  createRole,
+  listCollectionRoles,
+  listRoles,
+  removeRoleGrant,
+  setRoleGrant,
+} from '@/app/lib/api/roles';
+import { type AccessLevel, type CollectionRoleRow, type RoleSummary } from '@/app/types/Role';
+
+import styles from './CollectionRolesSection.module.scss';
+
+interface CollectionRolesSectionProps {
+  /** Saved collection id — the section only renders for persisted collections. */
+  collectionId: number;
+  /** Current title, used as the default name for the create-role shortcut. */
+  collectionTitle: string;
+}
+
+/**
+ * Role access panel on the collection edit Info tab — the inverse of the role-detail page:
+ * which roles can view this collection, at what level (GENERAL = view; CLIENT =
+ * download/tag/star). Changes save immediately via the existing role-grant endpoints, and every
+ * mutation re-fetches the grant list so the view stays authoritative. The add/create controls
+ * offer SHARED roles only; per-user access is granted by adding the user to a role instead.
+ */
+export function CollectionRolesSection({
+  collectionId,
+  collectionTitle,
+}: CollectionRolesSectionProps) {
+  const [grants, setGrants] = useState<CollectionRoleRow[]>([]);
+  const [allRoles, setAllRoles] = useState<RoleSummary[]>([]);
+  const [addRoleId, setAddRoleId] = useState('');
+  const [addLevel, setAddLevel] = useState<AccessLevel>('GENERAL');
+  const [createName, setCreateName] = useState(collectionTitle);
+  const [createLevel, setCreateLevel] = useState<AccessLevel>('GENERAL');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listCollectionRoles(collectionId)
+      .then(setGrants)
+      .catch(() => {
+        setGrants([]);
+        setError('Failed to load role access.');
+      });
+    listRoles()
+      .then(setAllRoles)
+      .catch(() => setAllRoles([]));
+  }, [collectionId]);
+
+  const grantedIds = new Set(grants.map(g => g.roleId));
+  const grantableRoles = allRoles.filter(r => r.kind === 'SHARED' && !grantedIds.has(r.id));
+
+  async function refresh() {
+    setGrants(await listCollectionRoles(collectionId));
+  }
+
+  async function run(action: () => Promise<void>, failMessage: string) {
+    setError(null);
+    try {
+      await action();
+      await refresh();
+    } catch {
+      setError(failMessage);
+    }
+  }
+
+  const onAddRole = () =>
+    addRoleId &&
+    run(
+      () => setRoleGrant(Number(addRoleId), collectionId, addLevel).then(() => setAddRoleId('')),
+      'Failed to add the role.'
+    );
+
+  const onChangeLevel = (roleId: number, level: AccessLevel) =>
+    run(() => setRoleGrant(roleId, collectionId, level), 'Failed to change the access level.');
+
+  const onRemove = (roleId: number) =>
+    run(() => removeRoleGrant(roleId, collectionId), 'Failed to remove the role.');
+
+  async function onCreateRole() {
+    const name = createName.trim();
+    if (!name) return;
+    setError(null);
+    try {
+      const created = await createRole({ name, kind: 'SHARED' });
+      if (created) {
+        await setRoleGrant(created.id, collectionId, createLevel);
+      }
+      setAllRoles(await listRoles());
+      await refresh();
+      setCreateName('');
+    } catch (error_) {
+      setError(
+        error_ instanceof ApiError && error_.status === 409
+          ? 'A role with that name already exists.'
+          : 'Failed to create the role.'
+      );
+    }
+  }
+
+  return (
+    <section aria-labelledby="collection-roles-heading" className={styles.section}>
+      <h3 id="collection-roles-heading" className={styles.sectionTitle}>
+        Role Access
+      </h3>
+      <p className={styles.fieldHint}>
+        Roles that can view this collection. Changes save immediately.
+      </p>
+
+      {error && <FormError>{error}</FormError>}
+
+      {grants.length === 0 && <p className={styles.empty}>No roles have access yet.</p>}
+      {grants.map(g => (
+        <div key={g.roleId} className={styles.row}>
+          <span className={styles.rowName}>
+            {g.name} <span className={styles.kindBadge}>{g.kind}</span>
+          </span>
+          <select
+            className={styles.select}
+            value={g.level}
+            onChange={e => onChangeLevel(g.roleId, e.target.value as AccessLevel)}
+            aria-label={`Access level for ${g.name}`}
+          >
+            <option value="GENERAL">General (view)</option>
+            <option value="CLIENT">Client (download/tag/star)</option>
+          </select>
+          <Button variant="ghost" size="sm" onClick={() => onRemove(g.roleId)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+
+      {grantableRoles.length > 0 && (
+        <div className={styles.addRow}>
+          <select
+            className={`${styles.select} ${styles.grow}`}
+            value={addRoleId}
+            onChange={e => setAddRoleId(e.target.value)}
+            aria-label="Add a role"
+          >
+            <option value="">Add a role...</option>
+            {grantableRoles.map(r => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className={styles.select}
+            value={addLevel}
+            onChange={e => setAddLevel(e.target.value as AccessLevel)}
+            aria-label="Access level for added role"
+          >
+            <option value="GENERAL">General</option>
+            <option value="CLIENT">Client</option>
+          </select>
+          <Button variant="ghost" size="sm" onClick={onAddRole} disabled={!addRoleId}>
+            Add
+          </Button>
+        </div>
+      )}
+
+      <div className={`${styles.addRow} ${styles.createRow}`}>
+        <div className={styles.grow}>
+          <Field label="Create role for this collection" htmlFor="collection-role-create-name">
+            <Input
+              id="collection-role-create-name"
+              value={createName}
+              onChange={e => setCreateName(e.target.value)}
+              autoComplete="off"
+            />
+          </Field>
+        </div>
+        <select
+          className={styles.select}
+          value={createLevel}
+          onChange={e => setCreateLevel(e.target.value as AccessLevel)}
+          aria-label="Access level for created role"
+        >
+          <option value="GENERAL">General</option>
+          <option value="CLIENT">Client</option>
+        </select>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void onCreateRole()}
+          disabled={!createName.trim()}
+        >
+          Create
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/app/components/ContentCollection/edit/sections/InfoTab.tsx
+++ b/app/components/ContentCollection/edit/sections/InfoTab.tsx
@@ -29,6 +29,7 @@ import { isContentImage } from '@/app/utils/contentTypeGuards';
 
 import { Button } from '../../../ui/Button/Button';
 import { type UseCollectionEditResult } from '../useCollectionEdit';
+import { CollectionRolesSection } from './CollectionRolesSection';
 import styles from './InfoTab.module.scss';
 
 interface InfoTabProps {
@@ -354,6 +355,13 @@ export function InfoTab({ edit }: InfoTabProps) {
             </p>
           )}
         </section>
+      )}
+
+      {collection?.id != null && (
+        <CollectionRolesSection
+          collectionId={collection.id}
+          collectionTitle={updateData.title ?? ''}
+        />
       )}
     </div>
   );

--- a/app/lib/api/roles.ts
+++ b/app/lib/api/roles.ts
@@ -13,6 +13,7 @@ import {
 } from '@/app/lib/api/core';
 import {
   type AccessLevel,
+  type CollectionRoleRow,
   type CreateRoleRequest,
   type RoleDetail,
   type RoleSummary,
@@ -80,4 +81,11 @@ export async function addUserToRole(userId: number, roleId: number): Promise<voi
 /** Remove a user from a role from the user-detail screen. */
 export async function removeUserFromRole(userId: number, roleId: number): Promise<void> {
   await fetchAdminDeleteApi<void>(`/users/${userId}/roles/${roleId}`);
+}
+
+// ---- collection-side grants (collection edit screen) ----
+
+/** The roles granting a collection (`GET /api/admin/collections/{id}/roles`). */
+export async function listCollectionRoles(collectionId: number): Promise<CollectionRoleRow[]> {
+  return (await fetchAdminGetApi<CollectionRoleRow[]>(`/collections/${collectionId}/roles`)) ?? [];
 }

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -50,6 +50,14 @@ export interface UserRoleRow {
   kind: RoleKind;
 }
 
+/** One role granting a collection (`GET /api/admin/collections/{id}/roles`). */
+export interface CollectionRoleRow {
+  roleId: number;
+  name: string;
+  kind: RoleKind;
+  level: AccessLevel;
+}
+
 /** Body for `POST /api/admin/roles`. `kind` defaults to SHARED server-side when omitted. */
 export interface CreateRoleRequest {
   name: string;

--- a/tests/components/CollectionRolesSection.test.tsx
+++ b/tests/components/CollectionRolesSection.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for CollectionRolesSection — the collection-edit "Role Access" panel (the inverse of the
+ * role-detail page). Renders the roles granting a collection, changes a level, revokes, adds an
+ * existing SHARED role, and creates-and-grants a new SHARED role in one action. All mutations
+ * save immediately and re-fetch the grant list.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import { CollectionRolesSection } from '@/app/components/ContentCollection/edit/sections/CollectionRolesSection';
+import { ApiError } from '@/app/lib/api/core';
+import * as rolesApi from '@/app/lib/api/roles';
+import { type CollectionRoleRow, type RoleSummary } from '@/app/types/Role';
+
+jest.mock('@/app/lib/api/roles', () => ({
+  listCollectionRoles: jest.fn(),
+  listRoles: jest.fn(),
+  createRole: jest.fn(),
+  setRoleGrant: jest.fn(),
+  removeRoleGrant: jest.fn(),
+}));
+
+const mockListCollectionRoles = rolesApi.listCollectionRoles as jest.MockedFunction<
+  typeof rolesApi.listCollectionRoles
+>;
+const mockListRoles = rolesApi.listRoles as jest.MockedFunction<typeof rolesApi.listRoles>;
+const mockCreateRole = rolesApi.createRole as jest.MockedFunction<typeof rolesApi.createRole>;
+const mockSetRoleGrant = rolesApi.setRoleGrant as jest.MockedFunction<typeof rolesApi.setRoleGrant>;
+const mockRemoveRoleGrant = rolesApi.removeRoleGrant as jest.MockedFunction<
+  typeof rolesApi.removeRoleGrant
+>;
+
+const COLLECTION_ID = 20;
+
+const grants: CollectionRoleRow[] = [
+  { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
+  { roleId: 2, name: 'ken@x.com', kind: 'PERSONAL', level: 'CLIENT' },
+];
+
+const allRoles: RoleSummary[] = [
+  { id: 1, name: 'pnwer', kind: 'SHARED' }, // already granted — excluded from the picker
+  { id: 3, name: 'power', kind: 'SHARED' }, // grantable
+  { id: 4, name: 'ken@x.com', kind: 'PERSONAL' }, // PERSONAL — excluded from the picker
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListCollectionRoles.mockResolvedValue(grants);
+  mockListRoles.mockResolvedValue(allRoles);
+  mockSetRoleGrant.mockResolvedValue();
+  mockRemoveRoleGrant.mockResolvedValue();
+});
+
+async function renderSection(title = 'Fall Wedding') {
+  render(<CollectionRolesSection collectionId={COLLECTION_ID} collectionTitle={title} />);
+  // Wait for the initial grant + role loads to settle (silences act() warnings).
+  await waitFor(() => {
+    expect(mockListCollectionRoles).toHaveBeenCalledWith(COLLECTION_ID);
+    expect(mockListRoles).toHaveBeenCalled();
+  });
+}
+
+describe('CollectionRolesSection', () => {
+  it('renders the granted roles with kind badge and current level', async () => {
+    await renderSection();
+
+    expect(await screen.findByText('pnwer')).toBeInTheDocument();
+    expect(screen.getByText('ken@x.com')).toBeInTheDocument();
+    expect(screen.getByText('SHARED')).toBeInTheDocument();
+    // PERSONAL appears once — the granted row badge (the picker excludes PERSONAL roles).
+    expect(screen.getByText('PERSONAL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Access level for pnwer')).toHaveValue('GENERAL');
+    expect(screen.getByLabelText('Access level for ken@x.com')).toHaveValue('CLIENT');
+  });
+
+  it('shows the empty state when no roles grant the collection', async () => {
+    mockListCollectionRoles.mockResolvedValue([]);
+    await renderSection();
+
+    expect(await screen.findByText('No roles have access yet.')).toBeInTheDocument();
+  });
+
+  it('adds an existing role via the picker and re-fetches the grants', async () => {
+    await renderSection();
+    await screen.findByLabelText('Add a role');
+
+    fireEvent.change(screen.getByLabelText('Add a role'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('Access level for added role'), {
+      target: { value: 'CLIENT' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(mockSetRoleGrant).toHaveBeenCalledWith(3, COLLECTION_ID, 'CLIENT');
+    });
+    // Initial load + post-mutation refresh.
+    await waitFor(() => {
+      expect(mockListCollectionRoles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('excludes PERSONAL and already-granted roles from the add picker', async () => {
+    await renderSection();
+    const picker = await screen.findByLabelText('Add a role');
+
+    expect(within(picker).getByRole('option', { name: 'power' })).toBeInTheDocument();
+    expect(within(picker).queryByRole('option', { name: 'pnwer' })).not.toBeInTheDocument();
+    expect(within(picker).queryByRole('option', { name: 'ken@x.com' })).not.toBeInTheDocument();
+  });
+
+  it('changes a granted role level via setRoleGrant', async () => {
+    await renderSection();
+    const levelSelect = await screen.findByLabelText('Access level for pnwer');
+
+    fireEvent.change(levelSelect, { target: { value: 'CLIENT' } });
+
+    await waitFor(() => {
+      expect(mockSetRoleGrant).toHaveBeenCalledWith(1, COLLECTION_ID, 'CLIENT');
+    });
+  });
+
+  it('removes a granted role via removeRoleGrant', async () => {
+    await renderSection();
+    const row = (await screen.findByLabelText('Access level for pnwer')).closest('div');
+    if (!row) throw new Error('granted-role row not found');
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(mockRemoveRoleGrant).toHaveBeenCalledWith(1, COLLECTION_ID);
+    });
+  });
+
+  it('creates a SHARED role named after the collection, then grants it', async () => {
+    mockCreateRole.mockResolvedValue({ id: 9, name: 'Fall Wedding', kind: 'SHARED' });
+    await renderSection();
+
+    const nameInput = await screen.findByLabelText('Create role for this collection');
+    expect(nameInput).toHaveValue('Fall Wedding'); // defaults to the collection title
+
+    fireEvent.change(screen.getByLabelText('Access level for created role'), {
+      target: { value: 'CLIENT' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mockCreateRole).toHaveBeenCalledWith({ name: 'Fall Wedding', kind: 'SHARED' });
+      expect(mockSetRoleGrant).toHaveBeenCalledWith(9, COLLECTION_ID, 'CLIENT');
+    });
+  });
+
+  it('surfaces a 409 duplicate role name as "already exists"', async () => {
+    mockCreateRole.mockRejectedValue(new ApiError('Conflict', 409));
+    await renderSection();
+    await screen.findByLabelText('Create role for this collection');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('A role with that name already exists.');
+    });
+    expect(mockSetRoleGrant).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/ContentCollection/CollectionEditSheet.test.tsx
+++ b/tests/components/ContentCollection/CollectionEditSheet.test.tsx
@@ -35,6 +35,13 @@ jest.mock('@/app/components/RatingStars/RatingStars', () => ({
   default: () => <div data-testid="rating-stars" />,
 }));
 
+// Self-contained section that fetches on mount — stubbed here; behavior is covered by
+// tests/components/CollectionRolesSection.test.tsx.
+jest.mock('@/app/components/ContentCollection/edit/sections/CollectionRolesSection', () => ({
+  __esModule: true,
+  CollectionRolesSection: () => <div data-testid="collection-roles-section" />,
+}));
+
 function makeCollection(overrides: Partial<CollectionModel> = {}): CollectionModel {
   return {
     id: 1,
@@ -259,6 +266,20 @@ describe('CollectionEditSheet — InfoTab', () => {
     });
     render(<CollectionEditSheet edit={edit} />);
     expect(screen.queryByRole('button', { name: 'Clear Password' })).not.toBeInTheDocument();
+  });
+
+  it('renders the roles access section for a saved collection regardless of type', () => {
+    render(<CollectionEditSheet edit={makeEdit({ editTab: 'info' })} />);
+    expect(screen.getByTestId('collection-roles-section')).toBeInTheDocument();
+  });
+
+  it('does not render the roles access section when the collection has no id (create flow)', () => {
+    const edit = makeEdit({
+      editTab: 'info',
+      currentState: makeState({ id: undefined }),
+    });
+    render(<CollectionEditSheet edit={edit} />);
+    expect(screen.queryByTestId('collection-roles-section')).not.toBeInTheDocument();
   });
 
   it('renders galleryStatus into the role="status" element', () => {

--- a/tests/lib/api/roles.test.ts
+++ b/tests/lib/api/roles.test.ts
@@ -11,6 +11,7 @@ import {
   createRole,
   deleteRole,
   getRole,
+  listCollectionRoles,
   listRoles,
   listUserRoles,
   removeRoleGrant,
@@ -124,5 +125,19 @@ describe('membership', () => {
     (core.fetchAdminDeleteApi as jest.Mock).mockResolvedValue(null);
     await removeUserFromRole(3, 1);
     expect(core.fetchAdminDeleteApi).toHaveBeenCalledWith('/users/3/roles/1');
+  });
+});
+
+describe('listCollectionRoles', () => {
+  it('GETs /collections/{id}/roles and returns the array', async () => {
+    const rows = [{ roleId: 1, name: 'power', kind: 'SHARED', level: 'GENERAL' }];
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(rows);
+    expect(await listCollectionRoles(20)).toEqual(rows);
+    expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/collections/20/roles');
+  });
+
+  it('returns [] when the endpoint yields no body', async () => {
+    (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(null);
+    expect(await listCollectionRoles(20)).toEqual([]);
   });
 });


### PR DESCRIPTION
Carries the collection-edit roles-access work to main. PR #219 merged this branch at f31cd39; PR #220 then merged the CollectionRolesSection commit (73908e7) into the branch five minutes later, so that delta never reached main. This PR delivers it.

## What's in the delta
- CollectionRoleRow type + listCollectionRoles() API call (GET /api/admin/collections/{id}/roles via the admin BFF proxy)
- CollectionRolesSection: granted-roles list (kind badge, GENERAL/CLIENT level select, Remove), add-existing-SHARED-role picker, and a create-role-for-this-collection shortcut (409 duplicate-name handled)
- Wired into InfoTab after Gallery Access, shown for all saved collections (admin-only), immediate save mirroring the sibling People/Gallery-Access sections
- Tests: 12 new (API + component + InfoTab wiring guards); full suite green at merge time (164 suites / 2556 tests); type-check clean

## Dependencies / follow-ups
- Backend endpoint merged in edens.zac.backend#126 — needs to be deployed before this UI goes live.
- A small stacked follow-up (branch collection-roles-inherited-badge) will badge/lock inherited rows once the waterfall-grants backend (edens.zac.backend#127) exposes inheritedFromCollectionId; inherited rows are edited at their origin collection.

Reviewed by a two-stage subagent pass (spec compliance + code quality): spec-compliant, approved, three minor notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)