### PR TITLE
feat(admin): badge and lock inherited role grants on collection edit

### DIFF
--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
@@ -48,6 +48,16 @@
   color: var(--color-fg-muted, var(--color-fg));
 }
 
+.inheritedBadge {
+  margin-left: var(--space-2);
+}
+
+.inheritedHint {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-on-surface-muted);
+}
+
 .select {
   font-family: inherit;
   font-size: var(--text-sm);
@@ -58,6 +68,11 @@
   background-color: var(--color-bg);
   color: var(--color-fg);
   cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
 
   &:focus-visible {
     outline: 2px solid var(--color-accent);

--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 import { Button } from '@/app/components/ui/Button/Button';
 import { Field } from '@/app/components/ui/Field/Field';
@@ -31,6 +31,10 @@ interface CollectionRolesSectionProps {
  * download/tag/star). Changes save immediately via the existing role-grant endpoints, and every
  * mutation re-fetches the grant list so the view stays authoritative. The add/create controls
  * offer SHARED roles only; per-user access is granted by adding the user to a role instead.
+ *
+ * Grants inherited from a parent collection (waterfall provenance on the row) render read-only:
+ * removing one here would just re-sync from the parent, so they are edited at the origin
+ * collection instead.
  */
 export function CollectionRolesSection({
   collectionId,
@@ -119,25 +123,48 @@ export function CollectionRolesSection({
       {error && <FormError>{error}</FormError>}
 
       {grants.length === 0 && <p className={styles.empty}>No roles have access yet.</p>}
-      {grants.map(g => (
-        <div key={g.roleId} className={styles.row}>
-          <span className={styles.rowName}>
-            {g.name} <span className={styles.kindBadge}>{g.kind}</span>
-          </span>
-          <select
-            className={styles.select}
-            value={g.level}
-            onChange={e => onChangeLevel(g.roleId, e.target.value as AccessLevel)}
-            aria-label={`Access level for ${g.name}`}
-          >
-            <option value="GENERAL">General (view)</option>
-            <option value="CLIENT">Client (download/tag/star)</option>
-          </select>
-          <Button variant="ghost" size="sm" onClick={() => onRemove(g.roleId)}>
-            Remove
-          </Button>
-        </div>
-      ))}
+      {grants.map(g => {
+        const inherited = g.inheritedFromCollectionId != null;
+        return (
+          <Fragment key={g.roleId}>
+            <div className={styles.row}>
+              <span className={styles.rowName}>
+                {g.name} <span className={styles.kindBadge}>{g.kind}</span>
+                {inherited && (
+                  <span className={`${styles.kindBadge} ${styles.inheritedBadge}`}>Inherited</span>
+                )}
+              </span>
+              <select
+                className={styles.select}
+                value={g.level}
+                onChange={
+                  inherited ? undefined : e => onChangeLevel(g.roleId, e.target.value as AccessLevel)
+                }
+                disabled={inherited}
+                aria-label={`Access level for ${g.name}`}
+              >
+                <option value="GENERAL">General (view)</option>
+                <option value="CLIENT">Client (download/tag/star)</option>
+              </select>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={inherited ? undefined : () => onRemove(g.roleId)}
+                disabled={inherited}
+              >
+                Remove
+              </Button>
+            </div>
+            {inherited && (
+              <p className={styles.inheritedHint}>
+                {g.inheritedFromCollectionTitle != null
+                  ? `Inherited from "${g.inheritedFromCollectionTitle}" — edit access on that collection.`
+                  : 'Inherited from a parent collection — edit access there.'}
+              </p>
+            )}
+          </Fragment>
+        );
+      })}
 
       {grantableRoles.length > 0 && (
         <div className={styles.addRow}>

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -50,12 +50,22 @@ export interface UserRoleRow {
   kind: RoleKind;
 }
 
-/** One role granting a collection (`GET /api/admin/collections/{id}/roles`). */
+/**
+ * One role granting a collection (`GET /api/admin/collections/{id}/roles`).
+ *
+ * `inheritedFromCollectionId`/`inheritedFromCollectionTitle` carry waterfall provenance: non-null
+ * means the grant was materialized down from a parent collection — the id/title identify the
+ * origin collection holding the direct grant, and the grant is edited there. Both are optional
+ * because the backend may not expose them yet; treat `undefined` exactly like `null` (a direct
+ * grant).
+ */
 export interface CollectionRoleRow {
   roleId: number;
   name: string;
   kind: RoleKind;
   level: AccessLevel;
+  inheritedFromCollectionId?: number | null;
+  inheritedFromCollectionTitle?: string | null;
 }
 
 /** Body for `POST /api/admin/roles`. `kind` defaults to SHARED server-side when omitted. */

--- a/tests/components/CollectionRolesSection.test.tsx
+++ b/tests/components/CollectionRolesSection.test.tsx
@@ -161,4 +161,99 @@ describe('CollectionRolesSection', () => {
     });
     expect(mockSetRoleGrant).not.toHaveBeenCalled();
   });
+
+  describe('inherited grants', () => {
+    const inheritedGrant: CollectionRoleRow = {
+      roleId: 5,
+      name: 'family',
+      kind: 'SHARED',
+      level: 'GENERAL',
+      inheritedFromCollectionId: 77,
+      inheritedFromCollectionTitle: 'Weddings 2026',
+    };
+
+    it('renders the Inherited badge and the origin-collection hint', async () => {
+      mockListCollectionRoles.mockResolvedValue([inheritedGrant]);
+      await renderSection();
+
+      expect(await screen.findByText('Inherited')).toBeInTheDocument();
+      expect(
+        screen.getByText('Inherited from "Weddings 2026" — edit access on that collection.')
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the generic hint when the origin title is null', async () => {
+      mockListCollectionRoles.mockResolvedValue([
+        { ...inheritedGrant, inheritedFromCollectionTitle: null },
+      ]);
+      await renderSection();
+
+      expect(
+        await screen.findByText('Inherited from a parent collection — edit access there.')
+      ).toBeInTheDocument();
+    });
+
+    it('disables the level select and Remove button on an inherited row', async () => {
+      mockListCollectionRoles.mockResolvedValue([inheritedGrant]);
+      await renderSection();
+
+      const levelSelect = await screen.findByLabelText('Access level for family');
+      expect(levelSelect).toBeDisabled();
+
+      const row = levelSelect.closest('div');
+      if (!row) throw new Error('inherited-role row not found');
+      expect(within(row).getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('does not call setRoleGrant or removeRoleGrant when interacting with an inherited row', async () => {
+      mockListCollectionRoles.mockResolvedValue([inheritedGrant]);
+      await renderSection();
+
+      const levelSelect = await screen.findByLabelText('Access level for family');
+      const row = levelSelect.closest('div');
+      if (!row) throw new Error('inherited-role row not found');
+
+      fireEvent.change(levelSelect, { target: { value: 'CLIENT' } });
+      fireEvent.click(within(row).getByRole('button', { name: 'Remove' }));
+
+      expect(mockSetRoleGrant).not.toHaveBeenCalled();
+      expect(mockRemoveRoleGrant).not.toHaveBeenCalled();
+    });
+
+    it('treats absent provenance fields (undefined) as a direct, fully editable grant', async () => {
+      // Pre-deploy tolerance: the backend may not send the fields at all.
+      mockListCollectionRoles.mockResolvedValue([
+        { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
+      ]);
+      await renderSection();
+
+      const levelSelect = await screen.findByLabelText('Access level for pnwer');
+      expect(levelSelect).not.toBeDisabled();
+      expect(screen.queryByText('Inherited')).not.toBeInTheDocument();
+
+      fireEvent.change(levelSelect, { target: { value: 'CLIENT' } });
+
+      await waitFor(() => {
+        expect(mockSetRoleGrant).toHaveBeenCalledWith(1, COLLECTION_ID, 'CLIENT');
+      });
+    });
+
+    it('renders a mixed list with direct rows editable and inherited rows locked', async () => {
+      mockListCollectionRoles.mockResolvedValue([
+        { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
+        inheritedGrant,
+      ]);
+      await renderSection();
+
+      const directSelect = await screen.findByLabelText('Access level for pnwer');
+      expect(directSelect).not.toBeDisabled();
+      expect(screen.getByLabelText('Access level for family')).toBeDisabled();
+      // Exactly one Inherited badge — the direct row must not grow one.
+      expect(screen.getAllByText('Inherited')).toHaveLength(1);
+
+      const directRow = directSelect.closest('div');
+      if (!directRow) throw new Error('direct-role row not found');
+      expect(within(directRow).getByRole('button', { name: 'Remove' })).not.toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
## Why

Cross-repo reconciliation with the backend waterfall feature (edens.zac.backend#127): parent-collection role grants are materialized down to child collections as real rows in the same table the collection-edit "Role Access" panel lists. Without this change, those inherited rows look editable at the child — but removing one is silently futile, since backend propagation re-syncs it from the parent. Inherited grants must be edited at the origin collection instead.

## Pinned API contract

`GET /api/admin/collections/{id}/roles` rows gain two nullable provenance fields:

```
{ roleId, name, kind, level, inheritedFromCollectionId: number | null, inheritedFromCollectionTitle: string | null }
```

`null` (or absent — the backend may not be deployed yet) = a direct grant. Non-null = inherited; the id/title identify the origin collection holding the direct grant. The frontend treats `undefined` exactly like `null` (pre-deploy tolerance).

## What changed

- `app/types/Role.ts` — `CollectionRoleRow` gains optional `inheritedFromCollectionId` / `inheritedFromCollectionTitle`, with jsdoc documenting the undefined-tolerance rule.
- `CollectionRolesSection.tsx` — rows with non-null `inheritedFromCollectionId` render an "Inherited" badge next to the kind badge, a disabled level select and Remove button (handlers detached, so no accidental `setRoleGrant`/`removeRoleGrant`), and a hint: `Inherited from "<title>" — edit access on that collection.` (generic fallback when the title is absent). Direct rows behave exactly as before; the add-picker and create-role flows are untouched (they always create direct grants).
- `CollectionRolesSection.module.scss` — minimal additions: `.inheritedBadge` spacing, `.inheritedHint`, `:disabled` styling on `.select`.
- `tests/components/CollectionRolesSection.test.tsx` — 6 new cases: badge + hint with origin title, null-title fallback, disabled controls, no mutation calls on interaction, absent-fields row fully editable, mixed direct/inherited list.

## Dependency note

Backend provenance fields ship in edens.zac.backend#127. This UI is safe to merge before that deploys: absent fields render as direct/editable exactly as today.

Stacks into #221 via `role-management-ui`.

## Test evidence

- `npm run type-check` — 0 errors
- `npx jest tests/components/CollectionRolesSection.test.tsx tests/lib/api/roles.test.ts` — 2 suites, 29 tests passed
- Full `npx jest` — 164 suites, 2562 tests passed (no flake this run)
- `npx eslint` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)