### PR TITLE
fix(layout): pad only the trailing leftover row with blank spacers

### DIFF
--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -296,12 +296,28 @@ function createBlankLeaf(aspectRatio: number, id: number): BoxTree {
 }
 
 /**
- * Pad an under-filled row with a trailing blank spacer so its real content
- * keeps its honest share of the width instead of being scaled up to full page
- * width (one lonely image becoming a full-width hero).
+ * Pad a genuine end-of-page leftover row with a trailing blank spacer so its
+ * real content keeps its honest share of the width instead of being scaled up
+ * to full page width.
  *
- * A row is under-filled when its real width-cost is below MIN_FILL_RATIO of the
- * budget. We append a horizontal blank sibling sized to absorb the leftover
+ * Reserving space is an END-OF-PAGE concern, not an every-under-filled-row one.
+ * Greedy fill from the front means only the LAST row can be a content-exhaustion
+ * leftover; every earlier under-filled row was closed by a deliberate decision
+ * (overfill-avoidance, or the {@link MAX_ROW_IMAGES} cap) and is a complete,
+ * intentional row that must fill the width. A single-image mobile row is the
+ * canonical example — a second image would overfill, so the row is complete at
+ * one image and should fill the phone width, never sprout a spacer.
+ *
+ * Three gates decide a genuine leftover:
+ * 1. **isLastRow** — only the trailing row can be a leftover.
+ * 2. **Under-filled** — real width-cost below MIN_FILL_RATIO of the budget.
+ * 3. **Had room for more** — the row could still have absorbed another item
+ *    (a second copy of its smallest item stays within MAX_FILL_RATIO). A row
+ *    that is under-filled only because it is already at capacity (any further
+ *    item would overfill — every narrow-budget single-image row) is complete,
+ *    not a leftover, and fills the width.
+ *
+ * When padded we append a horizontal blank sibling sized to absorb the leftover
  * width; the real subtree is nested untouched, so every item keeps its aspect
  * ratio. Padding is viewport-relative, so a higher-rated item fills more of the
  * row. Solo heroes are skipped -- their full-width row is intentional.
@@ -309,11 +325,20 @@ function createBlankLeaf(aspectRatio: number, id: number): BoxTree {
  * Guards return the row unchanged when width-cost is zero/NaN or the row's
  * aspect ratio is non-positive (degenerate zero-width content).
  */
-function padRowToWidth(row: RowResult, rowWidth: number, rowIndex: number): RowResult {
+function padRowToWidth(
+  row: RowResult,
+  rowWidth: number,
+  rowIndex: number,
+  isLastRow: boolean
+): RowResult {
   const realWidthCost = getTotalCV(row.components);
   if (!(realWidthCost > 0)) return row;
+  if (!isLastRow) return row;
   if (realWidthCost / rowWidth >= MIN_FILL_RATIO) return row;
   if (row.components.length === 1 && isSoloHero(row.components[0]!, rowWidth)) return row;
+
+  const minWidthCost = Math.min(...row.components.map(getWidthCost));
+  if ((realWidthCost + minWidthCost) / rowWidth > MAX_FILL_RATIO) return row;
 
   const realAspectRatio = calculateBoxTreeAspectRatio(row.boxTree);
   if (realAspectRatio <= 0) return row;
@@ -590,7 +615,10 @@ export function buildRows(
     }
   }
 
-  return rows.map((row, rowIndex) => padRowToWidth(row, rowWidth, rowIndex));
+  const lastRowIndex = rows.length - 1;
+  return rows.map((row, rowIndex) =>
+    padRowToWidth(row, rowWidth, rowIndex, rowIndex === lastRowIndex)
+  );
 }
 
 // =============================================================================

--- a/tests/utils/rowCombination.blankPadding.test.ts
+++ b/tests/utils/rowCombination.blankPadding.test.ts
@@ -143,27 +143,31 @@ describe('buildRows blank padding', () => {
     expect(rows[0]!.boxTree.type).toBe('leaf');
   });
 
-  it('assigns deterministic, unique, stable blank ids across rows', () => {
-    // Greedy fill normally strands only the LAST row, so to get two padded rows
-    // we need MAX_ROW_IMAGES to close rows early: 24 0-star verticals (Hv 0.75)
-    // at a high-density rowWidth 16 pack 12 per row — S 9.0, fill 0.563 — so
-    // both rows close at the item cap while still under-filled.
-    const items = Array.from({ length: 24 }, (_, i) => createVerticalImage(i + 1, 0));
-    const first = buildRows(items, 16).flatMap(r => collectBlanks(r.boxTree));
-    const second = buildRows(items, 16).flatMap(r => collectBlanks(r.boxTree));
+  it('assigns a deterministic, bounded blank id to the stranded last row', () => {
+    // Greedy fill strands only the LAST row, so a page pads at most one row.
+    // Four 3-star horizontals fill row 0 (complete); a trailing 0-star horizontal
+    // strands row 1 as a genuine leftover (had room for more) and gets the blank.
+    const items = [
+      ...[1, 2, 3, 4].map(id => createHorizontalImage(id, 3)),
+      createHorizontalImage(5, 0),
+    ];
+    const first = buildRows(items, DESKTOP);
+    const blanks = first.flatMap(r => collectBlanks(r.boxTree));
 
-    // Guard the assertions below are meaningful — uniqueness is vacuous at n<2
-    expect(first.length).toBeGreaterThanOrEqual(2);
+    // Exactly one blank, on the trailing leftover row — its id is keyed off that
+    // row's index (BLANK_ID_BASE - rowIndex), so distinct rows never collide.
+    expect(blanks).toHaveLength(1);
+    expect(blanks[0]!.id).toBe(BLANK_ID_BASE - (first.length - 1));
+    expect(blanks[0]!.id).toBeLessThanOrEqual(BLANK_ID_BASE);
 
-    const ids = first.map(b => b.id);
-    expect(new Set(ids).size).toBe(ids.length);
-    for (const id of ids) expect(id).toBeLessThanOrEqual(BLANK_ID_BASE);
-    // Same input → same ids → stable React keys across renders
-    expect(second.map(b => b.id)).toEqual(ids);
+    // Same input → same id → stable React keys across renders.
+    const second = buildRows(items, DESKTOP).flatMap(r => collectBlanks(r.boxTree));
+    expect(second.map(b => b.id)).toEqual(blanks.map(b => b.id));
   });
 
-  it('pads a multi-item under-filled row without touching its internal composition', () => {
-    // Two 0-star horizontals: total Hv 2.667, fill 0.333 — under-filled
+  it('pads a multi-item under-filled leftover without touching its internal composition', () => {
+    // Two 0-star horizontals: total Hv 2.667, fill 0.333, room for more — a
+    // genuine leftover (the only row is the last row).
     const items = [createHorizontalImage(1, 0), createHorizontalImage(2, 0)];
     const rows = buildRows(items, DESKTOP);
 
@@ -176,5 +180,41 @@ describe('buildRows blank padding', () => {
       .reduce((sum, s) => sum + s.width, 0);
     const expectedShare = items.reduce((sum, i) => sum + getWidthCost(i), 0) / DESKTOP;
     expect(realTotal / 1000).toBeCloseTo(expectedShare, 5);
+  });
+
+  it('never pads single-image mobile rows — every tile fills the width', () => {
+    // The reported regression: at the narrow mobile budget (rowWidth 2) each
+    // tile is its own row. A second tile would overfill, so every row is
+    // COMPLETE at one image and must fill the phone width — no blank spacer,
+    // not even on the last tile (it is at capacity, not a leftover).
+    const items = [1, 2, 3].map(id => createVerticalImage(id, 4));
+    const rows = buildRows(items, 2);
+
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.boxTree.type).toBe('leaf');
+      expect(collectBlanks(row.boxTree)).toHaveLength(0);
+    }
+  });
+
+  it('does not pad an under-filled non-last row — only the trailing leftover reserves space', () => {
+    // At high density (rowWidth 16) the MAX_ROW_IMAGES cap closes row 0 early
+    // while still under-filled. That row is complete-by-cap, not a leftover, so
+    // it fills the width; only the final stranded row may pad.
+    const items = Array.from({ length: 24 }, (_, i) => createVerticalImage(i + 1, 0));
+    const rows = buildRows(items, 16);
+
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    const lastIdx = rows.length - 1;
+    for (const [i, row] of rows.entries()) {
+      if (i !== lastIdx) {
+        expect(collectBlanks(row.boxTree)).toHaveLength(0);
+      }
+    }
+
+    // The accepted trade-off, pinned: the trailing row in this same scenario IS
+    // a leftover (under-filled with room for more), so it alone gets the blank —
+    // an identical-content cap-closed row above it stretches to full width.
+    expect(collectBlanks(rows[lastIdx]!.boxTree)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem
Blank-spacer padding (#216) fired on **every** under-filled row. At narrow mobile budgets each tile is its own row — complete at one image, since a second would overfill — yet it was treated as under-filled and got a trailing spacer instead of filling the phone width (reported via screenshot).

## Fix
`padRowToWidth` now pads only a **genuine end-of-page leftover**, gated three ways:
1. **isLastRow** — greedy fill from the front means only the trailing row can be a content-exhaustion leftover; every earlier row was closed deliberately.
2. **Under-filled** — real width-cost below `MIN_FILL_RATIO` of the budget (unchanged).
3. **Had room for more** — a second copy of the row's smallest item must still fit within `MAX_FILL_RATIO`; a row that is under-filled only because it is at capacity is complete, not a leftover.

## Verification
- `tsc --noEmit` clean; full `rowCombination*` suite 212/212 green, including two new regression tests: the exact `rowWidth=2` mobile case, and the last-row-only rule at high density.
- Independent adversarial review (probe-verified) confirmed correctness of the fix.

## Known, pinned trade-off
A `MAX_ROW_IMAGES`-capped mid-page row renders full width while an identical trailing row pads — same fill ratio, different rendering by page position. This is asserted explicitly in the 24-item test so it can't silently flip. If it proves visually annoying, the fix is to let gate 3 run on every row instead of gating on `isLastRow`; filed as a follow-up rather than blocking the mobile regression fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)