### PR TITLE
test(api): pin collections fixture timestamps to kill parallel-load flake

### DIFF
--- a/tests/lib/api/collections.test.ts
+++ b/tests/lib/api/collections.test.ts
@@ -30,6 +30,10 @@ const mockSuccessResponse = (data: unknown) => ({
 });
 
 // Test fixtures
+// Fixed timestamps keep the fixture deterministic: tests that build a collection twice (once for
+// the mocked response, once for the expected value) must get byte-identical objects. `new Date()`
+// straddled a millisecond boundary under full-suite CPU load, flaking the toEqual comparisons.
+const FIXTURE_TIMESTAMP = '2026-01-01T00:00:00.000Z';
 const createCollection = (id: number, overrides?: Partial<CollectionModel>): CollectionModel => ({
   id,
   slug: `collection-${id}`,
@@ -38,8 +42,8 @@ const createCollection = (id: number, overrides?: Partial<CollectionModel>): Col
   type: CollectionType.PORTFOLIO,
   visibility: CollectionVisibility.LISTED,
   locations: [],
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
+  createdAt: FIXTURE_TIMESTAMP,
+  updatedAt: FIXTURE_TIMESTAMP,
   ...overrides,
 });
 


### PR DESCRIPTION
## Root cause
`createCollection` stamped `createdAt`/`updatedAt` with `new Date().toISOString()`. The `saveCollectionFromTag` test builds the fixture twice — once for the mocked response, once for the expected value — with an `await` between. Under CPU load the two clock reads straddle a millisecond and `toEqual` fails with a 1 ms timestamp mismatch. Not shared mock state, not fetch cross-talk (Jest workers are separate processes; all 11 reproduced failures hit the identical line).

## Fix
A fixed `FIXTURE_TIMESTAMP` constant — the fixture is now byte-identical on every call, so no future double-call can flake either. Test-only; no production code touched.

## Verification
- Before: 11 failures in 48 CPU-contended runs (~23%), all at the same assertion.
- After: **0 failures in 100 contended runs**; full suite green at default workers (163 suites / 2546 tests).

Separate latent flakes surfaced during contention testing (SendMessageButton, useCollectionEdit.buffer, MenuDropdown) are distinct root causes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)