### PR TITLE
chore(dev): add verify-preview server config and ignore .next-verify

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -10,6 +10,16 @@
       "env": {
         "NEXT_BUILD_DIR": ".next-preview"
       }
+    },
+    {
+      "name": "Verify Preview",
+      "runtimeExecutable": "/opt/homebrew/bin/node",
+      "runtimeArgs": ["node_modules/.bin/next", "dev", "-H", "0.0.0.0", "--port", "3002"],
+      "port": 3002,
+      "autoPort": false,
+      "env": {
+        "NEXT_BUILD_DIR": ".next-verify"
+      }
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ dist
 # next.js
 /.next/
 /.next-preview/
+/.next-verify/
 /out/
 
 # production

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,9 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     ".next-preview/types/**/*.ts",
-    ".next-preview/dev/types/**/*.ts"
+    ".next-preview/dev/types/**/*.ts",
+    ".next-verify/types/**/*.ts",
+    ".next-verify/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules", "**/__tests__/**", "old/tests/**", "jest.setup.ts", "jest.config.mjs"]
 }


### PR DESCRIPTION
Adds a third `launch.json` dev-server entry — **Verify Preview**, port 3002, `NEXT_BUILD_DIR=.next-verify` — so automated verification runs get their own build dir without evicting the port-3000 user session or the port-3001 preview server. `tsconfig.json` picks up the generated `.next-verify` types (mirroring the existing `.next-preview` entries) and `.gitignore` excludes the build dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)