### PR TITLE
refactor(roles): remove RoleKind from admin UI (RBAC phase-2, deploy first)

### DIFF
--- a/app/(admin)/admin/roles/RolesPageClient.tsx
+++ b/app/(admin)/admin/roles/RolesPageClient.tsx
@@ -9,19 +9,18 @@ import { FormError } from '@/app/components/ui/Field/FormError';
 import { Input } from '@/app/components/ui/Field/Input';
 import { ApiError } from '@/app/lib/api/core';
 import { createRole, listRoles } from '@/app/lib/api/roles';
-import { type RoleKind, type RoleSummary } from '@/app/types/Role';
+import { type RoleSummary } from '@/app/types/Role';
 
 import styles from './roles.module.scss';
 
 /**
  * Admin roles list + create form. A user joins roles to inherit their per-collection grants
- * (managed on each role's detail page). SHARED roles are admin-curated; PERSONAL roles were
- * auto-created per user by the access migration and are read-mostly.
+ * (managed on each role's detail page). Roles are admin-curated groups of users sharing the same
+ * collection grants.
  */
 export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] }) {
   const [roles, setRoles] = useState<RoleSummary[]>(initialRoles);
   const [name, setName] = useState('');
-  const [kind, setKind] = useState<RoleKind>('SHARED');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -34,7 +33,7 @@ export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] 
     }
     try {
       setSubmitting(true);
-      await createRole({ name: name.trim(), kind });
+      await createRole({ name: name.trim() });
       setRoles(await listRoles());
       setName('');
     } catch (error_) {
@@ -68,18 +67,6 @@ export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] 
             disabled={submitting}
           />
         </Field>
-        <Field label="Type" htmlFor="role-kind">
-          <select
-            id="role-kind"
-            className={styles.select}
-            value={kind}
-            onChange={e => setKind(e.target.value as RoleKind)}
-            disabled={submitting}
-          >
-            <option value="SHARED">Shared</option>
-            <option value="PERSONAL">Personal</option>
-          </select>
-        </Field>
         <Button type="submit" loading={submitting}>
           {submitting ? 'Creating...' : 'Create role'}
         </Button>
@@ -92,7 +79,6 @@ export function RolesPageClient({ initialRoles }: { initialRoles: RoleSummary[] 
           <li key={r.id} className={styles.roleRow}>
             <Link href={`/admin/roles/${r.id}`} className={styles.roleLink}>
               <span className={styles.roleName}>{r.name}</span>
-              <span className={styles.kindBadge}>{r.kind}</span>
             </Link>
           </li>
         ))}

--- a/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
+++ b/app/(admin)/admin/roles/[roleId]/RoleDetailClient.tsx
@@ -109,9 +109,7 @@ export function RoleDetailClient({ initialRole }: { initialRole: RoleDetail }) {
           &lt;- Roles
         </Link>
         <div className={styles.titleRow}>
-          <h1 className={styles.title}>
-            {role.name} <span className={styles.kindBadge}>{role.kind}</span>
-          </h1>
+          <h1 className={styles.title}>{role.name}</h1>
           <Button variant="danger" size="sm" onClick={onDeleteRole}>
             Delete role
           </Button>

--- a/app/(admin)/admin/roles/roles.module.scss
+++ b/app/(admin)/admin/roles/roles.module.scss
@@ -88,16 +88,6 @@
   font-weight: 500;
 }
 
-.kindBadge {
-  flex: 0 0 auto;
-  font-size: var(--text-xs);
-  letter-spacing: 0.04em;
-  padding: 2px var(--space-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-1);
-  color: var(--color-fg-muted, var(--color-fg));
-}
-
 .empty {
   font-size: var(--text-sm);
   color: var(--color-fg-muted, var(--color-fg));

--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
@@ -30,7 +30,8 @@ interface CollectionRolesSectionProps {
  * which roles can view this collection, at what level (GENERAL = view; CLIENT =
  * download/tag/star). Changes save immediately via the existing role-grant endpoints, and every
  * mutation re-fetches the grant list so the view stays authoritative. The add/create controls
- * offer SHARED roles only; per-user access is granted by adding the user to a role instead.
+ * offer any role not already granted; per-user access is granted by adding the user to a role
+ * instead.
  *
  * Grants inherited from a parent collection (waterfall provenance on the row) render read-only:
  * removing one here would just re-sync from the parent, so they are edited at the origin
@@ -61,7 +62,7 @@ export function CollectionRolesSection({
   }, [collectionId]);
 
   const grantedIds = new Set(grants.map(g => g.roleId));
-  const grantableRoles = allRoles.filter(r => r.kind === 'SHARED' && !grantedIds.has(r.id));
+  const grantableRoles = allRoles.filter(r => !grantedIds.has(r.id));
 
   async function refresh() {
     setGrants(await listCollectionRoles(collectionId));
@@ -95,7 +96,7 @@ export function CollectionRolesSection({
     if (!name) return;
     setError(null);
     try {
-      const created = await createRole({ name, kind: 'SHARED' });
+      const created = await createRole({ name });
       if (created) {
         await setRoleGrant(created.id, collectionId, createLevel);
       }
@@ -129,7 +130,7 @@ export function CollectionRolesSection({
           <Fragment key={g.roleId}>
             <div className={styles.row}>
               <span className={styles.rowName}>
-                {g.name} <span className={styles.kindBadge}>{g.kind}</span>
+                {g.name}
                 {inherited && (
                   <span className={`${styles.kindBadge} ${styles.inheritedBadge}`}>Inherited</span>
                 )}

--- a/app/components/UserForm/UserForm.module.scss
+++ b/app/components/UserForm/UserForm.module.scss
@@ -33,7 +33,7 @@
   margin-top: var(--space-2);
 }
 
-.collections {
+.roles {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -41,19 +41,19 @@
   border-top: 1px solid var(--color-border);
 }
 
-.collectionsHeading {
+.rolesHeading {
   margin: 0;
   font-size: var(--text-md);
   font-weight: 600;
 }
 
-.collectionsEmpty {
+.rolesEmpty {
   margin: 0;
   font-size: var(--text-sm);
   color: var(--color-fg-muted);
 }
 
-.collectionRow {
+.roleRow {
   display: flex;
   align-items: center;
   gap: var(--space-3);

--- a/app/components/UserForm/UserForm.tsx
+++ b/app/components/UserForm/UserForm.tsx
@@ -209,13 +209,11 @@ export function UserForm(props: UserFormProps) {
       )}
 
       {isEdit && (
-        <section className={styles.collections}>
-          <h3 className={styles.collectionsHeading}>Roles</h3>
-          {userRoles.length === 0 && (
-            <p className={styles.collectionsEmpty}>Not in any roles yet.</p>
-          )}
+        <section className={styles.roles}>
+          <h3 className={styles.rolesHeading}>Roles</h3>
+          {userRoles.length === 0 && <p className={styles.rolesEmpty}>Not in any roles yet.</p>}
           {userRoles.map(r => (
-            <div key={r.roleId} className={styles.collectionRow}>
+            <div key={r.roleId} className={styles.roleRow}>
               <span>{r.name}</span>
               <Button variant="ghost" size="sm" type="button" onClick={() => removeRole(r.roleId)}>
                 Remove
@@ -223,7 +221,7 @@ export function UserForm(props: UserFormProps) {
             </div>
           ))}
           {availableRoles.length > 0 && (
-            <div className={styles.collectionRow}>
+            <div className={styles.roleRow}>
               <select value={addRoleId} onChange={e => setAddRoleId(e.target.value)}>
                 <option value="">Add to role...</option>
                 {availableRoles.map(r => (

--- a/app/lib/api/roles.ts
+++ b/app/lib/api/roles.ts
@@ -22,7 +22,7 @@ import {
 
 const BASE = '/roles';
 
-/** List all roles (SHARED before PERSONAL, then by name). `[]` when the endpoint yields no body. */
+/** List all roles, ordered by name. `[]` when the endpoint yields no body. */
 export async function listRoles(): Promise<RoleSummary[]> {
   return (await fetchAdminGetApi<RoleSummary[]>(BASE)) ?? [];
 }

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -10,14 +10,10 @@ import { type CollectionRole } from '@/app/types/Auth';
 /** Access a role grants on a collection. GENERAL = view-only; CLIENT = download + tag + star. */
 export type AccessLevel = CollectionRole;
 
-/** How a role came to exist. PERSONAL = auto-migrated per-user default; SHARED = admin-curated. */
-export type RoleKind = 'PERSONAL' | 'SHARED';
-
 /** A role in the admin list (`GET /api/admin/roles`). */
 export interface RoleSummary {
   id: number;
   name: string;
-  kind: RoleKind;
 }
 
 /** One member of a role (`RoleDetail.members`). `email`/`name` are null for tag-only identities. */
@@ -38,7 +34,6 @@ export interface RoleCollectionRow {
 export interface RoleDetail {
   id: number;
   name: string;
-  kind: RoleKind;
   members: RoleMemberRow[];
   collections: RoleCollectionRow[];
 }
@@ -47,7 +42,6 @@ export interface RoleDetail {
 export interface UserRoleRow {
   roleId: number;
   name: string;
-  kind: RoleKind;
 }
 
 /**
@@ -62,14 +56,12 @@ export interface UserRoleRow {
 export interface CollectionRoleRow {
   roleId: number;
   name: string;
-  kind: RoleKind;
   level: AccessLevel;
   inheritedFromCollectionId?: number | null;
   inheritedFromCollectionTitle?: string | null;
 }
 
-/** Body for `POST /api/admin/roles`. `kind` defaults to SHARED server-side when omitted. */
+/** Body for `POST /api/admin/roles`. */
 export interface CreateRoleRequest {
   name: string;
-  kind?: RoleKind;
 }

--- a/app/utils/galleryAccess.ts
+++ b/app/utils/galleryAccess.ts
@@ -2,7 +2,7 @@
  * Pure capability helpers over the resolved principal + the admin (editMode) signal.
  * Admin is the perimeter, surfaced to the client tree as `editMode` (localhost ?manage=1) — a
  * logged-in user is never admin. A CLIENT's per-collection powers come from `me.galleries`
- * (the user_collection memberships surfaced by /api/auth/me).
+ * (the role_collection grants surfaced by /api/auth/me).
  */
 import { type GalleryMembership, type MeResponse } from '@/app/types/Auth';
 import { type CollectionModel, CollectionType } from '@/app/types/Collection';
@@ -30,8 +30,9 @@ export function isClientOfCollection(
 
 /**
  * True when the viewer may download from this collection. Downloading is a *capability*, not a
- * collection *type*: the backend authorizes downloads by role (a `user_collection` CLIENT
- * membership on ANY collection), so the UI must too. The union below keeps both paths working:
+ * collection *type*: the backend authorizes downloads by role (a role_collection CLIENT grant on
+ * ANY collection, surfaced by /api/auth/me), so the UI must too. The union below keeps both paths
+ * working:
  *   - `CLIENT_GALLERY` type → the existing anonymous password-cookie client (who has no `me`);
  *   - a logged-in CLIENT membership → downloads on any collection type (e.g. a PORTFOLIO shared
  *     with a specific client), matching the admin "Client (download/tag)" grant.

--- a/tests/components/CollectionRolesSection.test.tsx
+++ b/tests/components/CollectionRolesSection.test.tsx
@@ -33,14 +33,13 @@ const mockRemoveRoleGrant = rolesApi.removeRoleGrant as jest.MockedFunction<
 const COLLECTION_ID = 20;
 
 const grants: CollectionRoleRow[] = [
-  { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
-  { roleId: 2, name: 'ken@x.com', kind: 'PERSONAL', level: 'CLIENT' },
+  { roleId: 1, name: 'pnwer', level: 'GENERAL' },
+  { roleId: 2, name: 'ken@x.com', level: 'CLIENT' },
 ];
 
 const allRoles: RoleSummary[] = [
-  { id: 1, name: 'pnwer', kind: 'SHARED' }, // already granted — excluded from the picker
-  { id: 3, name: 'power', kind: 'SHARED' }, // grantable
-  { id: 4, name: 'ken@x.com', kind: 'PERSONAL' }, // PERSONAL — excluded from the picker
+  { id: 1, name: 'pnwer' }, // already granted — excluded from the picker
+  { id: 3, name: 'power' }, // grantable
 ];
 
 beforeEach(() => {
@@ -61,14 +60,11 @@ async function renderSection(title = 'Fall Wedding') {
 }
 
 describe('CollectionRolesSection', () => {
-  it('renders the granted roles with kind badge and current level', async () => {
+  it('renders the granted roles and current level', async () => {
     await renderSection();
 
     expect(await screen.findByText('pnwer')).toBeInTheDocument();
     expect(screen.getByText('ken@x.com')).toBeInTheDocument();
-    expect(screen.getByText('SHARED')).toBeInTheDocument();
-    // PERSONAL appears once — the granted row badge (the picker excludes PERSONAL roles).
-    expect(screen.getByText('PERSONAL')).toBeInTheDocument();
     expect(screen.getByLabelText('Access level for pnwer')).toHaveValue('GENERAL');
     expect(screen.getByLabelText('Access level for ken@x.com')).toHaveValue('CLIENT');
   });
@@ -99,13 +95,12 @@ describe('CollectionRolesSection', () => {
     });
   });
 
-  it('excludes PERSONAL and already-granted roles from the add picker', async () => {
+  it('excludes already-granted roles from the add picker', async () => {
     await renderSection();
     const picker = await screen.findByLabelText('Add a role');
 
     expect(within(picker).getByRole('option', { name: 'power' })).toBeInTheDocument();
     expect(within(picker).queryByRole('option', { name: 'pnwer' })).not.toBeInTheDocument();
-    expect(within(picker).queryByRole('option', { name: 'ken@x.com' })).not.toBeInTheDocument();
   });
 
   it('changes a granted role level via setRoleGrant', async () => {
@@ -131,8 +126,8 @@ describe('CollectionRolesSection', () => {
     });
   });
 
-  it('creates a SHARED role named after the collection, then grants it', async () => {
-    mockCreateRole.mockResolvedValue({ id: 9, name: 'Fall Wedding', kind: 'SHARED' });
+  it('creates a role named after the collection, then grants it', async () => {
+    mockCreateRole.mockResolvedValue({ id: 9, name: 'Fall Wedding' });
     await renderSection();
 
     const nameInput = await screen.findByLabelText('Create role for this collection');
@@ -144,7 +139,7 @@ describe('CollectionRolesSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
     await waitFor(() => {
-      expect(mockCreateRole).toHaveBeenCalledWith({ name: 'Fall Wedding', kind: 'SHARED' });
+      expect(mockCreateRole).toHaveBeenCalledWith({ name: 'Fall Wedding' });
       expect(mockSetRoleGrant).toHaveBeenCalledWith(9, COLLECTION_ID, 'CLIENT');
     });
   });
@@ -166,7 +161,6 @@ describe('CollectionRolesSection', () => {
     const inheritedGrant: CollectionRoleRow = {
       roleId: 5,
       name: 'family',
-      kind: 'SHARED',
       level: 'GENERAL',
       inheritedFromCollectionId: 77,
       inheritedFromCollectionTitle: 'Weddings 2026',
@@ -223,7 +217,7 @@ describe('CollectionRolesSection', () => {
     it('treats absent provenance fields (undefined) as a direct, fully editable grant', async () => {
       // Pre-deploy tolerance: the backend may not send the fields at all.
       mockListCollectionRoles.mockResolvedValue([
-        { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
+        { roleId: 1, name: 'pnwer', level: 'GENERAL' },
       ]);
       await renderSection();
 
@@ -240,7 +234,7 @@ describe('CollectionRolesSection', () => {
 
     it('renders a mixed list with direct rows editable and inherited rows locked', async () => {
       mockListCollectionRoles.mockResolvedValue([
-        { roleId: 1, name: 'pnwer', kind: 'SHARED', level: 'GENERAL' },
+        { roleId: 1, name: 'pnwer', level: 'GENERAL' },
         inheritedGrant,
       ]);
       await renderSection();

--- a/tests/components/CollectionRolesSection.test.tsx
+++ b/tests/components/CollectionRolesSection.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for CollectionRolesSection — the collection-edit "Role Access" panel (the inverse of the
  * role-detail page). Renders the roles granting a collection, changes a level, revokes, adds an
- * existing SHARED role, and creates-and-grants a new SHARED role in one action. All mutations
+ * existing role, and creates-and-grants a new role in one action. All mutations
  * save immediately and re-fetch the grant list.
  */
 

--- a/tests/components/UserForm.test.tsx
+++ b/tests/components/UserForm.test.tsx
@@ -211,7 +211,7 @@ describe('UserForm', () => {
 
     it('adding a role calls addUserToRole and refreshes the membership list', async () => {
       mockListUserRoles.mockResolvedValue([]);
-      mockListRoles.mockResolvedValue([{ id: 3, name: 'power', kind: 'SHARED' }]);
+      mockListRoles.mockResolvedValue([{ id: 3, name: 'power' }]);
       mockAddUserToRole.mockResolvedValue();
 
       render(<UserForm mode="edit" user={user} onSuccess={onSuccess} onCancel={onCancel} />);
@@ -222,7 +222,7 @@ describe('UserForm', () => {
       });
 
       // After adding, the refresh reads back the joined role.
-      mockListUserRoles.mockResolvedValue([{ roleId: 3, name: 'power', kind: 'SHARED' }]);
+      mockListUserRoles.mockResolvedValue([{ roleId: 3, name: 'power' }]);
 
       fireEvent.change(screen.getByDisplayValue('Add to role...'), { target: { value: '3' } });
       fireEvent.click(screen.getByRole('button', { name: /^add$/i }));

--- a/tests/lib/api/roles.test.ts
+++ b/tests/lib/api/roles.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => jest.clearAllMocks());
 
 describe('listRoles', () => {
   it('GETs /roles and returns the array', async () => {
-    const roles = [{ id: 1, name: 'power', kind: 'SHARED' }];
+    const roles = [{ id: 1, name: 'power' }];
     (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(roles);
     expect(await listRoles()).toEqual(roles);
     expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/roles');
@@ -48,7 +48,7 @@ describe('listRoles', () => {
 
 describe('getRole', () => {
   it('GETs /roles/{id} and returns the detail', async () => {
-    const detail = { id: 1, name: 'power', kind: 'SHARED', members: [], collections: [] };
+    const detail = { id: 1, name: 'power', members: [], collections: [] };
     (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(detail);
     expect(await getRole(1)).toEqual(detail);
     expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/roles/1');
@@ -57,12 +57,11 @@ describe('getRole', () => {
 
 describe('createRole', () => {
   it('POSTs /roles with the body', async () => {
-    const created = { id: 9, name: 'power', kind: 'SHARED' };
+    const created = { id: 9, name: 'power' };
     (core.fetchAdminPostJsonApi as jest.Mock).mockResolvedValue(created);
-    expect(await createRole({ name: 'power', kind: 'SHARED' })).toEqual(created);
+    expect(await createRole({ name: 'power' })).toEqual(created);
     expect(core.fetchAdminPostJsonApi).toHaveBeenCalledWith('/roles', {
       name: 'power',
-      kind: 'SHARED',
     });
   });
 
@@ -130,7 +129,7 @@ describe('membership', () => {
 
 describe('listCollectionRoles', () => {
   it('GETs /collections/{id}/roles and returns the array', async () => {
-    const rows = [{ roleId: 1, name: 'power', kind: 'SHARED', level: 'GENERAL' }];
+    const rows = [{ roleId: 1, name: 'power', level: 'GENERAL' }];
     (core.fetchAdminGetApi as jest.Mock).mockResolvedValue(rows);
     expect(await listCollectionRoles(20)).toEqual(rows);
     expect(core.fetchAdminGetApi).toHaveBeenCalledWith('/collections/20/roles');


### PR DESCRIPTION
## What
Removes the `RoleKind` (PERSONAL|SHARED) data shape from the frontend — types, the roles admin pages, and the collection "Role Access" picker — so the backend can retire the concept.

## Why (RBAC phase-2)
Phase-2 retires the V45 `user:<id>` PERSONAL scaffolding roles. This FE change is the prerequisite: it stops the UI depending on `kind`. The one behavioral change is `CollectionRolesSection`'s add-role picker, which previously filtered to `kind === 'SHARED'` and now offers any not-already-granted role.

## Changes
- `app/types/Role.ts`: delete `RoleKind`; drop `kind` from `RoleSummary`, `RoleDetail`, `UserRoleRow`, `CollectionRoleRow`, `CreateRoleRequest`.
- Roles admin (`RolesPageClient`, `RoleDetailClient`): remove the "Type" select (incl. the PERSONAL option), the kind badges, and the `kind` arg to `createRole`.
- `CollectionRolesSection`: picker filter `kind === 'SHARED' && !granted` → `!granted`; remove badge + `kind:'SHARED'` arg.
- Comment/CSS cleanup (`roles.ts`, `galleryAccess.ts` comments; `UserForm` `styles.collection*` → `roles*`). Access LOGIC is byte-identical.

## Safety / tests
- Access-preserving: `galleryAccess.ts` `isClient`/`canDownload`/`findMembership` bodies unchanged (only comments).
- `npm test` = 2564 pass / 164 suites; `tsc --noEmit` clean. Independently reviewed (spec + code).

## Deploy ordering
**Deploy this FIRST**, before the backend RoleKind cleanup PR — the FE must stop needing `kind` before the BE stops emitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
