### PR TITLE
fix(reorder): materialize chronological order on reorder entry; give GIFs a capture date

### DIFF
--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -25,6 +25,7 @@ import {
   extractCollectionFilterOptions,
   hasAnyActiveFilter,
   hasFilterableOptions,
+  isDateable,
   isImageContent,
   mergeDateSortedImages,
 } from '@/app/utils/contentFilter';
@@ -247,7 +248,7 @@ export default function CollectionPageClient({
         ? processed
         : mergeDateSortedImages(
             processed,
-            sortByDate(processed.filter(isImageContent), filterState.dateSortDirection)
+            sortByDate(processed.filter(isDateable), filterState.dateSortDirection)
           );
 
     if (!selectsEnabled || pinnedSelectedIds.length === 0) {

--- a/app/components/ContentCollection/edit/EditModeLayer.module.scss
+++ b/app/components/ContentCollection/edit/EditModeLayer.module.scss
@@ -5,6 +5,21 @@
 }
 
 // Dismissible error banner — fixed just above the EditBar, edit mode only.
+// Neutral sibling of .errorBanner: an instruction line pinned above the EditBar, used by modes
+// whose only affordance is a grid click (capture-date pick).
+.hintBanner {
+  position: fixed;
+  inset-inline: 0;
+  bottom: calc(var(--edit-bar-height, 5rem) + env(safe-area-inset-bottom));
+  z-index: var(--z-modal-controls, 1002);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-sunken);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+  text-align: center;
+}
+
 .errorBanner {
   position: fixed;
   inset-inline: 0;

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -300,6 +300,7 @@ export default function EditModeLayer({
           selectedIds={edit.selectedIds}
           selectedImages={edit.contentToEdit}
           currentCollectionId={collection.id}
+          collectionImages={allImages}
         />
       )}
 

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -155,6 +155,9 @@ export default function EditModeLayer({
 
   const allImages = useMemo(() => allContent.filter(isImageContent), [allContent]);
 
+  /** Whether any image can seed a GIF's capture date — drives the metadata sheet's pick button. */
+  const hasDatedImages = useMemo(() => allImages.some(img => img.captureDate), [allImages]);
+
   const criteria = useMemo(() => buildCollectionCriteria(filterState), [filterState]);
 
   const hasActiveFilters = useMemo(() => hasAnyActiveFilter(filterState), [filterState]);
@@ -268,6 +271,13 @@ export default function EditModeLayer({
         </div>
       )}
 
+      {/* Pick mode arrives with the metadata sheet already closed, so the grid needs to say why. */}
+      {edit.manageMode === 'pick-date' && (
+        <div className={styles.hintBanner} role="status">
+          Click an image to copy its capture date.
+        </div>
+      )}
+
       {edit.manageMode === 'edit' && <CollectionEditSheet edit={edit} twoColumn={twoColumn} />}
 
       {!edit.editingContent && !edit.isTextBlockModalOpen && (
@@ -300,7 +310,8 @@ export default function EditModeLayer({
           selectedIds={edit.selectedIds}
           selectedImages={edit.contentToEdit}
           currentCollectionId={collection.id}
-          collectionImages={allImages}
+          // Gated on there being a date to copy at all — an empty pick mode would be a dead end.
+          onPickCaptureDate={hasDatedImages ? edit.startCaptureDatePick : undefined}
         />
       )}
 

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -23,6 +23,7 @@ import {
   buildCollectionCriteria,
   type ContentFilterCriteria,
   hasAnyActiveFilter,
+  isDateable,
   isImageContent,
   mergeDateSortedImages,
 } from '@/app/utils/contentFilter';
@@ -172,7 +173,7 @@ export default function EditModeLayer({
       liveCollection.displayMode
     );
     if (filterState.dateSortDirection === 'off') return processed;
-    const sorted = sortByDate(processed.filter(isImageContent), filterState.dateSortDirection);
+    const sorted = sortByDate(processed.filter(isDateable), filterState.dateSortDirection);
     return mergeDateSortedImages(processed, sorted);
   }, [
     filteredContent,

--- a/app/components/ContentCollection/edit/hooks/useCaptureDateSelection.ts
+++ b/app/components/ContentCollection/edit/hooks/useCaptureDateSelection.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
+
+import { getCollectionUpdateMetadata } from '@/app/lib/api/collections';
+import { updateGif } from '@/app/lib/api/content';
+import { collectionStorage } from '@/app/lib/storage/collectionStorage';
+import { type CollectionModel, type CollectionUpdateResponseDTO } from '@/app/types/Collection';
+import { handleApiError } from '@/app/utils/apiUtils';
+import { isContentImage } from '@/app/utils/contentTypeGuards';
+
+import { refreshCollectionAfterOperation, revalidateCollectionCache } from '../collectionEditUtils';
+
+interface UseCaptureDateSelectionParams {
+  collection: CollectionModel | null;
+  setCurrentState: Dispatch<SetStateAction<CollectionUpdateResponseDTO | null>>;
+  setOperationLoading: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+}
+
+/**
+ * Grid-click pick mode for copying a capture date onto a GIF/MP4.
+ *
+ * A GIF carries no EXIF, so its `captureDate` is sourced from a reference image the user picks
+ * off the manage grid. `captureDateTargetId` holds the GIF awaiting a source; while it is set the
+ * manage surface is in `pick-date` mode and every grid click routes here instead of opening the
+ * metadata editor.
+ *
+ * Like {@link useCoverImageSelection}, the pick persists immediately — there is no staged state to
+ * return to, since reaching the grid means the metadata sheet has already closed.
+ */
+export function useCaptureDateSelection({
+  collection,
+  setCurrentState,
+  setOperationLoading,
+  setError,
+}: UseCaptureDateSelectionParams) {
+  const [captureDateTargetId, setCaptureDateTargetId] = useState<number | null>(null);
+
+  const handleCaptureDateSourceClick = useCallback(
+    async (imageId: number) => {
+      if (!collection || captureDateTargetId === null) return;
+
+      const source = (collection.content ?? []).find(block => block.id === imageId);
+      const captureDate = source && isContentImage(source) ? source.captureDate : null;
+
+      // Undated images, text blocks and other GIFs are not valid sources. Stay in pick mode so
+      // the user can simply click a different block.
+      if (!captureDate) {
+        setError('That block has no capture date - pick an image that does.');
+        return;
+      }
+
+      const gifId = captureDateTargetId;
+      setCaptureDateTargetId(null);
+
+      try {
+        setOperationLoading(true);
+        setError(null);
+
+        const response = await refreshCollectionAfterOperation(
+          collection.slug,
+          async () => {
+            await updateGif(gifId, { captureDate });
+          },
+          getCollectionUpdateMetadata,
+          collectionStorage
+        );
+        setCurrentState(response);
+        await revalidateCollectionCache(collection.slug);
+      } catch (error) {
+        setError(handleApiError(error, 'Failed to copy the capture date.'));
+      } finally {
+        setOperationLoading(false);
+      }
+    },
+    [collection, captureDateTargetId, setCurrentState, setOperationLoading, setError]
+  );
+
+  return {
+    captureDateTargetId,
+    setCaptureDateTargetId,
+    handleCaptureDateSourceClick,
+  };
+}

--- a/app/components/ContentCollection/edit/hooks/useContentReordering.ts
+++ b/app/components/ContentCollection/edit/hooks/useContentReordering.ts
@@ -73,16 +73,19 @@ export function useContentReordering({
     });
   }, []);
 
-  const handleEnterReorderMode = useCallback(() => {
-    if (!processedContent) return;
-    onExitMultiSelect();
-    setReorderState({
-      active: true,
-      originalOrder: processedContent.map(c => c.id),
-      moves: [],
-      pickedUpImageId: null,
-    });
-  }, [processedContent, onExitMultiSelect]);
+  const handleEnterReorderMode = useCallback(
+    (baseOrder?: number[]) => {
+      if (!processedContent) return;
+      onExitMultiSelect();
+      setReorderState({
+        active: true,
+        originalOrder: baseOrder ?? processedContent.map(c => c.id),
+        moves: [],
+        pickedUpImageId: null,
+      });
+    },
+    [processedContent, onExitMultiSelect]
+  );
 
   const handleSaveReorder = useCallback(async () => {
     if (!collection || !currentState) return;

--- a/app/components/ContentCollection/edit/hooks/useImageClickHandler.ts
+++ b/app/components/ContentCollection/edit/hooks/useImageClickHandler.ts
@@ -14,6 +14,9 @@ import { manageHref } from '@/app/utils/manageUrl';
 import { handleCollectionNavigation, handleSingleImageEdit } from '../collectionEditUtils';
 
 interface UseImageClickHandlerParams {
+  /** True while a GIF is awaiting a capture-date source; every grid click routes to the pick. */
+  isPickingCaptureDate: boolean;
+  handleCaptureDateSourceClick: (imageId: number) => void;
   isSelectingCoverImage: boolean;
   isMultiSelectMode: boolean;
   handleCoverImageClick: (imageId: number) => void;
@@ -26,6 +29,8 @@ interface UseImageClickHandlerParams {
 }
 
 export function useImageClickHandler({
+  isPickingCaptureDate,
+  handleCaptureDateSourceClick,
   isSelectingCoverImage,
   isMultiSelectMode,
   handleCoverImageClick,
@@ -40,6 +45,11 @@ export function useImageClickHandler({
 
   const handleImageClick = useCallback(
     (imageId: number) => {
+      if (isPickingCaptureDate) {
+        handleCaptureDateSourceClick(imageId);
+        return;
+      }
+
       if (isSelectingCoverImage) {
         handleCoverImageClick(imageId);
         return;
@@ -63,6 +73,8 @@ export function useImageClickHandler({
       }
     },
     [
+      isPickingCaptureDate,
+      handleCaptureDateSourceClick,
       isSelectingCoverImage,
       isMultiSelectMode,
       handleCoverImageClick,

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -64,6 +64,7 @@ import {
   revalidateMetadataCache,
   toggleRelation,
 } from './collectionEditUtils';
+import { useCaptureDateSelection } from './hooks/useCaptureDateSelection';
 import { useCollectionRetype } from './hooks/useCollectionRetype';
 import { useContentReordering } from './hooks/useContentReordering';
 import { useCoverImageSelection } from './hooks/useCoverImageSelection';
@@ -79,7 +80,7 @@ function isAnimatedMediaFile(file: File): boolean {
   return ANIMATED_MEDIA_MIME_TYPES.has(file.type) || ANIMATED_MEDIA_EXTENSION_REGEX.test(file.name);
 }
 
-export type ManageMode = 'browse' | 'select' | 'reorder' | 'add' | 'edit';
+export type ManageMode = 'browse' | 'select' | 'reorder' | 'add' | 'edit' | 'pick-date';
 export type CollectionEditTab = 'info' | 'structure';
 
 export interface UseCollectionEditParams {
@@ -196,6 +197,12 @@ export interface UseCollectionEditResult {
   editingContent: EditableContent | null;
   closeEditor: () => void;
   contentToEdit: EditableContent[];
+  /**
+   * Closes the metadata sheet and puts the grid into `pick-date` mode, where clicking a dated
+   * image copies its capture date onto the GIF that was being edited. No-op unless the editor is
+   * currently open on a GIF/MP4.
+   */
+  startCaptureDatePick: () => void;
 
   handleMetadataSaveSuccess: (response: ContentImageUpdateResponse) => Promise<void>;
   handleGifSaveSuccess: (updated: ContentGifModel) => Promise<void>;
@@ -475,6 +482,28 @@ export function useCollectionEdit({
     setError,
   });
 
+  const { captureDateTargetId, setCaptureDateTargetId, handleCaptureDateSourceClick } =
+    useCaptureDateSelection({
+      collection,
+      setCurrentState,
+      setOperationLoading,
+      setError,
+    });
+
+  /**
+   * Metadata sheet -> grid: close the sheet so the GIF's capture date can be sourced by clicking a
+   * reference image. Multi-select is dropped explicitly (rather than relying on `closeEditor`,
+   * whose clear is conditional on a value this render already invalidated) so the bar lands on
+   * pick-date rather than falling back to select.
+   */
+  const startCaptureDatePick = useCallback(() => {
+    if (!editingContent || !isGifContent(editingContent)) return;
+    setCaptureDateTargetId(editingContent.id);
+    setIsMultiSelectMode(false);
+    setSelectedIds([]);
+    closeEditor();
+  }, [editingContent, closeEditor, setCaptureDateTargetId]);
+
   const {
     reorderState,
     reorderDisplayOrder,
@@ -500,6 +529,8 @@ export function useCollectionEdit({
   });
 
   const deriveManageMode = (): ManageMode => {
+    // Checked first: entering the pick clears every other mode flag, so nothing can outrank it.
+    if (captureDateTargetId !== null) return 'pick-date';
     if (reorderState.active) return 'reorder';
     if (isMultiSelectMode) return 'select';
     if (isEditSheetOpen) return 'edit';
@@ -519,9 +550,16 @@ export function useCollectionEdit({
     setIsAddMode(false);
     setIsEditSheetOpen(false);
     if (isSelectingCoverImage) setIsSelectingCoverImage(false);
+    setCaptureDateTargetId(null);
     handleCancelReorder();
     setUpdateData(seedUpdateData(latestCollectionRef.current));
-  }, [isSelectingCoverImage, setIsSelectingCoverImage, handleCancelReorder, seedUpdateData]);
+  }, [
+    isSelectingCoverImage,
+    setIsSelectingCoverImage,
+    setCaptureDateTargetId,
+    handleCancelReorder,
+    seedUpdateData,
+  ]);
 
   useEffect(() => {
     if (!enabled) resetToBrowse();
@@ -827,6 +865,8 @@ export function useCollectionEdit({
   }, [selectedIds, collection, openEditor]);
 
   const { handleImageClick } = useImageClickHandler({
+    isPickingCaptureDate: captureDateTargetId !== null,
+    handleCaptureDateSourceClick,
     isSelectingCoverImage,
     isMultiSelectMode,
     handleCoverImageClick,
@@ -1263,7 +1303,14 @@ export function useCollectionEdit({
         setOperationLoading(false);
       }
     })();
-  }, [collection, currentState, updateData, processedContent, seedUpdateData, handleEnterReorderMode]);
+  }, [
+    collection,
+    currentState,
+    updateData,
+    processedContent,
+    seedUpdateData,
+    handleEnterReorderMode,
+  ]);
   const enterAdd = useCallback(() => setIsAddMode(true), []);
   const enterEdit = useCallback(() => setIsEditSheetOpen(true), []);
   const exitToBrowse = resetToBrowse;
@@ -1272,6 +1319,11 @@ export function useCollectionEdit({
   const isLoading = isLoadingState || operationLoading;
 
   const bottomBarCells = useMemo<EditBarCell[]>(() => {
+    // Pick-date is a one-action mode: the grid click IS the commit, so Cancel is the only cell.
+    if (manageMode === 'pick-date') {
+      return [{ key: 'cancel', label: 'Cancel', onClick: resetToBrowse }];
+    }
+
     if (manageMode === 'reorder') {
       return [
         {
@@ -1528,6 +1580,7 @@ export function useCollectionEdit({
     editingContent,
     closeEditor,
     contentToEdit,
+    startCaptureDatePick,
 
     handleMetadataSaveSuccess,
     handleGifSaveSuccess,

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -50,11 +50,13 @@ import {
 import { buildLocationsDiff, convertLocationsToModels } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
 import { manageHref } from '@/app/utils/manageUrl';
+import { toChronologicalOrder } from '@/app/utils/sortByDate';
 import { buildTagsDiff, convertTagsToModels } from '@/app/utils/tagUtils';
 
 import { buildImageUpdateDiff } from '../../Metadata/metadataUtils';
 import {
   buildUpdatePayload,
+  executeReorderOperation,
   handleMultiSelectToggle as handleMultiSelectToggleUtil,
   mergeNewMetadata,
   refreshCollectionAfterOperation,
@@ -1227,6 +1229,20 @@ export function useCollectionEdit({
       try {
         setOperationLoading(true);
         setError(null);
+
+        // The true displayed (captureDate) order — what the viewer currently sees.
+        const chronoIds = toChronologicalOrder(processedContent).map(c => c.id);
+
+        // WRITE A: materialize the full order into orderIndex while still CHRONOLOGICAL. This is
+        // harmless (chronological display ignores orderIndex) and makes cancel safe. Full
+        // re-index (not a diff) so every unmoved item gets its true position persisted.
+        if (chronoIds.length > 0) {
+          const fullChanges = chronoIds.map((id, i) => ({ contentId: id, newOrderIndex: i }));
+          await executeReorderOperation(collection.id, fullChanges, collection.slug);
+        }
+
+        // WRITE B: switch to ORDERED. Done second so a failure above leaves the collection
+        // CHRONOLOGICAL and visually unchanged.
         const payload = buildUpdatePayload({ ...updateData, displayMode: 'ORDERED' }, collection);
         const response = await updateCollection(collection.id, payload);
         if (response !== null) {
@@ -1237,7 +1253,9 @@ export function useCollectionEdit({
           collectionStorage.update(response.collection.slug, response.collection);
           collectionStorage.updateFull(response.collection.slug, response);
           void revalidateCollectionCache(response.collection.slug);
-          handleEnterReorderMode();
+
+          // Seed the reorder base from the order we just persisted (not the stale processedContent).
+          handleEnterReorderMode(chronoIds);
         }
       } catch (error_) {
         setError(handleApiError(error_, 'Failed to switch to ordered mode.'));
@@ -1245,7 +1263,7 @@ export function useCollectionEdit({
         setOperationLoading(false);
       }
     })();
-  }, [collection, currentState, updateData, seedUpdateData, handleEnterReorderMode]);
+  }, [collection, currentState, updateData, processedContent, seedUpdateData, handleEnterReorderMode]);
   const enterAdd = useCallback(() => setIsAddMode(true), []);
   const enterEdit = useCallback(() => setIsEditSheetOpen(true), []);
   const exitToBrowse = resetToBrowse;

--- a/app/components/Metadata/MetadataModal.module.scss
+++ b/app/components/Metadata/MetadataModal.module.scss
@@ -144,6 +144,20 @@
   color: var(--color-on-surface-muted);
 }
 
+// Read-only value paired with a compact action button (e.g. the GIF capture date, which is
+// sourced by clicking an image on the manage grid rather than typed into a field).
+.inlineActionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.inlineActionValue {
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+  font-variant-numeric: tabular-nums;
+}
+
 .formInput,
 .formTextarea,
 .formSelect {

--- a/app/components/Metadata/MetadataModal.tsx
+++ b/app/components/Metadata/MetadataModal.tsx
@@ -7,11 +7,7 @@ import { CloseButton } from '@/app/components/ui/CloseButton/CloseButton';
 import { EditBar } from '@/app/components/ui/EditBar/EditBar';
 import { Modal } from '@/app/components/ui/Modal/Modal';
 import { type CollectionListModel, type LocationModel } from '@/app/types/Collection';
-import {
-  type ContentGifModel,
-  type ContentImageModel,
-  type ContentImageUpdateResponse,
-} from '@/app/types/Content';
+import { type ContentGifModel, type ContentImageUpdateResponse } from '@/app/types/Content';
 import {
   type ContentCameraModel,
   type ContentFilmTypeModel,
@@ -65,8 +61,11 @@ interface MetadataModalProps {
    */
   selectedImages: EditableContent[];
   currentCollectionId?: number;
-  /** Images in the current collection, offered as capture-date sources when editing a GIF/MP4. */
-  collectionImages?: ContentImageModel[];
+  /**
+   * Hands a single-GIF edit off to the manage grid's capture-date pick mode. Omitted when no image
+   * in the collection carries a date to copy.
+   */
+  onPickCaptureDate?: () => void;
 }
 
 /**
@@ -94,7 +93,7 @@ export default function MetadataModal({
   selectedIds,
   selectedImages,
   currentCollectionId,
-  collectionImages = [],
+  onPickCaptureDate,
 }: MetadataModalProps) {
   const [activeTab, setActiveTab] = useState<TabId>('info');
   const formRef = useRef<HTMLFormElement>(null);
@@ -175,7 +174,7 @@ export default function MetadataModal({
                   currentCollectionId={currentCollectionId}
                   isGif={isGif}
                   isBulkEdit={isBulkEdit}
-                  collectionImages={collectionImages}
+                  onPickCaptureDate={onPickCaptureDate}
                 />
                 <TagsPeopleSection
                   updateState={updateState}

--- a/app/components/Metadata/MetadataModal.tsx
+++ b/app/components/Metadata/MetadataModal.tsx
@@ -7,7 +7,11 @@ import { CloseButton } from '@/app/components/ui/CloseButton/CloseButton';
 import { EditBar } from '@/app/components/ui/EditBar/EditBar';
 import { Modal } from '@/app/components/ui/Modal/Modal';
 import { type CollectionListModel, type LocationModel } from '@/app/types/Collection';
-import { type ContentGifModel, type ContentImageUpdateResponse } from '@/app/types/Content';
+import {
+  type ContentGifModel,
+  type ContentImageModel,
+  type ContentImageUpdateResponse,
+} from '@/app/types/Content';
 import {
   type ContentCameraModel,
   type ContentFilmTypeModel,
@@ -61,6 +65,8 @@ interface MetadataModalProps {
    */
   selectedImages: EditableContent[];
   currentCollectionId?: number;
+  /** Images in the current collection, offered as capture-date sources when editing a GIF/MP4. */
+  collectionImages?: ContentImageModel[];
 }
 
 /**
@@ -88,6 +94,7 @@ export default function MetadataModal({
   selectedIds,
   selectedImages,
   currentCollectionId,
+  collectionImages = [],
 }: MetadataModalProps) {
   const [activeTab, setActiveTab] = useState<TabId>('info');
   const formRef = useRef<HTMLFormElement>(null);
@@ -168,6 +175,7 @@ export default function MetadataModal({
                   currentCollectionId={currentCollectionId}
                   isGif={isGif}
                   isBulkEdit={isBulkEdit}
+                  collectionImages={collectionImages}
                 />
                 <TagsPeopleSection
                   updateState={updateState}

--- a/app/components/Metadata/metadataUtils.ts
+++ b/app/components/Metadata/metadataUtils.ts
@@ -758,6 +758,7 @@ export function buildGifUpdatePayload(
   updateState: {
     title?: string | null;
     rating?: number | null;
+    captureDate?: string | null;
     collections?: ContentImageModel['collections'];
     people?: ContentImageModel['people'];
     locations?: LocationModel[];
@@ -773,6 +774,10 @@ export function buildGifUpdatePayload(
 
   if (updateState.rating !== undefined && updateState.rating !== (original.rating ?? null)) {
     payload.rating = updateState.rating ?? 0;
+  }
+
+  if ((updateState.captureDate ?? null) !== (original.captureDate ?? null)) {
+    payload.captureDate = updateState.captureDate ?? null;
   }
 
   // Collections: newValue/remove built from originalCollectionIds vs the current selection.

--- a/app/components/Metadata/sections/EssentialInfoSection.tsx
+++ b/app/components/Metadata/sections/EssentialInfoSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@/app/components/ui/Button/Button';
 import { LOCATION_ADD_NEW_FIELDS } from '@/app/components/ui/Dropdown/commonAddNewFields';
 import Dropdown from '@/app/components/ui/Dropdown/Dropdown';
 import { Checkbox } from '@/app/components/ui/Field/Checkbox';
@@ -7,7 +8,6 @@ import { Input } from '@/app/components/ui/Field/Input';
 import { Select } from '@/app/components/ui/Field/Select';
 import { Textarea } from '@/app/components/ui/Field/Textarea';
 import type { CollectionListModel, LocationModel } from '@/app/types/Collection';
-import type { ContentImageModel } from '@/app/types/Content';
 
 import type { ImageUpdateState } from '../hooks/useMetadataState';
 import modalStyles from '../MetadataModal.module.scss';
@@ -33,10 +33,12 @@ export interface EssentialInfoSectionProps {
   /** Bulk edit hides per-item fields (Title/Caption/Alt) that should never be shared across images. */
   isBulkEdit?: boolean;
   /**
-   * Images in the current collection, offered as capture-date sources when editing a GIF/MP4 —
-   * picking one copies its `captureDate` so the GIF sorts chronologically alongside images.
+   * Hands a GIF/MP4 off to the manage grid's capture-date pick mode: the sheet closes and the next
+   * image the user clicks supplies its `captureDate`, so the GIF sorts chronologically alongside
+   * images. Omitted when no image in the collection carries a date to copy, which disables the
+   * button.
    */
-  collectionImages?: ContentImageModel[];
+  onPickCaptureDate?: () => void;
 }
 
 export default function EssentialInfoSection({
@@ -47,7 +49,7 @@ export default function EssentialInfoSection({
   currentCollectionId,
   isGif,
   isBulkEdit = false,
-  collectionImages = [],
+  onPickCaptureDate,
 }: EssentialInfoSectionProps): React.JSX.Element {
   const currentCollectionVisible = isCurrentCollectionVisible(
     updateState.collections,
@@ -188,32 +190,27 @@ export default function EssentialInfoSection({
 
       {isGif && !isBulkEdit && (
         <div className={modalStyles.formGroup}>
-          <label className={modalStyles.formLabel}>Capture date (copy from image)</label>
-          {/* Action picker, not a bound field: always resets to the placeholder after a pick
-              so the same option can be re-selected to re-copy a date. */}
-          <Select
-            value=""
-            onChange={e => {
-              const image = collectionImages.find(img => String(img.id) === e.target.value);
-              if (image?.captureDate) {
-                updateStateField({ captureDate: image.captureDate });
+          <label className={modalStyles.formLabel}>Capture date</label>
+          {/* Not a bound field: the date is sourced by clicking a reference image on the manage
+              grid, so this button closes the sheet and hands off to pick mode. */}
+          <div className={modalStyles.inlineActionRow}>
+            <span className={modalStyles.inlineActionValue}>
+              {updateState.captureDate ? updateState.captureDate.split('T')[0] : 'Not set'}
+            </span>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onPickCaptureDate}
+              disabled={!onPickCaptureDate}
+              title={
+                onPickCaptureDate
+                  ? 'Close this sheet and click an image to copy its capture date'
+                  : 'No image in this collection has a capture date to copy.'
               }
-            }}
-            className={modalStyles.formSelect}
-          >
-            <option value="" disabled>
-              {updateState.captureDate
-                ? `Current: ${updateState.captureDate}`
-                : 'Pick a reference image'}
-            </option>
-            {collectionImages
-              .filter(img => img.captureDate)
-              .map(img => (
-                <option key={img.id} value={String(img.id)}>
-                  {img.title ?? `Image ${img.id}`} - {img.captureDate!.split('T')[0]}
-                </option>
-              ))}
-          </Select>
+            >
+              Update Date
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/app/components/Metadata/sections/EssentialInfoSection.tsx
+++ b/app/components/Metadata/sections/EssentialInfoSection.tsx
@@ -186,9 +186,11 @@ export default function EssentialInfoSection({
         )}
       </div>
 
-      {isGif && (
+      {isGif && !isBulkEdit && (
         <div className={modalStyles.formGroup}>
           <label className={modalStyles.formLabel}>Capture date (copy from image)</label>
+          {/* Action picker, not a bound field: always resets to the placeholder after a pick
+              so the same option can be re-selected to re-copy a date. */}
           <Select
             value=""
             onChange={e => {
@@ -208,7 +210,7 @@ export default function EssentialInfoSection({
               .filter(img => img.captureDate)
               .map(img => (
                 <option key={img.id} value={String(img.id)}>
-                  {img.title ?? `Image ${img.id}`} - {img.captureDate}
+                  {img.title ?? `Image ${img.id}`} - {img.captureDate!.split('T')[0]}
                 </option>
               ))}
           </Select>

--- a/app/components/Metadata/sections/EssentialInfoSection.tsx
+++ b/app/components/Metadata/sections/EssentialInfoSection.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/app/components/ui/Field/Input';
 import { Select } from '@/app/components/ui/Field/Select';
 import { Textarea } from '@/app/components/ui/Field/Textarea';
 import type { CollectionListModel, LocationModel } from '@/app/types/Collection';
+import type { ContentImageModel } from '@/app/types/Content';
 
 import type { ImageUpdateState } from '../hooks/useMetadataState';
 import modalStyles from '../MetadataModal.module.scss';
@@ -31,6 +32,11 @@ export interface EssentialInfoSectionProps {
   isGif: boolean;
   /** Bulk edit hides per-item fields (Title/Caption/Alt) that should never be shared across images. */
   isBulkEdit?: boolean;
+  /**
+   * Images in the current collection, offered as capture-date sources when editing a GIF/MP4 —
+   * picking one copies its `captureDate` so the GIF sorts chronologically alongside images.
+   */
+  collectionImages?: ContentImageModel[];
 }
 
 export default function EssentialInfoSection({
@@ -41,6 +47,7 @@ export default function EssentialInfoSection({
   currentCollectionId,
   isGif,
   isBulkEdit = false,
+  collectionImages = [],
 }: EssentialInfoSectionProps): React.JSX.Element {
   const currentCollectionVisible = isCurrentCollectionVisible(
     updateState.collections,
@@ -178,6 +185,35 @@ export default function EssentialInfoSection({
           </div>
         )}
       </div>
+
+      {isGif && (
+        <div className={modalStyles.formGroup}>
+          <label className={modalStyles.formLabel}>Capture date (copy from image)</label>
+          <Select
+            value=""
+            onChange={e => {
+              const image = collectionImages.find(img => String(img.id) === e.target.value);
+              if (image?.captureDate) {
+                updateStateField({ captureDate: image.captureDate });
+              }
+            }}
+            className={modalStyles.formSelect}
+          >
+            <option value="" disabled>
+              {updateState.captureDate
+                ? `Current: ${updateState.captureDate}`
+                : 'Pick a reference image'}
+            </option>
+            {collectionImages
+              .filter(img => img.captureDate)
+              .map(img => (
+                <option key={img.id} value={String(img.id)}>
+                  {img.title ?? `Image ${img.id}`} - {img.captureDate}
+                </option>
+              ))}
+          </Select>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/lib/api/content.ts
+++ b/app/lib/api/content.ts
@@ -198,6 +198,8 @@ export async function createGif(collectionId: number, file: File): Promise<Conte
 export interface ContentGifUpdateRequest {
   title?: string;
   rating?: number;
+  /** ISO capture date copied from a reference image; persisted to content_gif.capture_date. */
+  captureDate?: string | null;
   tags?: TagUpdate;
   /** Person updates using prev/newValue/remove pattern (many-to-many) */
   people?: PersonUpdate;

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -188,6 +188,12 @@ export interface ContentGifModel extends Content {
   author?: string | null;
   createDate?: string | null;
   /**
+   * Photographic capture time (ISO string), copied from a reference image so the GIF/MP4 sorts
+   * chronologically alongside images. Null for GIFs the admin has not dated (they stay at the end
+   * of a chronological collection). Mirrors backend ContentModels.Gif.captureDate.
+   */
+  captureDate?: string | null;
+  /**
    * Layout rating (0-5 or null). Drives slot-width selection in the row grid:
    * horizontal GIF rating >= 4 takes the full row; rating 3 takes half a row;
    * lower ratings take a single slot. New uploads default to 4. Vertical content

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -14,6 +14,7 @@ import {
   type ContentImageModel,
 } from '@/app/types/Content';
 import { type FilmFilter, type FilterState, type LensType } from '@/app/types/GalleryFilter';
+import { isGifContent } from '@/app/utils/contentTypeGuards';
 import { getLensType } from '@/app/utils/focalLength';
 
 /**
@@ -903,23 +904,33 @@ export function applyCollectionFilters(
 }
 
 /**
- * Re-interleave date-sorted images back into a processed content array.
+ * A "dateable" content block participates in the chronological date sort: any image, or a GIF/MP4
+ * that has been given a captureDate. Text, collections, and undated GIFs are NOT dateable and keep
+ * their processed position (undated GIFs therefore stay at the end of a chronological collection).
+ */
+export function isDateable(block: AnyContentModel): boolean {
+  return isImageContent(block) || (isGifContent(block) && Boolean(block.captureDate));
+}
+
+/**
+ * Re-interleave date-sorted dateable content back into a processed content array.
  *
- * Date sort runs after `processContentBlocks` (which sorts by orderIndex), so
- * this walks the processed array and replaces each image slot, in order, with
- * the next date-sorted image — leaving non-image blocks in place.
+ * Date sort runs after `processContentBlocks` (which sorts by orderIndex), so this walks the
+ * processed array and replaces each dateable slot (images, plus GIFs/MP4s with a captureDate), in
+ * order, with the next date-sorted item — leaving non-dateable blocks (text, collections, undated
+ * GIFs) in place.
  *
  * @param processed - Content already processed for layout
- * @param sortedImages - The processed images re-sorted by date
+ * @param sortedDateables - The processed dateable content re-sorted by date
  */
 export function mergeDateSortedImages(
   processed: AnyContentModel[],
-  sortedImages: ContentImageModel[]
+  sortedDateables: AnyContentModel[]
 ): AnyContentModel[] {
-  let imageIdx = 0;
+  let idx = 0;
   return processed.map(item => {
-    if (!isImageContent(item)) return item;
-    return sortedImages[imageIdx++] ?? item;
+    if (!isDateable(item)) return item;
+    return sortedDateables[idx++] ?? item;
   });
 }
 

--- a/app/utils/sortByDate.ts
+++ b/app/utils/sortByDate.ts
@@ -1,13 +1,12 @@
-import { type ContentImageModel } from '@/app/types/Content';
-
 /**
- * Sorts images by captureDate. Uses createdAt as a tiebreaker for same-day images
- * (upload sequence approximates capture sequence; captureDate has no intra-day precision).
+ * Sorts dateable content (images or GIFs/MP4s with a captureDate) by captureDate. Uses createdAt
+ * as a tiebreaker for same-day items (upload sequence approximates capture sequence; captureDate
+ * has no intra-day precision).
  */
-export function sortByDate(
-  images: ContentImageModel[],
+export function sortByDate<T extends { captureDate?: string | null; createdAt?: string | null }>(
+  images: T[],
   direction: 'asc' | 'desc'
-): ContentImageModel[] {
+): T[] {
   return [...images].sort((a, b) => {
     const dateA = a.captureDate ? new Date(a.captureDate).getTime() : 0;
     const dateB = b.captureDate ? new Date(b.captureDate).getTime() : 0;

--- a/app/utils/sortByDate.ts
+++ b/app/utils/sortByDate.ts
@@ -1,3 +1,6 @@
+import { type AnyContentModel } from '@/app/types/Content';
+import { isDateable, mergeDateSortedImages } from '@/app/utils/contentFilter';
+
 /**
  * Sorts dateable content (images or GIFs/MP4s with a captureDate) by captureDate. Uses createdAt
  * as a tiebreaker for same-day items (upload sequence approximates capture sequence; captureDate
@@ -16,4 +19,15 @@ export function sortByDate<T extends { captureDate?: string | null; createdAt?: 
     const createdB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
     return direction === 'asc' ? createdA - createdB : createdB - createdA;
   });
+}
+
+/**
+ * The full ascending chronological order of already-processed content: dateable items (images +
+ * dated GIFs) sorted by captureDate and re-interleaved into their slots; everything else left put.
+ * This is exactly the order the public page shows for a CHRONOLOGICAL collection, so materializing
+ * it into orderIndex makes an ORDERED collection match what the viewer saw.
+ */
+export function toChronologicalOrder<T extends AnyContentModel>(processed: T[]): T[] {
+  const sorted = sortByDate(processed.filter(isDateable) as T[], 'asc');
+  return mergeDateSortedImages(processed, sorted as AnyContentModel[]) as T[];
 }

--- a/app/utils/sortByDate.ts
+++ b/app/utils/sortByDate.ts
@@ -26,6 +26,11 @@ export function sortByDate<T extends { captureDate?: string | null; createdAt?: 
  * dated GIFs) sorted by captureDate and re-interleaved into their slots; everything else left put.
  * This is exactly the order the public page shows for a CHRONOLOGICAL collection, so materializing
  * it into orderIndex makes an ORDERED collection match what the viewer saw.
+ *
+ * Note: if `processed` includes items hidden from the public view (e.g. the manage/edit path,
+ * which passes filterVisible=false through processContentBlocks), hidden dateables still
+ * participate in this sort, so the result can differ slightly from the public (visible-only) view
+ * around non-dateable blocks.
  */
 export function toChronologicalOrder<T extends AnyContentModel>(processed: T[]): T[] {
   const sorted = sortByDate(processed.filter(isDateable) as T[], 'asc');

--- a/tests/components/ContentCollection/useCollectionEdit.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.test.tsx
@@ -4,6 +4,7 @@ import { useCollectionEdit } from '@/app/components/ContentCollection/edit/useCo
 import {
   getCollectionUpdateMetadata,
   getMetadata,
+  reorderCollectionContent,
   updateCollection,
   updateCollectionRating,
 } from '@/app/lib/api/collections';
@@ -17,6 +18,11 @@ import {
   type GeneralMetadataDTO,
 } from '@/app/types/Collection';
 import { CollectionVisibility } from '@/app/types/CollectionVisibility';
+import {
+  type AnyContentModel,
+  type ContentGifModel,
+  type ContentImageModel,
+} from '@/app/types/Content';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
@@ -34,6 +40,9 @@ const mockGetCollectionUpdateMetadata = getCollectionUpdateMetadata as jest.Mock
   typeof getCollectionUpdateMetadata
 >;
 const mockUpdateCollection = updateCollection as jest.MockedFunction<typeof updateCollection>;
+const mockReorderCollectionContent = reorderCollectionContent as jest.MockedFunction<
+  typeof reorderCollectionContent
+>;
 const mockGetMetadata = getMetadata as jest.MockedFunction<typeof getMetadata>;
 const mockUpdateCollectionRating = updateCollectionRating as jest.MockedFunction<
   typeof updateCollectionRating
@@ -107,6 +116,31 @@ function makeResponseWith(
   return {
     ...makeResponse(collectionOverrides),
     ...metadata,
+  };
+}
+
+/** Mirrors tests/utils/contentFilter.test.ts's makeImage fixture. */
+function makeContentImage(overrides: Partial<ContentImageModel> = {}): ContentImageModel {
+  return {
+    id: 1,
+    contentType: 'IMAGE',
+    orderIndex: 0,
+    imageUrl: 'https://example.com/test.jpg',
+    imageWidth: 1600,
+    imageHeight: 1067,
+    locations: [],
+    ...overrides,
+  };
+}
+
+/** Mirrors tests/utils/contentFilter.test.ts's makeGif fixture. */
+function makeContentGif(overrides: Partial<ContentGifModel> = {}): ContentGifModel {
+  return {
+    id: 200,
+    contentType: 'GIF',
+    orderIndex: 0,
+    gifUrl: 'https://example.com/test.gif',
+    ...overrides,
   };
 }
 
@@ -280,6 +314,81 @@ describe('useCollectionEdit', () => {
       );
       await waitFor(() => expect(result.current.manageMode).toBe('reorder'));
       expect(result.current.reorder.active).toBe(true);
+    });
+
+    it('enterReorder on a non-empty CHRONOLOGICAL collection materializes the full captureDate order (WRITE A) before switching to ORDERED (WRITE B), then seeds reorder from it', async () => {
+      // captureDate order (asc) differs from array order: img2 (01-01) < img1 (01-05).
+      // The undated gif is not dateable, so it keeps its own slot (index 2).
+      const content: AnyContentModel[] = [
+        makeContentImage({ id: 1, captureDate: '2024-01-05', createdAt: '2024-06-01' }),
+        makeContentImage({ id: 2, captureDate: '2024-01-01', createdAt: '2024-06-02' }),
+        makeContentGif({ id: 3, createdAt: '2024-06-03' }),
+      ];
+      mockGetCollectionUpdateMetadata.mockResolvedValue(
+        makeResponse({ displayMode: 'CHRONOLOGICAL', content })
+      );
+      mockReorderCollectionContent.mockResolvedValue(makeCollection({ content }));
+      mockUpdateCollection.mockResolvedValue(makeResponse({ displayMode: 'ORDERED', content }));
+
+      const { result } = renderEdit({
+        collection: makeCollection({ displayMode: 'CHRONOLOGICAL', content }),
+      });
+      await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+      const reorderCell = result.current.bottomBarCells.find(c => c.key === 'reorder');
+      await act(async () => {
+        reorderCell?.onClick?.();
+      });
+
+      // WRITE A: the full chronological order (not a diff) is sent to reorderCollectionContent.
+      expect(mockReorderCollectionContent).toHaveBeenCalledWith(42, [
+        { contentId: 2, newOrderIndex: 0 },
+        { contentId: 1, newOrderIndex: 1 },
+        { contentId: 3, newOrderIndex: 2 },
+      ]);
+      // WRITE B: the displayMode switch.
+      expect(mockUpdateCollection).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ displayMode: 'ORDERED' })
+      );
+
+      // WRITE A happens strictly before WRITE B.
+      const reorderCallOrder = mockReorderCollectionContent.mock.invocationCallOrder[0]!;
+      const updateCallOrder = mockUpdateCollection.mock.invocationCallOrder[0]!;
+      expect(reorderCallOrder).toBeLessThan(updateCallOrder);
+
+      // The reorder session is seeded from the materialized chronological order, not the
+      // (now-stale) upload-order processedContent.
+      await waitFor(() => expect(result.current.manageMode).toBe('reorder'));
+      expect(result.current.reorder.active).toBe(true);
+      expect(result.current.reorder.displayOrder).toEqual([2, 1, 3]);
+    });
+
+    it('enterReorder on CHRONOLOGICAL does not switch to ORDERED when WRITE A (the materialization write) fails', async () => {
+      const content: AnyContentModel[] = [
+        makeContentImage({ id: 1, captureDate: '2024-01-01' }),
+        makeContentImage({ id: 2, captureDate: '2024-01-02' }),
+      ];
+      mockGetCollectionUpdateMetadata.mockResolvedValue(
+        makeResponse({ displayMode: 'CHRONOLOGICAL', content })
+      );
+      mockReorderCollectionContent.mockRejectedValue(new Error('reorder failed'));
+
+      const { result } = renderEdit({
+        collection: makeCollection({ displayMode: 'CHRONOLOGICAL', content }),
+      });
+      await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+      const reorderCell = result.current.bottomBarCells.find(c => c.key === 'reorder');
+      await act(async () => {
+        reorderCell?.onClick?.();
+      });
+
+      expect(mockReorderCollectionContent).toHaveBeenCalled();
+      expect(mockUpdateCollection).not.toHaveBeenCalled();
+      expect(result.current.error).toMatch(/reorder failed/i);
+      expect(result.current.manageMode).toBe('browse');
+      expect(result.current.reorder.active).toBe(false);
     });
 
     it('enterReorder on CHRONOLOGICAL surfaces an error when the admin DTO never loaded', async () => {

--- a/tests/components/ContentCollection/useCollectionEdit.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.test.tsx
@@ -8,7 +8,7 @@ import {
   updateCollection,
   updateCollectionRating,
 } from '@/app/lib/api/collections';
-import { createImages } from '@/app/lib/api/content';
+import { createImages, updateGif } from '@/app/lib/api/content';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import {
   type CollectionListModel,
@@ -51,6 +51,7 @@ const mockStorageGetFull = collectionStorage.getFull as jest.MockedFunction<
   typeof collectionStorage.getFull
 >;
 const mockCreateImages = createImages as jest.MockedFunction<typeof createImages>;
+const mockUpdateGif = updateGif as jest.MockedFunction<typeof updateGif>;
 
 function makeMetadata(overrides: Partial<GeneralMetadataDTO> = {}): GeneralMetadataDTO {
   return {
@@ -944,6 +945,98 @@ describe('useCollectionEdit', () => {
       rerender({ collection: { ...collection } });
 
       expect(result.current.updateData.title).toBe('Unsaved Edit');
+    });
+  });
+
+  describe('capture-date pick mode', () => {
+    const GIF_ID = 300;
+    const datedContent: AnyContentModel[] = [
+      makeContentImage({ id: 1, captureDate: '2024-06-14T00:00:00Z' }),
+      makeContentImage({ id: 2, captureDate: null }),
+      makeContentGif({ id: GIF_ID }),
+    ];
+
+    async function armPick() {
+      mockGetCollectionUpdateMetadata.mockResolvedValue(makeResponse({ content: datedContent }));
+      const { result } = renderEdit({ collection: makeCollection({ content: datedContent }) });
+      await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+      // Open the metadata sheet on the GIF, then hand off to the grid.
+      act(() => result.current.handleImageClick(GIF_ID));
+      expect(result.current.editingContent?.id).toBe(GIF_ID);
+      act(() => result.current.startCaptureDatePick());
+      return result;
+    }
+
+    it('startCaptureDatePick() closes the sheet and enters pick-date with a Cancel-only bar', async () => {
+      const result = await armPick();
+
+      expect(result.current.manageMode).toBe('pick-date');
+      expect(result.current.editingContent).toBeNull();
+      expect(result.current.bottomBarCells.map(c => c.key)).toEqual(['cancel']);
+    });
+
+    it('startCaptureDatePick() is a no-op while the editor is closed or open on an image', async () => {
+      mockGetCollectionUpdateMetadata.mockResolvedValue(makeResponse({ content: datedContent }));
+      const { result } = renderEdit({ collection: makeCollection({ content: datedContent }) });
+      await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+      act(() => result.current.startCaptureDatePick());
+      expect(result.current.manageMode).toBe('browse');
+
+      act(() => result.current.handleImageClick(1));
+      expect(result.current.editingContent?.id).toBe(1);
+      act(() => result.current.startCaptureDatePick());
+      expect(result.current.manageMode).toBe('browse');
+    });
+
+    it('clicking a dated image patches the GIF with that captureDate and returns to browse', async () => {
+      const result = await armPick();
+
+      await act(async () => {
+        result.current.handleImageClick(1);
+      });
+
+      expect(mockUpdateGif).toHaveBeenCalledWith(GIF_ID, { captureDate: '2024-06-14T00:00:00Z' });
+      await waitFor(() => expect(result.current.manageMode).toBe('browse'));
+      expect(result.current.error).toBeNull();
+    });
+
+    it('clicking an undated block errors and stays in pick-date so another can be chosen', async () => {
+      const result = await armPick();
+
+      await act(async () => {
+        result.current.handleImageClick(2);
+      });
+
+      expect(mockUpdateGif).not.toHaveBeenCalled();
+      expect(result.current.error).toMatch(/no capture date/i);
+      expect(result.current.manageMode).toBe('pick-date');
+
+      // A second click on a valid source still commits.
+      await act(async () => {
+        result.current.handleImageClick(1);
+      });
+      expect(mockUpdateGif).toHaveBeenCalledWith(GIF_ID, { captureDate: '2024-06-14T00:00:00Z' });
+    });
+
+    it('a grid click in pick-date never opens the metadata editor', async () => {
+      const result = await armPick();
+
+      await act(async () => {
+        result.current.handleImageClick(1);
+      });
+
+      expect(result.current.editingContent).toBeNull();
+    });
+
+    it('exitToBrowse() cancels the pick without patching', async () => {
+      const result = await armPick();
+
+      act(() => result.current.exitToBrowse());
+
+      expect(result.current.manageMode).toBe('browse');
+      expect(mockUpdateGif).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/components/Metadata/metadataUtils.test.ts
+++ b/tests/components/Metadata/metadataUtils.test.ts
@@ -2426,4 +2426,36 @@ describe('buildGifUpdatePayload (single-GIF save payload builder)', () => {
       locations: { prev: [5] },
     });
   });
+
+  it('includes captureDate when changed', () => {
+    const original = createGifContent(1, { captureDate: null });
+
+    const result = buildGifUpdatePayload(
+      { captureDate: '2024-06-14' },
+      original,
+      new Set<number>()
+    );
+
+    expect(result.captureDate).toBe('2024-06-14');
+  });
+
+  it('omits captureDate when unchanged', () => {
+    const original = createGifContent(1, { captureDate: '2024-06-14' });
+
+    const result = buildGifUpdatePayload(
+      { captureDate: '2024-06-14' },
+      original,
+      new Set<number>()
+    );
+
+    expect(result.captureDate).toBeUndefined();
+  });
+
+  it('treats null/undefined captureDate equivalently (no diff when both unset)', () => {
+    const original = createGifContent(1, { captureDate: undefined });
+
+    const result = buildGifUpdatePayload({ captureDate: null }, original, new Set<number>());
+
+    expect(result.captureDate).toBeUndefined();
+  });
 });

--- a/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
+++ b/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import type { ImageUpdateState } from '@/app/components/Metadata/hooks/useMetadataState';
 import EssentialInfoSection from '@/app/components/Metadata/sections/EssentialInfoSection';
 import type { CollectionListModel, LocationModel } from '@/app/types/Collection';
+import { createImageContent } from '@/tests/fixtures/contentFixtures';
 
 const baseUpdateState: ImageUpdateState = {
   id: 101,
@@ -175,6 +176,84 @@ describe('EssentialInfoSection', () => {
           { collectionId: 42, name: 'Pacific Northwest', visible: false, orderIndex: 1 },
         ],
       });
+    });
+  });
+
+  describe('Capture date picker (GIF reference-image copy)', () => {
+    const datedImage = createImageContent(1, { title: 'Beach', captureDate: '2024-06-14T00:00:00Z' });
+    const undatedImage = createImageContent(2, { title: 'No Date', captureDate: null });
+
+    it('renders when isGif=true and isBulkEdit=false', () => {
+      render(
+        <EssentialInfoSection
+          {...makeProps({ isGif: true, isBulkEdit: false, collectionImages: [datedImage] })}
+        />
+      );
+      expect(screen.getByText(/capture date \(copy from image\)/i)).toBeInTheDocument();
+    });
+
+    it('does not render when isGif=true and isBulkEdit=true (bulk selection)', () => {
+      render(
+        <EssentialInfoSection
+          {...makeProps({ isGif: true, isBulkEdit: true, collectionImages: [datedImage] })}
+        />
+      );
+      expect(screen.queryByText(/capture date \(copy from image\)/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render for image content (isGif=false)', () => {
+      render(
+        <EssentialInfoSection
+          {...makeProps({ isGif: false, isBulkEdit: false, collectionImages: [datedImage] })}
+        />
+      );
+      expect(screen.queryByText(/capture date \(copy from image\)/i)).not.toBeInTheDocument();
+    });
+
+    it('only includes dated images as options, filtering out undated ones', () => {
+      render(
+        <EssentialInfoSection
+          {...makeProps({
+            isGif: true,
+            isBulkEdit: false,
+            collectionImages: [datedImage, undatedImage],
+          })}
+        />
+      );
+      expect(screen.getByRole('option', { name: /beach/i })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /no date/i })).not.toBeInTheDocument();
+    });
+
+    it('selecting an option calls updateStateField with that image\'s captureDate', () => {
+      const updateStateField = jest.fn();
+      render(
+        <EssentialInfoSection
+          {...makeProps({
+            isGif: true,
+            isBulkEdit: false,
+            collectionImages: [datedImage],
+            updateStateField,
+          })}
+        />
+      );
+      const group = screen.getByText(/capture date \(copy from image\)/i).closest('div')!;
+      const select = within(group).getByRole('combobox');
+      fireEvent.change(select, { target: { value: String(datedImage.id) } });
+      expect(updateStateField).toHaveBeenCalledWith({ captureDate: datedImage.captureDate });
+    });
+
+    it('renders just the disabled placeholder with zero dated images (no crash)', () => {
+      render(
+        <EssentialInfoSection
+          {...makeProps({ isGif: true, isBulkEdit: false, collectionImages: [undatedImage] })}
+        />
+      );
+      const group = screen.getByText(/capture date \(copy from image\)/i).closest('div')!;
+      const select = within(group).getByRole('combobox');
+      const options = select.querySelectorAll('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toBeDisabled();
+      expect(options[0]).toHaveTextContent(/pick a reference image/i);
     });
   });
 });

--- a/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
+++ b/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
@@ -1,9 +1,8 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { ImageUpdateState } from '@/app/components/Metadata/hooks/useMetadataState';
 import EssentialInfoSection from '@/app/components/Metadata/sections/EssentialInfoSection';
 import type { CollectionListModel, LocationModel } from '@/app/types/Collection';
-import { createImageContent } from '@/tests/fixtures/contentFixtures';
 
 const baseUpdateState: ImageUpdateState = {
   id: 101,
@@ -179,81 +178,72 @@ describe('EssentialInfoSection', () => {
     });
   });
 
-  describe('Capture date picker (GIF reference-image copy)', () => {
-    const datedImage = createImageContent(1, { title: 'Beach', captureDate: '2024-06-14T00:00:00Z' });
-    const undatedImage = createImageContent(2, { title: 'No Date', captureDate: null });
+  describe('Capture date hand-off (GIF grid pick)', () => {
+    const dateButton = () => screen.queryByRole('button', { name: /update date/i });
 
     it('renders when isGif=true and isBulkEdit=false', () => {
       render(
         <EssentialInfoSection
-          {...makeProps({ isGif: true, isBulkEdit: false, collectionImages: [datedImage] })}
+          {...makeProps({ isGif: true, isBulkEdit: false, onPickCaptureDate: jest.fn() })}
         />
       );
-      expect(screen.getByText(/capture date \(copy from image\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/^capture date$/i)).toBeInTheDocument();
+      expect(dateButton()).toBeInTheDocument();
     });
 
     it('does not render when isGif=true and isBulkEdit=true (bulk selection)', () => {
       render(
         <EssentialInfoSection
-          {...makeProps({ isGif: true, isBulkEdit: true, collectionImages: [datedImage] })}
+          {...makeProps({ isGif: true, isBulkEdit: true, onPickCaptureDate: jest.fn() })}
         />
       );
-      expect(screen.queryByText(/capture date \(copy from image\)/i)).not.toBeInTheDocument();
+      expect(dateButton()).not.toBeInTheDocument();
     });
 
     it('does not render for image content (isGif=false)', () => {
       render(
         <EssentialInfoSection
-          {...makeProps({ isGif: false, isBulkEdit: false, collectionImages: [datedImage] })}
+          {...makeProps({ isGif: false, isBulkEdit: false, onPickCaptureDate: jest.fn() })}
         />
       );
-      expect(screen.queryByText(/capture date \(copy from image\)/i)).not.toBeInTheDocument();
+      expect(dateButton()).not.toBeInTheDocument();
     });
 
-    it('only includes dated images as options, filtering out undated ones', () => {
-      render(
-        <EssentialInfoSection
-          {...makeProps({
-            isGif: true,
-            isBulkEdit: false,
-            collectionImages: [datedImage, undatedImage],
-          })}
-        />
-      );
-      expect(screen.getByRole('option', { name: /beach/i })).toBeInTheDocument();
-      expect(screen.queryByRole('option', { name: /no date/i })).not.toBeInTheDocument();
-    });
-
-    it('selecting an option calls updateStateField with that image\'s captureDate', () => {
+    it('pressing the button hands off to the grid pick without touching edit state', () => {
+      const onPickCaptureDate = jest.fn();
       const updateStateField = jest.fn();
       render(
         <EssentialInfoSection
+          {...makeProps({ isGif: true, isBulkEdit: false, onPickCaptureDate, updateStateField })}
+        />
+      );
+      fireEvent.click(dateButton()!);
+      expect(onPickCaptureDate).toHaveBeenCalledTimes(1);
+      expect(updateStateField).not.toHaveBeenCalled();
+    });
+
+    it('shows the current capture date as a day, and "Not set" when absent', () => {
+      const { unmount } = render(
+        <EssentialInfoSection
           {...makeProps({
             isGif: true,
-            isBulkEdit: false,
-            collectionImages: [datedImage],
-            updateStateField,
+            updateState: { ...baseUpdateState, captureDate: '2024-06-14T09:30:00Z' },
+            onPickCaptureDate: jest.fn(),
           })}
         />
       );
-      const group = screen.getByText(/capture date \(copy from image\)/i).closest('div')!;
-      const select = within(group).getByRole('combobox');
-      fireEvent.change(select, { target: { value: String(datedImage.id) } });
-      expect(updateStateField).toHaveBeenCalledWith({ captureDate: datedImage.captureDate });
+      expect(screen.getByText('2024-06-14')).toBeInTheDocument();
+      unmount();
+
+      render(
+        <EssentialInfoSection {...makeProps({ isGif: true, onPickCaptureDate: jest.fn() })} />
+      );
+      expect(screen.getByText(/not set/i)).toBeInTheDocument();
     });
 
-    it('renders just the disabled placeholder with zero dated images (no crash)', () => {
-      render(
-        <EssentialInfoSection
-          {...makeProps({ isGif: true, isBulkEdit: false, collectionImages: [undatedImage] })}
-        />
-      );
-      const group = screen.getByText(/capture date \(copy from image\)/i).closest('div')!;
-      const select = within(group).getByRole('combobox');
-      const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(1);
-      expect(options[0]).toBeDisabled();
-      expect(options[0]).toHaveTextContent(/pick a reference image/i);
+    it('disables the button when no dated image is available to copy from', () => {
+      render(<EssentialInfoSection {...makeProps({ isGif: true, isBulkEdit: false })} />);
+      expect(dateButton()).toBeDisabled();
     });
   });
 });

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1,6 +1,7 @@
 import {
   type AnyContentModel,
   type ContentCollectionModel,
+  type ContentGifModel,
   type ContentImageModel,
   type ContentTextModel,
 } from '@/app/types/Content';
@@ -21,10 +22,12 @@ import {
   filterContent,
   hasAnyActiveFilter,
   hasFilterableOptions,
+  isDateable,
   mergeDateSortedImages,
   parseFilterFromParams,
   serializeFilterToParams,
 } from '@/app/utils/contentFilter';
+import { sortByDate } from '@/app/utils/sortByDate';
 
 // ─── Test Fixtures ───
 
@@ -49,6 +52,16 @@ function makeTextBlock(): ContentTextModel {
     items: [{ type: 'text', value: 'Hello' }],
     format: 'plain',
     align: 'left',
+  };
+}
+
+function makeGif(overrides: Partial<ContentGifModel> = {}): ContentGifModel {
+  return {
+    id: 200,
+    contentType: 'GIF',
+    orderIndex: 0,
+    gifUrl: 'https://example.com/test.gif',
+    ...overrides,
   };
 }
 
@@ -1366,6 +1379,42 @@ describe('mergeDateSortedImages', () => {
     const text = makeTextBlock();
     const result = mergeDateSortedImages([text], []);
     expect(result).toEqual([text]);
+  });
+});
+
+describe('isDateable', () => {
+  it('is true for images', () => {
+    expect(isDateable(makeImage())).toBe(true);
+  });
+
+  it('is true for a GIF with a captureDate', () => {
+    expect(isDateable(makeGif({ captureDate: '2024-01-01' }))).toBe(true);
+  });
+
+  it('is false for a GIF without a captureDate', () => {
+    expect(isDateable(makeGif({ captureDate: null }))).toBe(false);
+    expect(isDateable(makeGif())).toBe(false);
+  });
+
+  it('is false for non-image, non-gif content', () => {
+    expect(isDateable(makeTextBlock())).toBe(false);
+  });
+});
+
+describe('isDateable + sortByDate + mergeDateSortedImages integration', () => {
+  it('dated GIF interleaves by captureDate; undated GIF stays put', () => {
+    const img1 = makeImage({ id: 1, captureDate: '2024-01-03', createdAt: '2024-06-01' });
+    const gifDated = makeGif({ id: 2, captureDate: '2024-01-01', createdAt: '2024-06-02' });
+    const img2 = makeImage({ id: 3, captureDate: '2024-01-05', createdAt: '2024-06-03' });
+    const gifUndated = makeGif({ id: 4, createdAt: '2024-06-04' });
+    const processed: AnyContentModel[] = [img1, gifDated, img2, gifUndated];
+
+    const sorted = sortByDate(processed.filter(isDateable), 'asc');
+    const merged = mergeDateSortedImages(processed, sorted);
+
+    // Dateable slots (indices 0,1,2) filled by captureDate order: gifDated(2) < img1(1) < img2(3).
+    expect(merged.map(m => m.id)).toEqual([2, 1, 3, 4]);
+    // Undated GIF (id 4) never moved from its slot.
   });
 });
 

--- a/tests/utils/sortByDate.test.ts
+++ b/tests/utils/sortByDate.test.ts
@@ -1,0 +1,59 @@
+import {
+  type AnyContentModel,
+  type ContentGifModel,
+  type ContentImageModel,
+} from '@/app/types/Content';
+import { sortByDate, toChronologicalOrder } from '@/app/utils/sortByDate';
+
+// ─── Test Fixtures ───
+// Mirrors tests/utils/contentFilter.test.ts's makeImage/makeGif conventions.
+
+function makeImage(overrides: Partial<ContentImageModel> = {}): ContentImageModel {
+  return {
+    id: 1,
+    contentType: 'IMAGE',
+    orderIndex: 0,
+    imageUrl: 'https://example.com/test.jpg',
+    imageWidth: 1600,
+    imageHeight: 1067,
+    locations: [],
+    ...overrides,
+  };
+}
+
+function makeGif(overrides: Partial<ContentGifModel> = {}): ContentGifModel {
+  return {
+    id: 200,
+    contentType: 'GIF',
+    orderIndex: 0,
+    gifUrl: 'https://example.com/test.gif',
+    ...overrides,
+  };
+}
+
+describe('sortByDate', () => {
+  it('sorts by captureDate ascending, tiebreaking on createdAt', () => {
+    const a = makeImage({ id: 1, captureDate: '2024-01-05', createdAt: '2024-06-01' });
+    const b = makeImage({ id: 2, captureDate: '2024-01-01', createdAt: '2024-06-02' });
+    expect(sortByDate([a, b], 'asc').map(i => i.id)).toEqual([2, 1]);
+  });
+});
+
+describe('toChronologicalOrder', () => {
+  it('places dateables by captureDate, keeps others put', () => {
+    const img1 = makeImage({ id: 1, captureDate: '2024-01-03', createdAt: '2024-06-01' });
+    const gifDated = makeGif({ id: 2, captureDate: '2024-01-01', createdAt: '2024-06-02' });
+    const img2 = makeImage({ id: 3, captureDate: '2024-01-05', createdAt: '2024-06-03' });
+    const gifUndated = makeGif({ id: 4, createdAt: '2024-06-04' });
+    const processed: AnyContentModel[] = [img1, gifDated, img2, gifUndated];
+
+    expect(toChronologicalOrder(processed).map(c => c.id)).toEqual([2, 1, 3, 4]);
+  });
+
+  it('returns content unchanged when nothing is dateable', () => {
+    const gif1 = makeGif({ id: 1 });
+    const gif2 = makeGif({ id: 2 });
+    const processed: AnyContentModel[] = [gif1, gif2];
+    expect(toChronologicalOrder(processed).map(c => c.id)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Why

Two related problems with chronological collections:

1. **Entering reorder scrambled the order.** A `CHRONOLOGICAL` collection displays by `captureDate` but its `orderIndex` values were never made to agree — on `chamonix` three separate items sat at index 1. Pressing Reorder flipped the collection to `ORDERED`, at which point `orderIndex` suddenly became authoritative and the grid jumped to an order the user had never seen. Moving one image appeared to revert the others.

2. **GIFs had no date.** With no EXIF they always sorted to the end, so an animated block could not sit where it belonged in a day's sequence.

Depends on **[themancalledzac/edens.zac.backend#131](https://github.com/themancalledzac/edens.zac.backend/pull/131)** — the picker PATCHes `captureDate` to `/api/admin/content/gifs/{id}`, which only exists once that merges.

## What

**Reorder fix.** Entering reorder on a `CHRONOLOGICAL` collection now does two ordered writes: first it materializes the true `captureDate` order into `orderIndex` for every item (a full re-index, not a diff, so unmoved items get a real position too), then it flips to `ORDERED`. Writes are in that order deliberately — if the first fails, the collection stays `CHRONOLOGICAL` and visually unchanged. The reorder session is seeded from the order just persisted, not from the stale `processedContent`.

**GIF capture dates.** `captureDate` added to `ContentGifModel` and the update request; `sortByDate` interleaves any dateable content rather than images only; undated GIFs still fall to the end.

**The picker.** A compact `Update Date` button in the metadata sheet closes the sheet and arms a new `pick-date` manage mode — the next dated image clicked on the grid supplies its date, PATCHed immediately. Modelled on the existing cover-image pick flow: `useCaptureDateSelection` mirrors `useCoverImageSelection` and `useImageClickHandler` gains a sibling branch ahead of the cover check.

## Verification

- **jest: 165 suites / 2589 tests, 0 failures**; `tsc` clean; eslint clean on all touched files
- V49 confirmed applied against a real local Postgres, and a live PATCH round-tripped `2026-07-20T08:03:25` into `content_gif.capture_date` for GIF 1776

Two defects were caught and fixed in review: a Flyway baseline conflict that broke 143 backend integration tests, and a missing `!isBulkEdit` gate that would have overwritten `captureDate` on every image in a mixed bulk selection.

## Known gaps

- **The four browser steps are unrun.** The manage route sits behind the frontend's own sign-in, which I could not pass. Everything under those steps is unit- and integration-tested and the backend half is confirmed live, but the visual confirmations (reorder shows date order; a move survives reload; cancel leaves a coherent `ORDERED` collection; a GIF moves into date position) still want a human pass.
- **On an `ORDERED` collection, `Update Date` writes a date that visibly does nothing** — position comes from `orderIndex` there. The write is correct and takes effect under the date-sort toggle or after switching to `CHRONOLOGICAL`, but the button gives no hint. Deferred; either hide it or surface the display mode next to it.
- `computeFilterVisibility` is still image-keyed, so a collection of only dated GIFs and no images would not surface the date-sort toggle.
- `mergeDateSortedImages` is now a stale name — it merges any dateable content.
- Pre-existing a11y gap in `EssentialInfoSection`: labels are not wired to inputs via `htmlFor`/`id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
