### PR TITLE
refactor(layout): rename cryptic locals and trim docblocks in rowCombination

### DIFF
--- a/app/utils/rowCombination.md
+++ b/app/utils/rowCombination.md
@@ -179,7 +179,7 @@ H (root, forced hPair)
    as its own leaf inherits the full row height and balloons. **Which vertical lands solo
    vs. stacked is not monotonic in rating** — it falls out of adjacency + AR-fitting.
 2. **The AR floor is enforced only at the ROOT**, not at internal nodes
-   ([`rowAR_Cost`](rowCombination.ts) / `pickRootAssignment`), so a sub-tree `vStack` of two
+   ([`rowARCost`](rowCombination.ts) / `pickRootAssignment`), so a sub-tree `vStack` of two
    verticals at AR 0.28 is permitted as long as the root row clears 1.0.
 3. **The equity tiebreak can't rescue it.** `equitySpread` (the only mechanism that tries to
    make area track prominence) is confined to `AR_EQUITY_BAND` (0.3) around the AR-optimal

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -305,7 +305,7 @@ function padRowToWidth(
   rowIndex: number,
   isLastRow: boolean
 ): RowResult {
-  const realWidthCost = getTotalCV(row.components);
+  const realWidthCost = getTotalWidthCost(row.components);
   if (!(realWidthCost > 0)) return row;
   if (!isLastRow) return row;
   if (realWidthCost / rowWidth >= MIN_FILL_RATIO) return row;

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -593,8 +593,9 @@ type AbstractNode =
 
 /**
  * Build an unlabeled binary tree by recursively splitting at the adjacent boundary
- * whose two halves have the closest effectiveRating sums. Order is preserved (only
- * splits, no swaps), so the split reflects prominence rather than packing width.
+ * whose two halves have the closest effectiveRating sums. Balances on effectiveRating,
+ * not width-cost, so the split reflects prominence rather than packing width. Order is
+ * preserved - only adjacent splits, never swaps.
  */
 function splitByPointBalance(items: ImageType[]): AbstractNode {
   if (items.length === 0) throw new Error('buildAtomic requires at least 1 image');
@@ -804,7 +805,8 @@ const LAMBDA = 0.15;
 /**
  * Soft upper bound on row AR, as a multiple of the row's target. A row wider than
  * CEILING_MULT × target is rejected (mirror of the hard lower floor), so equity
- * cannot collapse a horizontal row into a thin strip.
+ * cannot collapse a horizontal row into a thin strip. A ceiling rather than a larger
+ * LAMBDA, which would over-square vertical-hero rows.
  */
 const CEILING_MULT = 2.0;
 
@@ -823,6 +825,9 @@ function arPenalty(rowAR: number, target: number): number {
  * subtree. Area splits geometrically: hPair ∝ AR, vStack ∝ 1/AR; leaf shares sum to 1
  * within the subtree. `value` is prominence P, so equitySpread rewards high-rated
  * verticals with more area.
+ *
+ * vStack inverts: leftFactor uses rightAR (and vice versa) - under 1/AR the smaller-AR
+ * child claims the larger share.
  */
 function leafShares(ac: AtomicComponent): {
   ar: number;

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -55,7 +55,10 @@ function getTotalWidthCost(components: AnyContentModel[]): number {
 export const MIN_FILL_RATIO = 0.9;
 /** Maximum fill ratio; rows above this are rejected to avoid squeezing items. */
 export const MAX_FILL_RATIO = 1.15;
-/** Effective rating at or below which an item can be skipped past for a hero. */
+/**
+ * A leading item whose effective rating is at or below this may be passed over so that
+ * a solo-eligible hero just behind it leads the row instead.
+ */
 export const LOW_RATED_THRESHOLD = 2;
 
 /**
@@ -218,7 +221,8 @@ export const MAX_ROW_IMAGES = 12;
 /**
  * Width-cost fraction at or above which an extreme-AR item claims its own full-width
  * row. Paired with an extremeness gate (see isSoloHero): the fraction alone is not
- * enough, since a normal landscape at a small rowWidth can exceed it.
+ * enough, since a normal landscape at a small rowWidth can exceed it, which would
+ * collapse low-density rows into full-width singles.
  */
 export const HERO_SOLO_WIDTH_FRACTION = 0.5;
 
@@ -334,6 +338,9 @@ function padRowToWidth(
  * Estimate a row's combined aspect ratio via the cheap single-structure composer
  * (point-balance tree only), keeping the Stage-1 fill loop fast. The expensive
  * multi-structure equity search runs only at final per-row composition.
+ *
+ * The invariant that buys this: row-membership decisions never run the expensive
+ * search, so density-to-size behavior stays independent of how a row is composed.
  */
 export function estimateRowAR(images: ImageType[], targetAR: number): number {
   if (images.length === 0) throw new Error('estimateRowAR requires at least 1 image');
@@ -372,6 +379,16 @@ function collectRowItems(
  * then builds each row's atomic tree. A wide top-rated panorama claiming its own row
  * is an emergent result of its large Hv exceeding the budget, not a special case. The
  * AR-floor check is disabled on mobile (rowWidth ≤ 2).
+ *
+ * Three fill decisions that are not self-evident from the code:
+ * 1. The fill bar (effectiveMinFill) is the constant MIN_FILL_RATIO, not a scaled one.
+ *    Density already drives packing through rowWidth, so a rowWidth-scaled bar would
+ *    over-inflate past MAX_FILL_RATIO at high density.
+ * 2. A row still under that bar accepts one moderate overfill (newFill up to 1.35)
+ *    rather than closing short - a lone under-filled row reads worse than a slightly
+ *    tight one.
+ * 3. A solo-eligible item met after the row has started is skipped rather than taken,
+ *    so it surfaces as a leading solo hero on the next iteration and gets its own row.
  *
  * @param rowWidth - Row width budget (5 desktop, 4 tablet, etc.).
  * @param targetARBaseline - Baseline (viewport) target AR. Fill and estimate use it
@@ -783,8 +800,10 @@ interface Candidate {
 const ROW_AR_FLOOR = 1.0;
 
 /**
- * Stage-1 AR cost: sub-floor candidates get a large penalty (preferred only as a last
- * resort); at or above the floor, the candidate closest to the target wins.
+ * AR cost, used both by the Stage-1 estimator (pickRootAssignment) and by the Stage-2
+ * fallback ranking (pickBestComposition's arClosest): sub-floor candidates get a large
+ * penalty (preferred only as a last resort); at or above the floor, the candidate
+ * closest to the target wins.
  */
 function rowAR_Cost(rowAR: number, target: number): number {
   if (rowAR < ROW_AR_FLOOR) return 1000 + (ROW_AR_FLOOR - rowAR);
@@ -798,7 +817,7 @@ function rowAR_Cost(rowAR: number, target: number): number {
 /**
  * Weight of the AR-target term in the equity-primary score. Small, so equitySpread
  * (area tracks prominence) dominates and the AR-target only breaks ties among
- * near-equity options.
+ * near-equity options. Replaces the retired AR_EQUITY_BAND gate.
  */
 const LAMBDA = 0.15;
 
@@ -876,6 +895,9 @@ function equitySpread(ac: AtomicComponent): number {
  * Every direction-assigned AtomicComponent for a subtree: one candidate per leaf, an
  * hPair and a vStack at each internal node, multiplied across nesting. Cost is 2^N in
  * the number of internal nodes, bounded by row size.
+ *
+ * The two AR forms: hPair adds (ar = leftAR + rightAR), vStack takes the harmonic form
+ * (1/ar = 1/leftAR + 1/rightAR), written here as the equivalent product-over-sum.
  */
 function enumerateAssignments(node: AbstractNode): Candidate[] {
   if (node.kind === 'leaf') {

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -385,7 +385,7 @@ function collectRowItems(
  *    Density already drives packing through rowWidth, so a rowWidth-scaled bar would
  *    over-inflate past MAX_FILL_RATIO at high density.
  * 2. A row still under that bar accepts one moderate overfill (newFill up to 1.35)
- *    rather than closing short - a lone under-filled row reads worse than a slightly
+ *    rather than closing short — a lone under-filled row reads worse than a slightly
  *    tight one.
  * 3. A solo-eligible item met after the row has started is skipped rather than taken,
  *    so it surfaces as a leading solo hero on the next iteration and gets its own row.
@@ -612,7 +612,7 @@ type AbstractNode =
  * Build an unlabeled binary tree by recursively splitting at the adjacent boundary
  * whose two halves have the closest effectiveRating sums. Balances on effectiveRating,
  * not width-cost, so the split reflects prominence rather than packing width. Order is
- * preserved - only adjacent splits, never swaps.
+ * preserved — only adjacent splits, never swaps.
  */
 function splitByPointBalance(items: ImageType[]): AbstractNode {
   if (items.length === 0) throw new Error('buildAtomic requires at least 1 image');
@@ -845,7 +845,7 @@ function arPenalty(rowAR: number, target: number): number {
  * within the subtree. `value` is prominence P, so equitySpread rewards high-rated
  * verticals with more area.
  *
- * vStack inverts: leftFactor uses rightAR (and vice versa) - under 1/AR the smaller-AR
+ * vStack inverts: leftFactor uses rightAR (and vice versa) — under 1/AR the smaller-AR
  * child claims the larger share.
  */
 function leafShares(component: AtomicComponent): {

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -172,14 +172,14 @@ export function hChain(images: ImageType[]): AtomicComponent {
 }
 
 /** Convert an AtomicComponent tree to a BoxTree for rendering. */
-export function acToBoxTree(ac: AtomicComponent): BoxTree {
-  if (ac.type === 'single') {
-    return { type: 'leaf', content: ac.img.source };
+export function acToBoxTree(component: AtomicComponent): BoxTree {
+  if (component.type === 'single') {
+    return { type: 'leaf', content: component.img.source };
   }
   return {
     type: 'combined',
-    direction: ac.direction === 'H' ? 'horizontal' : 'vertical',
-    children: [acToBoxTree(ac.children[0]), acToBoxTree(ac.children[1])],
+    direction: component.direction === 'H' ? 'horizontal' : 'vertical',
+    children: [acToBoxTree(component.children[0]), acToBoxTree(component.children[1])],
   };
 }
 
@@ -448,26 +448,26 @@ export function buildRows(
 
     const arFloor = rowWidth <= 2 ? 0 : targetARBaseline * AR_FLOOR_MULTIPLIER;
     const expandedWindow = remaining.slice(0, MAX_ROW_IMAGES);
-    let seqTotal = 0;
-    let seqCount = 0;
+    let sequentialTotal = 0;
+    let sequentialCount = 0;
     const skippedStandalones: number[] = [];
     let slotCountComplete = false;
 
     for (let i = 0; i < expandedWindow.length; i++) {
       const widthCost = getWidthCost(expandedWindow[i]!);
 
-      if (seqCount > 0 && isSoloHero(expandedWindow[i]!, rowWidth)) {
+      if (sequentialCount > 0 && isSoloHero(expandedWindow[i]!, rowWidth)) {
         skippedStandalones.push(i);
         continue;
       }
 
-      const newFill = (seqTotal + widthCost) / rowWidth;
+      const newFill = (sequentialTotal + widthCost) / rowWidth;
 
       if (newFill > MAX_FILL_RATIO && !slotCountComplete) {
-        const currentFill = seqTotal / rowWidth;
+        const currentFill = sequentialTotal / rowWidth;
         if (currentFill < effectiveMinFill && newFill <= 1.35) {
-          seqTotal += widthCost;
-          seqCount += 1;
+          sequentialTotal += widthCost;
+          sequentialCount += 1;
         }
         break;
       }
@@ -478,21 +478,21 @@ export function buildRows(
           break;
         }
 
-        seqTotal += widthCost;
-        seqCount += 1;
+        sequentialTotal += widthCost;
+        sequentialCount += 1;
 
-        const expandedItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
+        const expandedItems = collectRowItems(expandedWindow, sequentialCount, skippedStandalones);
         const expandedImgs = expandedItems.map(item => toImageType(item));
         const expandedAR = estimateRowAR(expandedImgs, targetARBaseline);
         if (expandedAR >= arFloor) break;
         continue;
       }
 
-      seqTotal += widthCost;
-      seqCount += 1;
+      sequentialTotal += widthCost;
+      sequentialCount += 1;
 
       if (newFill >= effectiveMinFill) {
-        const rowItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
+        const rowItems = collectRowItems(expandedWindow, sequentialCount, skippedStandalones);
         const rowImgs = rowItems.map(item => toImageType(item));
         const rowAR = estimateRowAR(rowImgs, targetARBaseline);
 
@@ -503,8 +503,8 @@ export function buildRows(
       }
     }
 
-    if (seqCount > 0) {
-      const rowItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
+    if (sequentialCount > 0) {
+      const rowItems = collectRowItems(expandedWindow, sequentialCount, skippedStandalones);
       const rowImgs = rowItems.map(item => toImageType(item));
       const composition = buildAtomic(rowImgs, rowTargetAR(rowImgs, targetARBaseline));
       const boxTree = acToBoxTree(composition);
@@ -516,7 +516,7 @@ export function buildRows(
 
       const usedIndices = new Set<number>();
       let taken = 0;
-      for (let i = 0; i < expandedWindow.length && taken < seqCount; i++) {
+      for (let i = 0; i < expandedWindow.length && taken < sequentialCount; i++) {
         if (!skippedStandalones.includes(i)) {
           usedIndices.add(i);
           taken++;
@@ -529,19 +529,19 @@ export function buildRows(
       continue;
     }
 
-    const bfComponents: AnyContentModel[] = [];
-    const bfUsedIndices: number[] = [];
+    const bestFitComponents: AnyContentModel[] = [];
+    const bestFitUsedIndices: number[] = [];
     const available = new Set(window.map((_, i) => i));
 
-    bfComponents.push(window[0]!);
-    bfUsedIndices.push(0);
+    bestFitComponents.push(window[0]!);
+    bestFitUsedIndices.push(0);
     available.delete(0);
 
-    if (!isRowComplete(bfComponents, rowWidth)) {
+    if (!isRowComplete(bestFitComponents, rowWidth)) {
       for (let idx = 1; idx < window.length; idx++) {
         if (!available.has(idx)) continue;
 
-        const currentTotal = getTotalWidthCost(bfComponents);
+        const currentTotal = getTotalWidthCost(bestFitComponents);
         const candidateWidthCost = getWidthCost(window[idx]!);
         const newTotal = currentTotal + candidateWidthCost;
         const newFill = newTotal / rowWidth;
@@ -557,31 +557,31 @@ export function buildRows(
           if (underfillDistance <= overfillDistance) {
             continue;
           }
-          bfComponents.push(window[idx]!);
-          bfUsedIndices.push(idx);
+          bestFitComponents.push(window[idx]!);
+          bestFitUsedIndices.push(idx);
           break;
         }
 
-        bfComponents.push(window[idx]!);
-        bfUsedIndices.push(idx);
+        bestFitComponents.push(window[idx]!);
+        bestFitUsedIndices.push(idx);
         available.delete(idx);
 
-        if (isRowComplete(bfComponents, rowWidth)) {
+        if (isRowComplete(bestFitComponents, rowWidth)) {
           break;
         }
       }
     }
 
-    const bfImgs = bfComponents.map(item => toImageType(item));
-    const composition = buildAtomic(bfImgs, rowTargetAR(bfImgs, targetARBaseline));
+    const bestFitImgs = bestFitComponents.map(item => toImageType(item));
+    const composition = buildAtomic(bestFitImgs, rowTargetAR(bestFitImgs, targetARBaseline));
     const boxTree = acToBoxTree(composition);
 
     rows.push({
-      components: bfComponents,
+      components: bestFitComponents,
       boxTree,
     });
 
-    const sortedIndices = [...bfUsedIndices].sort((a, b) => b - a);
+    const sortedIndices = [...bestFitUsedIndices].sort((a, b) => b - a);
     for (const idx of sortedIndices) {
       remaining.splice(idx, 1);
     }
@@ -805,7 +805,7 @@ const ROW_AR_FLOOR = 1.0;
  * penalty (preferred only as a last resort); at or above the floor, the candidate
  * closest to the target wins.
  */
-function rowAR_Cost(rowAR: number, target: number): number {
+function rowARCost(rowAR: number, target: number): number {
   if (rowAR < ROW_AR_FLOOR) return 1000 + (ROW_AR_FLOOR - rowAR);
   return Math.abs(rowAR - Math.max(target, ROW_AR_FLOOR));
 }
@@ -848,19 +848,19 @@ function arPenalty(rowAR: number, target: number): number {
  * vStack inverts: leftFactor uses rightAR (and vice versa) - under 1/AR the smaller-AR
  * child claims the larger share.
  */
-function leafShares(ac: AtomicComponent): {
+function leafShares(component: AtomicComponent): {
   ar: number;
   leaves: Array<{ value: number; share: number }>;
 } {
-  if (ac.type === 'single') {
-    return { ar: ac.img.numericAR, leaves: [{ value: ac.img.prominence, share: 1 }] };
+  if (component.type === 'single') {
+    return { ar: component.img.numericAR, leaves: [{ value: component.img.prominence, share: 1 }] };
   }
-  const left = leafShares(ac.children[0]);
-  const right = leafShares(ac.children[1]);
+  const left = leafShares(component.children[0]);
+  const right = leafShares(component.children[1]);
   const leftAR = left.ar;
   const rightAR = right.ar;
   const sum = leftAR + rightAR;
-  const isH = ac.direction === 'H';
+  const isH = component.direction === 'H';
   const ar = isH ? sum : (leftAR * rightAR) / sum;
   const leftFactor = isH ? leftAR / sum : rightAR / sum;
   const rightFactor = isH ? rightAR / sum : leftAR / sum;
@@ -878,8 +878,8 @@ function leafShares(ac: AtomicComponent): {
  * max(area/value) / min(area/value) across leaves. 1.0 = perfectly proportional;
  * larger is worse. Uses prominence P so high-rated verticals are not penalized.
  */
-function equitySpread(ac: AtomicComponent): number {
-  const { leaves } = leafShares(ac);
+function equitySpread(component: AtomicComponent): number {
+  const { leaves } = leafShares(component);
   let min = Infinity;
   let max = 0;
   for (const { value, share } of leaves) {
@@ -926,7 +926,7 @@ function enumerateAssignments(node: AbstractNode): Candidate[] {
 /**
  * AR-closest direction assignment for a single point-balance tree — the cheap Stage-1
  * estimator behind estimateRowAR. The root is forced hPair (rows are horizontal);
- * among the children's assignments the lowest rowAR_Cost wins. No equity search here;
+ * among the children's assignments the lowest rowARCost wins. No equity search here;
  * that runs only at final composition.
  */
 function pickRootAssignment(tree: AbstractNode, targetAR: number): AtomicComponent {
@@ -939,7 +939,7 @@ function pickRootAssignment(tree: AbstractNode, targetAR: number): AtomicCompone
   let bestArCost = Infinity;
   for (const leftOption of leftOptions) {
     for (const rightOption of rightOptions) {
-      const arCost = rowAR_Cost(leftOption.ar + rightOption.ar, targetAR);
+      const arCost = rowARCost(leftOption.ar + rightOption.ar, targetAR);
       if (arCost < bestArCost) {
         bestArCost = arCost;
         best = hPair(leftOption.component, rightOption.component);
@@ -975,7 +975,7 @@ function pickBestComposition(
 
   const consider = (component: AtomicComponent, rowAR: number): void => {
     if (counters) counters.candidates += 1;
-    const cost = rowAR_Cost(rowAR, target);
+    const cost = rowARCost(rowAR, target);
     if (cost < arClosestCost) {
       arClosestCost = cost;
       arClosest = component;

--- a/app/utils/rowCombination.ts
+++ b/app/utils/rowCombination.ts
@@ -1,21 +1,16 @@
 /**
- * Row Combination — row layout engine (two stages).
+ * Row layout engine. Two stages:
  *
- * Stage 1 (`buildRows`): greedy sequential fill decides which items go in each
- * row, using a per-row width-cost budget (rowWidth) and an AR-floor check. Row AR
- * during fill is estimated cheaply from a single point-balance tree (`estimateRowAR`).
- * Stage 2 (`buildAtomic`): for each finalized row, a bounded set of order-preserving
- * tree SHAPES is enumerated (`enumerateStructures`), and across every shape × every
- * hPair/vStack direction assignment the composition is selected by an equity-primary
- * objective — `equitySpread + λ·arPenalty` — so each image's rendered AREA tracks its
- * prominence P (area-to-value), hard-bounded by an AR floor at 1.0 ("never taller than
- * wide") and a soft ceiling at CEILING_MULT × target ("never a thin strip").
+ * 1. buildRows — greedy sequential fill decides which items go in each row, using a
+ *    per-row width-cost budget and an aspect-ratio floor check. Row AR during fill
+ *    is estimated cheaply from a single point-balance tree (estimateRowAR).
+ * 2. buildAtomic — for each finalized row, enumerate order-preserving tree shapes and
+ *    H/V direction assignments, then pick the composition whose rendered areas best
+ *    track each image's prominence, bounded by an AR floor (never taller than wide)
+ *    and a soft ceiling (never a thin strip).
  *
- * Key concepts:
- * - A "component" is anything that occupies row space: a single image, gif, text, or combined block.
- * - Width-cost Hv = √(P·AR) is each item's packing cost (orientation-agnostic): a wide
- *   panorama costs more horizontal space, a tall portrait less. fill = ΣHv / rowWidth.
- * - A row is "complete" when total width-cost >= 0.9 of rowWidth (90% threshold).
+ * Width-cost Hv = √(P·AR) is an item's orientation-agnostic packing cost; a row's
+ * fill is ΣHv / rowWidth, and a row is complete once fill reaches MIN_FILL_RATIO.
  */
 
 import { EXTREMENESS_RAMP_START } from '@/app/constants';
@@ -34,7 +29,7 @@ import { calculateBoxTreeAspectRatio } from '@/app/utils/rowStructureAlgorithm';
 // TYPES
 // =============================================================================
 
-/** Recursive tree structure for rendering combinations */
+/** Recursive tree structure for rendering combinations. */
 export type BoxTree =
   | { type: 'leaf'; content: AnyContentModel }
   | {
@@ -47,11 +42,8 @@ export type BoxTree =
 // HELPER FUNCTIONS
 // =============================================================================
 
-/**
- * Total Stage-1 packing cost of a set of items, summing the width-cost
- * Hv = √(P·AR) (orientation-agnostic) rather than the vertical-biased cv.
- */
-function getTotalCV(components: AnyContentModel[]): number {
+/** Sum of every item's width-cost Hv = √(P·AR). */
+function getTotalWidthCost(components: AnyContentModel[]): number {
   return components.reduce((sum, item) => sum + getWidthCost(item), 0);
 }
 
@@ -59,21 +51,19 @@ function getTotalCV(components: AnyContentModel[]): number {
 // isRowComplete
 // =============================================================================
 
-/** Minimum fill ratio for a row to be considered complete */
+/** Minimum fill ratio for a row to be considered complete. */
 export const MIN_FILL_RATIO = 0.9;
-/** Maximum fill ratio — rows exceeding this are rejected to prevent item squeezing */
+/** Maximum fill ratio; rows above this are rejected to avoid squeezing items. */
 export const MAX_FILL_RATIO = 1.15;
-/** Effective rating at or below which an item is considered low-rated for standalone skip */
+/** Effective rating at or below which an item can be skipped past for a hero. */
 export const LOW_RATED_THRESHOLD = 2;
 
 /**
- * Check if a set of components fills a row within acceptable bounds.
+ * Whether a set of components fills a row within the acceptable band
+ * (MIN_FILL_RATIO to MAX_FILL_RATIO of rowWidth).
  *
- * A row is "complete" when fill is between 90% and 115% of row width.
- *
- * @param components - Items to check
- * @param rowWidth - Row width budget (e.g., 5 for desktop)
- * @returns true if total component value is within 90-115% of row width
+ * @param components - Items to check.
+ * @param rowWidth - Row width budget (e.g. 5 for desktop).
  */
 export function isRowComplete(components: AnyContentModel[], rowWidth: number): boolean {
   if (components.length === 0) return false;
@@ -88,7 +78,7 @@ export function isRowComplete(components: AnyContentModel[], rowWidth: number): 
 // ROW RESULT
 // =============================================================================
 
-/** A row result from the row-building algorithm */
+/** A row produced by the row-building algorithm. */
 export interface RowResult {
   components: AnyContentModel[];
   boxTree: BoxTree;
@@ -98,23 +88,23 @@ export interface RowResult {
 // ARCHITECTURE TYPES
 // =============================================================================
 
-/** Orientation shorthand for composition decisions */
+/** Orientation shorthand for composition decisions. */
 export type OrientationShort = 'H' | 'V';
 
-/** Thin view over AnyContentModel — pre-computed fields for composition */
+/** Thin view over AnyContentModel with pre-computed fields for composition. */
 export interface ImageType {
   source: AnyContentModel;
   title: string;
   ar: OrientationShort;
   numericAR: number;
   effectiveRating: number;
-  /** Orientation-agnostic prominence P — used as the equity-target for area allocation. */
+  /** Orientation-agnostic prominence P; the target for area allocation. */
   prominence: number;
-  /** Height demand Vv = √(P/AR) — drives the per-row target AR (taller rows for tall heroes). */
+  /** Height demand Vv = √(P/AR); drives the per-row target AR. */
   heightDemand: number;
 }
 
-/** Recursive composition structure */
+/** Recursive composition structure. */
 export type AtomicComponent =
   | { type: 'single'; img: ImageType }
   | {
@@ -127,7 +117,7 @@ export type AtomicComponent =
 // ARCHITECTURE HELPERS
 // =============================================================================
 
-/** Convert AnyContentModel to ImageType for composition decisions */
+/** Convert AnyContentModel to ImageType for composition decisions. */
 export function toImageType(item: AnyContentModel): ImageType {
   const numericAR = getAspectRatio(item);
   const ar: OrientationShort = numericAR > 1.0 ? 'H' : 'V';
@@ -147,22 +137,22 @@ export function toImageType(item: AnyContentModel): ImageType {
   };
 }
 
-/** Create a single-image AtomicComponent */
+/** Create a single-image AtomicComponent. */
 export function single(img: ImageType): AtomicComponent {
   return { type: 'single', img };
 }
 
-/** Create a horizontal pair */
+/** Create a horizontal pair. */
 export function hPair(left: AtomicComponent, right: AtomicComponent): AtomicComponent {
   return { type: 'pair', direction: 'H', children: [left, right] };
 }
 
-/** Create a vertical stack */
+/** Create a vertical stack. */
 export function vStack(top: AtomicComponent, bottom: AtomicComponent): AtomicComponent {
   return { type: 'pair', direction: 'V', children: [top, bottom] };
 }
 
-/** Create a left-heavy horizontal chain from 2+ images */
+/** Create a left-heavy horizontal chain from one or more images. */
 export function hChain(images: ImageType[]): AtomicComponent {
   if (images.length === 0) {
     throw new Error('hChain requires at least 1 image');
@@ -178,7 +168,7 @@ export function hChain(images: ImageType[]): AtomicComponent {
   return tree;
 }
 
-/** Convert AtomicComponent tree to BoxTree for rendering */
+/** Convert an AtomicComponent tree to a BoxTree for rendering. */
 export function acToBoxTree(ac: AtomicComponent): BoxTree {
   if (ac.type === 'single') {
     return { type: 'leaf', content: ac.img.source };
@@ -191,33 +181,28 @@ export function acToBoxTree(ac: AtomicComponent): BoxTree {
 }
 
 // =============================================================================
-// estimateRowAR — quick AR estimate for a set of images
+// estimateRowAR
 // =============================================================================
 
-/** AR floor multiplier: row AR must be at least targetAR * this value */
+/** Row AR must be at least targetAR × this value. */
 export const AR_FLOOR_MULTIPLIER = 0.7;
 
-// Per-row target AR band (Phase 2 — directional prominence). rowTargetAR pulls the
-// viewport baseline toward a floor in proportion to the row's peak height-demand
-// (Vv) ABOVE the Vv ceiling of wide/normal images, so a row holding a tall hero
-// targets a taller (lower-AR) shape and sizes the hero bigger, while rows of
-// landscapes/panos keep the baseline. Two anchors: peak Vv at/below
-// ROW_TARGET_AR_VV_LOW pulls nothing; at/above ROW_TARGET_AR_VV_HIGH the pull is
-// full. Clamped so a row never drops below ROW_TARGET_AR_MIN_FRACTION of the
-// baseline, preserving the density→size monotonicity shipped 2026-05-29.
-export const ROW_TARGET_AR_MIN_FRACTION = 0.6; // never below 60% of the baseline
-export const ROW_TARGET_AR_VV_LOW = 1.85; // ≈ just above a 5★ pano's Vv (1.826)
-export const ROW_TARGET_AR_VV_HIGH = 5.0; // ≈ a 1:3 portrait hero → full pull-down
+/** Never pull a row's target AR below this fraction of the baseline. */
+export const ROW_TARGET_AR_MIN_FRACTION = 0.6;
+/** Peak height-demand at or below which no pull is applied (≈ a 5★ pano's Vv). */
+export const ROW_TARGET_AR_VV_LOW = 1.85;
+/** Peak height-demand at or above which the pull is full (≈ a 1:3 portrait hero). */
+export const ROW_TARGET_AR_VV_HIGH = 5.0;
 
 /**
- * Per-row target AR: the viewport baseline pulled toward a floor by the row's peak
- * height-demand (Vv). A bland horizontal row (peak Vv below the wide-image ceiling
- * ROW_TARGET_AR_VV_LOW) keeps the baseline; a row with a tall vertical hero targets
- * a taller (lower-AR) shape so the hero renders bigger. The pull is content-driven
- * (peak Vv), not count-driven, so it does not affect density→size monotonicity.
+ * Per-row target AR: the viewport baseline pulled toward a floor in proportion to
+ * the row's peak height-demand (Vv). A row of landscapes keeps the baseline; a row
+ * with a tall vertical hero targets a taller (lower-AR) shape so the hero renders
+ * bigger. The pull is content-driven, not count-driven, so it does not affect
+ * density-to-size behavior.
  */
 export function rowTargetAR(items: ImageType[], baseline: number): number {
-  const peakVv = items.reduce((max, it) => Math.max(max, it.heightDemand), 0);
+  const peakVv = items.reduce((max, item) => Math.max(max, item.heightDemand), 0);
   const span = ROW_TARGET_AR_VV_HIGH - ROW_TARGET_AR_VV_LOW;
   const pull = Math.min(1, Math.max(0, (peakVv - ROW_TARGET_AR_VV_LOW) / span));
   const floor = baseline * ROW_TARGET_AR_MIN_FRACTION;
@@ -225,40 +210,29 @@ export function rowTargetAR(items: ImageType[], baseline: number): number {
 }
 
 /**
- * Maximum images per row. Caps greedy fill AND bounds buildAtomic's Phase 2
- * enumeration (~2^(n-1) candidates for an n-leaf row), so keep this modest.
+ * Maximum images per row. Caps greedy fill and bounds buildAtomic's enumeration
+ * (~2^(n-1) candidates for an n-leaf row), so keep it modest.
  */
 export const MAX_ROW_IMAGES = 12;
 
 /**
- * Width-cost fraction at or above which an extreme-AR item claims its OWN
- * full-width row. Paired with an extremeness gate (see {@link isSoloHero}); the
- * fraction alone is not enough because a normal landscape at a small rowWidth can
- * exceed it (a 3★ landscape Hv ≈ 2.11 is 0.53 of a rowWidth-4 budget) — that
- * would collapse low-density rows into full-width singles.
+ * Width-cost fraction at or above which an extreme-AR item claims its own full-width
+ * row. Paired with an extremeness gate (see isSoloHero): the fraction alone is not
+ * enough, since a normal landscape at a small rowWidth can exceed it.
  */
 export const HERO_SOLO_WIDTH_FRACTION = 0.5;
 
 /**
- * Whether an item should claim its own full-width row — the emergent successor to
- * the retired isFullWidthHero rule. Two gates, both required:
+ * Whether an item should claim its own full-width row. Both gates are required:
  *
- * 1. **Extremeness gate** ({@link getArExtremeness} ≥ {@link EXTREMENESS_RAMP_START}):
- *    only images far from square in EITHER direction are solo-eligible. This ties
- *    eligibility to the prominence model's own extremeness concept (no new magic
- *    number) and subsumes the old AR≥2 gate. A normal landscape (ext 1.78 < 2) is
- *    never eligible at any rowWidth; the rating gate is correctly dropped per the
- *    prominence philosophy.
- * 2. **Width-cost gate** (Hv / rowWidth ≥ {@link HERO_SOLO_WIDTH_FRACTION}):
- *    the item's width-cost must dominate the row budget. This subsumes the old
- *    density ceiling — a wide 5★ pano (Hv ≈ 5.48) clears 0.5 of a rowWidth-10
- *    budget (low/medium density → solos) but only 0.27 of a rowWidth-20 budget
- *    (high density → shares).
+ * 1. Extremeness: getArExtremeness ≥ EXTREMENESS_RAMP_START — only images far from
+ *    square (in either direction) are eligible.
+ * 2. Width-cost: Hv / rowWidth ≥ HERO_SOLO_WIDTH_FRACTION — the item must dominate the
+ *    row budget, so a wide pano solos at low density but shares at high density.
  *
- * A tall portrait passes the extremeness gate but its small Hv keeps its
- * width-fraction below the bar, so it never solos — its prominence is expressed
- * as row height via {@link rowTargetAR}, not a solo row. Disabled on mobile
- * (rowWidth ≤ 2) to keep the narrow-slot path unchanged.
+ * A tall portrait passes the extremeness gate but its small Hv keeps it below the
+ * width-cost bar, so it never solos; its prominence shows as row height via
+ * rowTargetAR instead. Disabled on mobile (rowWidth ≤ 2).
  */
 export function isSoloHero(item: AnyContentModel, rowWidth: number): boolean {
   if (rowWidth <= 2) return false;
@@ -357,11 +331,9 @@ function padRowToWidth(
 }
 
 /**
- * Estimate a row's combined aspect ratio. Routes through the CHEAP single-structure
- * composer (point-balance tree only) so the Stage-1 fill loop stays fast — the
- * multi-structure equity search is reserved for final per-row composition. This
- * keeps the density→size monotonicity shipped 2026-05-29 unchanged (membership
- * decisions never run the expensive search).
+ * Estimate a row's combined aspect ratio via the cheap single-structure composer
+ * (point-balance tree only), keeping the Stage-1 fill loop fast. The expensive
+ * multi-structure equity search runs only at final per-row composition.
  */
 export function estimateRowAR(images: ImageType[], targetAR: number): number {
   if (images.length === 0) throw new Error('estimateRowAR requires at least 1 image');
@@ -377,7 +349,7 @@ export function estimateRowAR(images: ImageType[], targetAR: number): number {
 // buildRows
 // =============================================================================
 
-/** Collect non-skipped items from a window for row building */
+/** Collect the first `count` non-skipped items from a window. */
 function collectRowItems(
   window: AnyContentModel[],
   count: number,
@@ -395,16 +367,15 @@ function collectRowItems(
 }
 
 /**
- * Row-first layout algorithm. Builds rows over a lookahead window:
- * standalone-skips a hero past low-rated items, greedy sequential fill (by the
- * width-cost Hv = √(P·AR)), best-fit fallback, then builds each row's atomic
- * tree. A wide top-rated panorama claiming its own row at low/medium density is
- * an EMERGENT consequence of its large Hv exceeding the row budget — no longer a
- * hard-coded special case. AR-floor check is disabled on mobile (rowWidth <= 2).
+ * Row-first layout. Over a lookahead window it optionally skips a leading low-rated
+ * run to surface a solo hero, greedily fills by width-cost Hv, falls back to best-fit,
+ * then builds each row's atomic tree. A wide top-rated panorama claiming its own row
+ * is an emergent result of its large Hv exceeding the budget, not a special case. The
+ * AR-floor check is disabled on mobile (rowWidth ≤ 2).
  *
- * @param rowWidth - Row width budget (5 for desktop, 4 for tablet, etc.)
- * @param targetARBaseline - Baseline (viewport) target AR. Fill/estimate use it directly;
- *   each row's final composition derives a per-row target from it via {@link rowTargetAR}.
+ * @param rowWidth - Row width budget (5 desktop, 4 tablet, etc.).
+ * @param targetARBaseline - Baseline (viewport) target AR. Fill and estimate use it
+ *   directly; each row derives a per-row target from it via rowTargetAR.
  */
 export function buildRows(
   items: AnyContentModel[],
@@ -414,17 +385,11 @@ export function buildRows(
   const rows: RowResult[] = [];
   const remaining = [...items];
 
-  // Constant fill bar: density drives packing through rowWidth (chunkSize ×2.5),
-  // so a rowWidth-scaled bar would over-inflate past MAX_FILL_RATIO at high density.
   const effectiveMinFill = MIN_FILL_RATIO;
 
   while (remaining.length > 0) {
     const window = remaining.slice(0, 5);
 
-    // Emergent full-width hero: a leading extreme-AR item whose width-cost
-    // dominates the row budget claims its own row (see {@link isSoloHero}).
-    // Replaces the retired isFullWidthHero AR+rating rule — a wide top-rated
-    // panorama qualifies at low/medium density and shares at high density.
     if (isSoloHero(window[0]!, rowWidth)) {
       const heroItem = window[0]!;
       rows.push({
@@ -472,41 +437,33 @@ export function buildRows(
     let slotCountComplete = false;
 
     for (let i = 0; i < expandedWindow.length; i++) {
-      const cv = getWidthCost(expandedWindow[i]!);
+      const widthCost = getWidthCost(expandedWindow[i]!);
 
-      // Emergent full-width hero (mid-window): once the row has started, a later
-      // solo-eligible item (see {@link isSoloHero}) is skipped here so it surfaces
-      // as a leading solo hero on the next iteration. Mirrors the leading-item
-      // check above; replaces the retired isFullWidthHero skip.
       if (seqCount > 0 && isSoloHero(expandedWindow[i]!, rowWidth)) {
         skippedStandalones.push(i);
         continue;
       }
 
-      const newFill = (seqTotal + cv) / rowWidth;
+      const newFill = (seqTotal + widthCost) / rowWidth;
 
       if (newFill > MAX_FILL_RATIO && !slotCountComplete) {
-        // Accept moderate overfill when the row is still under the density-
-        // scaled MIN_FILL bar — solo underfilled row is worse than slight overfill.
         const currentFill = seqTotal / rowWidth;
         if (currentFill < effectiveMinFill && newFill <= 1.35) {
-          seqTotal += cv;
+          seqTotal += widthCost;
           seqCount += 1;
         }
         break;
       }
 
       if (slotCountComplete) {
-        // Don't swallow high-rated images into someone else's row
         const candidateRating = getEffectiveRating(expandedWindow[i]!);
         if (candidateRating >= 4) {
           break;
         }
 
-        seqTotal += cv;
+        seqTotal += widthCost;
         seqCount += 1;
 
-        // Re-check AR with the expanded set
         const expandedItems = collectRowItems(expandedWindow, seqCount, skippedStandalones);
         const expandedImgs = expandedItems.map(item => toImageType(item));
         const expandedAR = estimateRowAR(expandedImgs, targetARBaseline);
@@ -514,7 +471,7 @@ export function buildRows(
         continue;
       }
 
-      seqTotal += cv;
+      seqTotal += widthCost;
       seqCount += 1;
 
       if (newFill >= effectiveMinFill) {
@@ -541,11 +498,11 @@ export function buildRows(
       });
 
       const usedIndices = new Set<number>();
-      let t = 0;
-      for (let i = 0; i < expandedWindow.length && t < seqCount; i++) {
+      let taken = 0;
+      for (let i = 0; i < expandedWindow.length && taken < seqCount; i++) {
         if (!skippedStandalones.includes(i)) {
           usedIndices.add(i);
-          t++;
+          taken++;
         }
       }
       const sortedUsed = [...usedIndices].sort((a, b) => b - a);
@@ -564,14 +521,12 @@ export function buildRows(
     available.delete(0);
 
     if (!isRowComplete(bfComponents, rowWidth)) {
-      // Take items in sequential order to preserve original ordering.
-      // Previous approach picked by cv-distance-to-gap which scrambled order.
       for (let idx = 1; idx < window.length; idx++) {
         if (!available.has(idx)) continue;
 
-        const currentTotal = getTotalCV(bfComponents);
-        const candidateCV = getWidthCost(window[idx]!);
-        const newTotal = currentTotal + candidateCV;
+        const currentTotal = getTotalWidthCost(bfComponents);
+        const candidateWidthCost = getWidthCost(window[idx]!);
+        const newTotal = currentTotal + candidateWidthCost;
         const newFill = newTotal / rowWidth;
 
         if (newFill > MAX_FILL_RATIO) {
@@ -580,10 +535,10 @@ export function buildRows(
           const overfillDistance = Math.abs(1.0 - newFill);
 
           if (currentFill >= MIN_FILL_RATIO) {
-            break; // Row already well-filled, stop here
+            break;
           }
           if (underfillDistance <= overfillDistance) {
-            continue; // Skip this item, try next (it's too big but row needs more)
+            continue;
           }
           bfComponents.push(window[idx]!);
           bfUsedIndices.push(idx);
@@ -624,14 +579,12 @@ export function buildRows(
 // =============================================================================
 // ROW COMPOSITION
 // =============================================================================
-// buildAtomic — final-row composer. Enumerates candidate tree SHAPES (Phase 1b,
-// multi-structure) × direction assignments (Phase 2), then selects equity-primary
-// (area tracks prominence P) under a hard AR-1.0 floor + soft CEILING_MULT ceiling.
-// The cheap single point-balance split (Phase 1, pickRootAssignment) is reserved
-// for the Stage-1 fill estimator. Algorithm & rationale: ./rowCombination.md
-//
-// Phase 1 (splitByPointBalance) — single point-balance hierarchical split, the
-// Stage-1 AR estimator only.
+// buildAtomic composes each finalized row: it enumerates candidate tree shapes
+// (enumerateStructures) and every H/V direction assignment, then selects the one
+// whose leaf areas best track prominence P under a hard AR-1.0 floor and a soft
+// CEILING_MULT ceiling. The cheap single point-balance split (splitByPointBalance +
+// pickRootAssignment) backs only the Stage-1 AR estimator.
+// Algorithm & rationale: ./rowCombination.md
 // =============================================================================
 
 type AbstractNode =
@@ -639,19 +592,14 @@ type AbstractNode =
   | { kind: 'merge'; left: AbstractNode; right: AbstractNode };
 
 /**
- * Build the unlabeled binary tree by recursively splitting at the adjacent
- * boundary whose two halves have the closest effectiveRating sums. Order
- * preserved — no swaps, only splits.
- *
- * Balances on effectiveRating (now penalty-free — equal to the raw rating for
- * both orientations) rather than the width-cost cv, so the split point reflects
- * prominence, not packing width. See ./rowCombination.md.
+ * Build an unlabeled binary tree by recursively splitting at the adjacent boundary
+ * whose two halves have the closest effectiveRating sums. Order is preserved (only
+ * splits, no swaps), so the split reflects prominence rather than packing width.
  */
 function splitByPointBalance(items: ImageType[]): AbstractNode {
   if (items.length === 0) throw new Error('buildAtomic requires at least 1 image');
   if (items.length === 1) return { kind: 'leaf', img: items[0]! };
 
-  // For 2 items there's only one valid split.
   if (items.length === 2) {
     return {
       kind: 'merge',
@@ -660,14 +608,10 @@ function splitByPointBalance(items: ImageType[]): AbstractNode {
     };
   }
 
-  // Total effectiveRating "points" across all items.
   let total = 0;
-  for (const it of items) total += it.effectiveRating;
+  for (const item of items) total += item.effectiveRating;
   const half = total / 2;
 
-  // Walk adjacent splits left-to-right tracking running leftSum.
-  // Score = |leftSum − half| + |rightSum − half| (lower is more balanced).
-  // Tiebreaker: distance from the middle gap index.
   const middleGapIdx = (items.length - 2) / 2;
   let leftSum = 0;
   let bestGapIdx = 0;
@@ -685,7 +629,6 @@ function splitByPointBalance(items: ImageType[]): AbstractNode {
     }
   }
 
-  // Split AFTER bestGapIdx — items [0..bestGapIdx] go left, the rest right.
   const splitPoint = bestGapIdx + 1;
   return {
     kind: 'merge',
@@ -695,33 +638,25 @@ function splitByPointBalance(items: ImageType[]): AbstractNode {
 }
 
 // =============================================================================
-// Phase 1b — candidate STRUCTURE generator (area-to-value)
+// Candidate structure generator
 // =============================================================================
-//
-// Replaces the single point-balance shape with a BOUNDED SET of order-preserving
-// binary tree SHAPES (no direction yet). Order is always preserved — only adjacent
-// splits. The point-balance tree is ALWAYS included so results are never worse than
-// today. Each shape is then fed to enumerateAssignments for H/V directions and
-// scored equity-primary in pickBestComposition.
 
 /**
- * Full enumeration cutoff. For n ≤ N_FULL we emit ALL order-preserving binary
- * trees (the Catalan set: C(n-1) shapes — 42 for n=6). For n > N_FULL we fall
- * back to the bounded generator.
+ * Full-enumeration cutoff. For n ≤ N_FULL emit every order-preserving binary tree
+ * (the Catalan set: C(n-1) shapes, 42 for n=6); for n > N_FULL use the bounded
+ * generator instead.
  */
 const N_FULL = 6;
 
 /**
- * Hard cap on the number of SHAPES generated for n > N_FULL. Bounds the
- * structure × direction search so an n=12 row composes within budget
- * (~11k candidates, a few ms — validated by the perf guard test).
+ * Hard cap on shapes generated for n > N_FULL. Bounds the structure × direction
+ * search so an n=12 row composes within budget (~11k candidates, a few ms).
  */
 const STRUCTURE_CAP = 64;
 
 /**
- * All order-preserving binary tree shapes over `items` (the Catalan set).
- * Memoized on (lo, hi) ranges so repeated subranges are not rebuilt. Cost is
- * C(n-1) shapes — 42 for n=6, 132 for n=7 — so guarded by N_FULL upstream.
+ * Every order-preserving binary tree shape over `items` (the Catalan set), memoized
+ * on (lo, hi) ranges. Cost is C(n-1) shapes, so it is guarded by N_FULL upstream.
  */
 function enumerateFullShapes(items: ImageType[]): AbstractNode[] {
   const memo = new Map<string, AbstractNode[]>();
@@ -734,9 +669,9 @@ function enumerateFullShapes(items: ImageType[]): AbstractNode[] {
     for (let split = lo; split < hi; split++) {
       const lefts = build(lo, split);
       const rights = build(split + 1, hi);
-      for (const l of lefts) {
-        for (const r of rights) {
-          out.push({ kind: 'merge', left: l, right: r });
+      for (const left of lefts) {
+        for (const right of rights) {
+          out.push({ kind: 'merge', left, right });
         }
       }
     }
@@ -747,30 +682,29 @@ function enumerateFullShapes(items: ImageType[]): AbstractNode[] {
 }
 
 /**
- * Bounded shape generator for n > N_FULL. Recursively splits at the top-K most
- * point-balanced adjacent boundaries (instead of only the single best), capping
- * the total shape count at STRUCTURE_CAP. Always seeds the legacy point-balance
- * tree first so the result is never worse than today.
+ * Bounded shape generator for n > N_FULL. Seeds the point-balance tree first (so the
+ * result is never worse than the single-structure path), then adds alternative
+ * top-level splits and a few leaf-to-root shapes (which can hand a hero its own
+ * full-height column), all capped at STRUCTURE_CAP.
  */
 function enumerateBoundedShapes(items: ImageType[]): AbstractNode[] {
   const seen = new Set<string>();
   const shapes: AbstractNode[] = [];
 
-  const keyOf = (n: AbstractNode): string =>
-    n.kind === 'leaf' ? `L${n.img.source.id}` : `(${keyOf(n.left)}|${keyOf(n.right)})`;
+  const keyOf = (node: AbstractNode): string =>
+    node.kind === 'leaf' ? `L${node.img.source.id}` : `(${keyOf(node.left)}|${keyOf(node.right)})`;
 
-  const push = (n: AbstractNode): boolean => {
-    const k = keyOf(n);
-    if (seen.has(k)) return true;
-    seen.add(k);
-    shapes.push(n);
+  const push = (node: AbstractNode): boolean => {
+    const key = keyOf(node);
+    if (seen.has(key)) return true;
+    seen.add(key);
+    shapes.push(node);
     return shapes.length < STRUCTURE_CAP;
   };
 
-  // Ranked adjacent split boundaries for a slice, best-balanced first.
   const rankedSplits = (slice: ImageType[]): number[] => {
     let total = 0;
-    for (const it of slice) total += it.effectiveRating;
+    for (const item of slice) total += item.effectiveRating;
     const half = total / 2;
     const scored: Array<{ idx: number; score: number }> = [];
     let leftSum = 0;
@@ -780,16 +714,14 @@ function enumerateBoundedShapes(items: ImageType[]): AbstractNode[] {
       scored.push({ idx: i, score: Math.abs(leftSum - half) + Math.abs(rightSum - half) });
     }
     scored.sort((a, b) => a.score - b.score);
-    return scored.map(s => s.idx);
+    return scored.map(entry => entry.idx);
   };
 
-  // 1) Legacy point-balance tree first (guarantees never-worse-than-today).
   if (!push(splitByPointBalance(items))) return shapes;
 
-  // 2) Alternative top-level split points, each recursively point-balanced.
   const topSplits = rankedSplits(items);
-  for (let r = 0; r < topSplits.length; r++) {
-    const split = topSplits[r]! + 1;
+  for (let i = 0; i < topSplits.length; i++) {
+    const split = topSplits[i]! + 1;
     const alt: AbstractNode = {
       kind: 'merge',
       left: splitByPointBalance(items.slice(0, split)),
@@ -798,8 +730,6 @@ function enumerateBoundedShapes(items: ImageType[]): AbstractNode[] {
     if (!push(alt)) return shapes;
   }
 
-  // 3) A few extra shapes that pull a single leaf to the root on each side —
-  //    the structural lever that hands a hero its own full-height column.
   for (let lead = 1; lead <= Math.min(2, items.length - 1); lead++) {
     const leftLead: AbstractNode = {
       kind: 'merge',
@@ -820,10 +750,9 @@ function enumerateBoundedShapes(items: ImageType[]): AbstractNode[] {
 }
 
 /**
- * Candidate structure generator. Returns order-preserving binary tree SHAPES
- * (direction-free AbstractNodes). For n ≤ N_FULL: the full Catalan set. For
- * n > N_FULL: a bounded set capped at STRUCTURE_CAP, always including the legacy
- * point-balance tree.
+ * Candidate structure generator. Returns order-preserving binary tree shapes: the
+ * full Catalan set for n ≤ N_FULL, otherwise a bounded set (STRUCTURE_CAP) that
+ * always includes the point-balance tree.
  */
 function enumerateStructures(items: ImageType[]): AbstractNode[] {
   if (items.length <= 1) return [{ kind: 'leaf', img: items[0]! }];
@@ -840,65 +769,60 @@ function enumerateStructures(items: ImageType[]): AbstractNode[] {
 }
 
 // =============================================================================
-// Phase 2 — enumerate direction assignments, score by root-row constraint
+// Direction assignment and scoring
 // =============================================================================
 
-/** One candidate direction assignment for a subtree. */
+/** One candidate direction assignment for a subtree, with its resulting AR. */
 interface Candidate {
   component: AtomicComponent;
-  /** Resulting aspect ratio if this assignment is used. */
   ar: number;
 }
 
-/**
- * A row must never be taller than it is wide, so AR has a hard floor at 1.0.
- * Sub-floor candidates get a large penalty (the least-tall one is preferred
- * only as a last resort when nothing reaches the floor). At or above the floor,
- * the candidate closest to the square target wins.
- */
+/** A row is never taller than wide, so its AR has a hard floor at 1.0. */
 const ROW_AR_FLOOR = 1.0;
 
+/**
+ * Stage-1 AR cost: sub-floor candidates get a large penalty (preferred only as a last
+ * resort); at or above the floor, the candidate closest to the target wins.
+ */
 function rowAR_Cost(rowAR: number, target: number): number {
   if (rowAR < ROW_AR_FLOOR) return 1000 + (ROW_AR_FLOOR - rowAR);
   return Math.abs(rowAR - Math.max(target, ROW_AR_FLOOR));
 }
 
 // =============================================================================
-// area-to-value: equity-primary selection across (shape × direction)
+// Area-to-value selection
 // =============================================================================
 
 /**
- * Weight of the AR-target deviation term in the equity-primary score. Small so
- * equitySpread (area tracks prominence P) dominates and the AR-target only pulls
- * AMONG near-equity options. Replaces the retired AR_EQUITY_BAND tiebreak gate.
+ * Weight of the AR-target term in the equity-primary score. Small, so equitySpread
+ * (area tracks prominence) dominates and the AR-target only breaks ties among
+ * near-equity options.
  */
 const LAMBDA = 0.15;
 
 /**
- * Soft upper bound on row AR, expressed as a multiple of the row's target. A row
- * wider than CEILING_MULT × target is hard-rejected (mirror of the hard lower
- * floor). Prevents equity from collapsing a horizontal row into a thin strip
- * without raising λ globally (which would over-square vertical-hero rows).
+ * Soft upper bound on row AR, as a multiple of the row's target. A row wider than
+ * CEILING_MULT × target is rejected (mirror of the hard lower floor), so equity
+ * cannot collapse a horizontal row into a thin strip.
  */
 const CEILING_MULT = 2.0;
 
 /**
- * Scale-symmetric AR distance term: |ln(rowAR / target)|. Symmetric in log space
- * so being 2× too wide and 2× too tall cost the same; the hard floor (1.0) and
- * the CEILING_MULT ceiling carry the asymmetric "never taller than wide / never a
- * thin strip" constraints, leaving this term as a pure closeness-to-target pull.
+ * Scale-symmetric AR distance |ln(rowAR / target)|: being 2× too wide and 2× too tall
+ * cost the same. The hard floor and CEILING_MULT ceiling carry the asymmetric
+ * constraints; this term is a pure closeness-to-target pull.
  */
 function arPenalty(rowAR: number, target: number): number {
-  const t = Math.max(target, ROW_AR_FLOOR);
-  return Math.abs(Math.log(rowAR / t));
+  const safeTarget = Math.max(target, ROW_AR_FLOOR);
+  return Math.abs(Math.log(rowAR / safeTarget));
 }
 
 /**
- * Relative area each leaf occupies (and its prominence P) for a fully
- * direction-assigned subtree. Area splits geometrically: hPair ∝ AR, vStack ∝ 1/AR.
- * Leaf shares sum to 1 within the subtree. `value` is prominence P (orientation-agnostic),
- * so {@link equitySpread} rewards high-rated verticals with more area rather than
- * penalising them via the packing cv.
+ * Relative area of each leaf (and its prominence) for a fully direction-assigned
+ * subtree. Area splits geometrically: hPair ∝ AR, vStack ∝ 1/AR; leaf shares sum to 1
+ * within the subtree. `value` is prominence P, so equitySpread rewards high-rated
+ * verticals with more area.
  */
 function leafShares(ac: AtomicComponent): {
   ar: number;
@@ -909,29 +833,26 @@ function leafShares(ac: AtomicComponent): {
   }
   const left = leafShares(ac.children[0]);
   const right = leafShares(ac.children[1]);
-  const aL = left.ar;
-  const aR = right.ar;
-  const sum = aL + aR;
+  const leftAR = left.ar;
+  const rightAR = right.ar;
+  const sum = leftAR + rightAR;
   const isH = ac.direction === 'H';
-  const ar = isH ? sum : (aL * aR) / sum;
-  // hPair: area ∝ AR. vStack: area ∝ 1/AR → left gets aR/sum, right gets aL/sum.
-  const leftFactor = isH ? aL / sum : aR / sum;
-  const rightFactor = isH ? aR / sum : aL / sum;
+  const ar = isH ? sum : (leftAR * rightAR) / sum;
+  const leftFactor = isH ? leftAR / sum : rightAR / sum;
+  const rightFactor = isH ? rightAR / sum : leftAR / sum;
   return {
     ar,
     leaves: [
-      ...left.leaves.map(l => ({ value: l.value, share: l.share * leftFactor })),
-      ...right.leaves.map(l => ({ value: l.value, share: l.share * rightFactor })),
+      ...left.leaves.map(leaf => ({ value: leaf.value, share: leaf.share * leftFactor })),
+      ...right.leaves.map(leaf => ({ value: leaf.value, share: leaf.share * rightFactor })),
     ],
   };
 }
 
 /**
- * How unevenly a candidate sizes its images relative to their prominence.
- * Returns max(area/value) / min(area/value) across leaves: 1.0 = perfectly
- * proportional; larger = some image is over- or under-sized. Lower is better.
- * Uses prominence P (orientation-agnostic) so high-rated verticals are not
- * penalised by the vertical-penalty baked into packing cv.
+ * How unevenly a candidate sizes its images relative to prominence:
+ * max(area/value) / min(area/value) across leaves. 1.0 = perfectly proportional;
+ * larger is worse. Uses prominence P so high-rated verticals are not penalized.
  */
 function equitySpread(ac: AtomicComponent): number {
   const { leaves } = leafShares(ac);
@@ -947,10 +868,9 @@ function equitySpread(ac: AtomicComponent): number {
 }
 
 /**
- * Enumerate every possible (direction-assigned) AtomicComponent for a subtree.
- * Returns one candidate per leaf, two candidates (hPair + vStack) at every
- * internal node, multiplied across nesting. Cost is 2^N where N is the number
- * of internal nodes in the subtree — bounded by row size (≤8 items → ≤128).
+ * Every direction-assigned AtomicComponent for a subtree: one candidate per leaf, an
+ * hPair and a vStack at each internal node, multiplied across nesting. Cost is 2^N in
+ * the number of internal nodes, bounded by row size.
  */
 function enumerateAssignments(node: AbstractNode): Candidate[] {
   if (node.kind === 'leaf') {
@@ -959,18 +879,16 @@ function enumerateAssignments(node: AbstractNode): Candidate[] {
   const leftOptions = enumerateAssignments(node.left);
   const rightOptions = enumerateAssignments(node.right);
   const out: Candidate[] = [];
-  for (const l of leftOptions) {
-    for (const r of rightOptions) {
+  for (const leftOption of leftOptions) {
+    for (const rightOption of rightOptions) {
       out.push(
-        // hPair: total = leftAR + rightAR
         {
-          component: hPair(l.component, r.component),
-          ar: l.ar + r.ar,
+          component: hPair(leftOption.component, rightOption.component),
+          ar: leftOption.ar + rightOption.ar,
         },
-        // vStack: 1/total = 1/leftAR + 1/rightAR
         {
-          component: vStack(l.component, r.component),
-          ar: (l.ar * r.ar) / (l.ar + r.ar),
+          component: vStack(leftOption.component, rightOption.component),
+          ar: (leftOption.ar * rightOption.ar) / (leftOption.ar + rightOption.ar),
         }
       );
     }
@@ -979,51 +897,38 @@ function enumerateAssignments(node: AbstractNode): Candidate[] {
 }
 
 /**
- * Pick the AR-closest direction assignment for a single point-balance tree.
- *
- * Stage-1 ONLY — the cheap estimator behind {@link estimateRowAR}. Root is forced
- * hPair (rows are horizontal by definition); among the children's direction
- * assignments the one with the lowest {@link rowAR_Cost} wins (closest to target,
- * sub-floor candidates carry a huge cost so the floor is preserved). No equity
- * search here: the multi-structure equity-primary selection runs ONLY at final
- * composition ({@link pickBestComposition}), keeping the Stage-1 fill loop fast.
+ * AR-closest direction assignment for a single point-balance tree — the cheap Stage-1
+ * estimator behind estimateRowAR. The root is forced hPair (rows are horizontal);
+ * among the children's assignments the lowest rowAR_Cost wins. No equity search here;
+ * that runs only at final composition.
  */
 function pickRootAssignment(tree: AbstractNode, targetAR: number): AtomicComponent {
-  // Leaf-only trees should never reach Phase 2 (handled by buildAtomic entry).
   if (tree.kind === 'leaf') return single(tree.img);
 
   const leftOptions = enumerateAssignments(tree.left);
   const rightOptions = enumerateAssignments(tree.right);
 
-  // Root forced hPair; pick the lowest-arCost combination. Cheap: <= 2^(n-1)
-  // candidates for an n-leaf row, n bounded by MAX_ROW_IMAGES.
   let best: AtomicComponent | null = null;
   let bestArCost = Infinity;
-  for (const l of leftOptions) {
-    for (const r of rightOptions) {
-      const arCost = rowAR_Cost(l.ar + r.ar, targetAR);
+  for (const leftOption of leftOptions) {
+    for (const rightOption of rightOptions) {
+      const arCost = rowAR_Cost(leftOption.ar + rightOption.ar, targetAR);
       if (arCost < bestArCost) {
         bestArCost = arCost;
-        best = hPair(l.component, r.component);
+        best = hPair(leftOption.component, rightOption.component);
       }
     }
   }
-  // At least one candidate always exists for a non-leaf tree, so `best` is set.
   return best!;
 }
 
 /**
- * Equity-primary composition across every candidate STRUCTURE shape and every
- * (root-forced-hPair) direction assignment — the area-to-value selector. Hard-
- * rejects rows below the AR floor (1.0) or above the soft ceiling
- * (CEILING_MULT × target). Among survivors, minimizes
- *   score = equitySpread + LAMBDA · arPenalty(rowAR, target)
- * (equitySpread primary — area tracks prominence P; AR-target soft secondary).
- * Tiebreak: closer rowAR to target. No AR_EQUITY_BAND gate — equity is the
- * primary objective.
- *
- * Counts candidates/shapes evaluated (for the perf-guard test) via the optional
- * sink.
+ * Equity-primary composition across every candidate shape and every root-hPair
+ * direction assignment. Rejects rows below the AR floor (1.0) or above the ceiling
+ * (CEILING_MULT × target); among survivors, minimizes
+ * equitySpread + LAMBDA · arPenalty(rowAR, target), tiebroken by closeness to target.
+ * Falls back to the AR-closest candidate (then a flat hChain) only if nothing lands in
+ * band. `counters`, when passed, records shapes/candidates for the perf-guard test.
  */
 function pickBestComposition(
   items: ImageType[],
@@ -1035,19 +940,12 @@ function pickBestComposition(
   const target = Math.max(targetAR, ROW_AR_FLOOR);
   const ceiling = CEILING_MULT * target;
 
-  // In-band winner: lowest equity-primary score among candidates within
-  // [floor, ceiling]. arClosest is the AR-closest candidate overall (by
-  // rowAR_Cost, which hard-penalises sub-floor) and is used ONLY when nothing
-  // lands in band — so a too-wide row beats a taller-than-wide one, and we never
-  // fall through to the flat (widest-possible) hChain.
   let best: AtomicComponent | null = null;
   let bestScore = Infinity;
   let bestArDist = Infinity;
   let arClosest: AtomicComponent | null = null;
   let arClosestCost = Infinity;
 
-  // Root forced hPair: rows are horizontal by definition, so a candidate's row AR
-  // is the sum of its two children's ARs.
   const consider = (component: AtomicComponent, rowAR: number): void => {
     if (counters) counters.candidates += 1;
     const cost = rowAR_Cost(rowAR, target);
@@ -1055,7 +953,7 @@ function pickBestComposition(
       arClosestCost = cost;
       arClosest = component;
     }
-    if (rowAR < ROW_AR_FLOOR || rowAR > ceiling) return; // out of band — fallback only
+    if (rowAR < ROW_AR_FLOOR || rowAR > ceiling) return;
     const score = equitySpread(component) + LAMBDA * arPenalty(rowAR, target);
     const arDist = Math.abs(rowAR - target);
     if (score < bestScore || (score === bestScore && arDist < bestArDist)) {
@@ -1072,9 +970,12 @@ function pickBestComposition(
     }
     const leftOptions = enumerateAssignments(shape.left);
     const rightOptions = enumerateAssignments(shape.right);
-    for (const l of leftOptions) {
-      for (const r of rightOptions) {
-        consider(hPair(l.component, r.component), l.ar + r.ar);
+    for (const leftOption of leftOptions) {
+      for (const rightOption of rightOptions) {
+        consider(
+          hPair(leftOption.component, rightOption.component),
+          leftOption.ar + rightOption.ar
+        );
       }
     }
   }
@@ -1087,13 +988,9 @@ function pickBestComposition(
 // =============================================================================
 
 /**
- * Build a row's atomic component tree. Leaves stay in input order. targetAR below
- * ROW_AR_FLOOR (1.0) is lifted to it.
- *
- * Final per-row composition runs the multi-structure equity-primary search
- * (enumerateStructures × enumerateAssignments). The cheap single-structure path
- * (splitByPointBalance + pickRootAssignment) is reserved for estimateRowAR in the
- * Stage-1 fill loop. targetAR is the per-row target; AR is intrinsic to the tree.
+ * Build a row's atomic component tree, leaves in input order. Runs the multi-structure
+ * equity-primary search; targetAR below ROW_AR_FLOOR (1.0) is lifted to it. The cheap
+ * single-structure path backs estimateRowAR in the Stage-1 fill loop.
  */
 export function buildAtomic(items: ImageType[], targetAR: number): AtomicComponent {
   if (items.length === 0) throw new Error('buildAtomic requires at least 1 image');
@@ -1103,9 +1000,9 @@ export function buildAtomic(items: ImageType[], targetAR: number): AtomicCompone
 }
 
 /**
- * Compose a row AND report the number of candidate shapes / direction assignments
- * evaluated. Backs the perf-guard test (asserts the search stays bounded — e.g.
- * an n=12 row stays well under STRUCTURE_CAP shapes). Not used by production code.
+ * Compose a row and report how many candidate shapes / direction assignments were
+ * evaluated. Backs the perf-guard test (the search stays bounded). Not used in
+ * production.
  */
 export function composeRowWithCandidateCount(
   items: ImageType[],

--- a/tests/utils/rowCombination.test.ts
+++ b/tests/utils/rowCombination.test.ts
@@ -1426,7 +1426,7 @@ describe('row density packing', () => {
 
   it('does not drop a high-cost 5★ image at rowWidth 3 (best-fit fallback forces its row)', () => {
     // 5★ cv 5.0 at rowWidth 3 = fill 1.67 on the first item → greedy fill exits
-    // with seqCount 0; the best-fit fallback must still give it its own row.
+    // with sequentialCount 0; the best-fit fallback must still give it its own row.
     const items = [createHorizontalImage(1, 5), createHorizontalImage(2, 3)];
     const rows = buildRows(items, 3, 1.0);
     const total = rows.reduce((n, r) => n + r.components.length, 0);


### PR DESCRIPTION
Readability pass over `app/utils/rowCombination.ts`, the two-stage row layout engine. Identifiers and comments only — no logic change.

## What changes

**Renames**, each applied consistently at declaration and every use:

| before | after |
|---|---|
| `getTotalCV` | `getTotalWidthCost` |
| `cv` | `widthCost` |
| `it` | `item` |
| `l` / `r` | `left` / `right` |
| `aL` / `aR` | `leftAR` / `rightAR` |
| `n` | `node` |
| `k` | `key` |
| `t` | `taken` / `safeTarget` |

**Comments** — archaeology-heavy docblocks trimmed to concise form and all inline comments removed, per the docblocks-only convention. This is where the net −103 lines comes from; the code itself is close to unchanged in volume.

The one edit that reads like logic is `topSplits[r]` → `topSplits[i]`, which is the loop variable rename applied to both the `for` declaration and its use in the same hunk.

## Why the identifiers matter here

This file carries the equity-primary objective (`equitySpread + λ·arPenalty`) and the AR floor/ceiling bounds. Single-letter names like `aL`/`aR`/`cv` in that math are the main obstacle to reviewing whether a future change to row composition is correct.

## A rename collided with new code on main

The rename of `getTotalCV` collided with `padRowToWidth`, which `main` added independently and which calls `getTotalCV`. The two changes sit in different regions of the file, so **git rebased them with no conflict** — and the result failed to compile with `TS2304`, taking 151 tests down. The second commit points that call site at the new name.

Worth knowing because the failure mode isn't visible in a diff review: a rename in one branch plus a new caller in another produces a clean merge and a broken build.

## Verification

`tsc --noEmit` clean; 165 suites / 2589 tests passing, including the row-layout characterization suite that pins exact layout output. For a pure refactor of live layout code that suite passing unchanged is the load-bearing evidence.

## Note on the branch name

The branch is `claude/lcp-image-eager-loading-5d86eb`, which describes work that is not in it — there is no LCP or eager-loading change here. The branch was reused; only this refactor is in the diff.