### PR TITLE
feat(collections): typeless U3 — frontend becomes mixed-content ready

### DIFF
--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -117,7 +117,7 @@ export default function CollectionContentRenderer({
   const handleClick = useCallback(() => {
     if (contentType === 'TEXT') return;
     if (isReorderMode) return;
-    if (hasSlug && !onImageClick) return; // navigation handled by <Tile href>
+    if (isSlugNav) return; // navigation handled by <Tile href>
 
     const fullScreenContent: ViewableContent =
       contentType === 'GIF'
@@ -154,7 +154,7 @@ export default function CollectionContentRenderer({
     onImageClick,
     enableFullScreenView,
     onFullScreenImageClick,
-    hasSlug,
+    isSlugNav,
     isReorderMode,
   ]);
 

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -104,7 +104,8 @@ export default function CollectionContentRenderer({
   const parallaxRef = useParallax({ enableParallax });
 
   // COLLECTION tiles navigate via href; IMAGE/GIF fullscreen stays on onClick. `hasClickHandler`
-  // mirrors the guard logic in handleClick (TEXT/reorder produce no action).
+  // mirrors the guard logic in handleClick (TEXT/reorder produce no action). currentCollectionId
+  // is the manage/public discriminant — on the manage grid onImageClick is the router.
   const { hasClickHandler, isSlugNav } = getClickEligibility({
     contentType,
     isReorderMode,
@@ -112,6 +113,7 @@ export default function CollectionContentRenderer({
     onImageClick,
     enableFullScreenView,
     onFullScreenImageClick,
+    currentCollectionId,
   });
 
   const handleClick = useCallback(() => {

--- a/app/components/Content/ContentBlockWithFullScreen.tsx
+++ b/app/components/Content/ContentBlockWithFullScreen.tsx
@@ -8,6 +8,7 @@ import { useFullScreenImage } from '@/app/hooks/useFullScreenImage';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import { type CollectionModel } from '@/app/types/Collection';
 import { type AnyContentModel, type ViewableContent } from '@/app/types/Content';
+import { isCollectionCard } from '@/app/utils/contentRatingUtils';
 
 import Component from './Component';
 import styles from './ContentBlockWithFullScreen.module.scss';
@@ -108,11 +109,17 @@ export default function ContentBlockWithFullScreen({
    * Every content block that can open in the fullscreen viewer — still images, parallax images,
    * and animated GIF/MP4 blocks. The fullscreen prev/next navigation walks this list, so adding
    * GIFs here means they get the same swipe/arrow-key flow as images.
+   *
+   * Child-collection CARDS are excluded: `convertCollectionContentToParallax` stamps them
+   * `contentType: 'IMAGE'`, so a plain contentType check would put a collection cover into
+   * prev/next as a photograph with no EXIF and no route into the collection. Keyed on
+   * {@link isCollectionCard} so this can never disagree with the layout/badge code. The
+   * `?image=<id>` deep-link restore below reads the same list, so it is covered too.
    */
   const viewableBlocks = useMemo(() => {
     return allBlocks.filter(
       (block): block is ViewableContent =>
-        block.contentType === 'IMAGE' || block.contentType === 'GIF'
+        (block.contentType === 'IMAGE' || block.contentType === 'GIF') && !isCollectionCard(block)
     );
   }, [allBlocks]);
 

--- a/app/components/Content/collectionContentRendererUtils.ts
+++ b/app/components/Content/collectionContentRendererUtils.ts
@@ -62,6 +62,12 @@ export interface ClickEligibilityInput {
   onImageClick?: (imageId: number) => void;
   enableFullScreenView?: boolean;
   onFullScreenImageClick?: (image: ViewableContent) => void;
+  /**
+   * Set only on the manage path (EditModeLayer threads the collection id down); the public
+   * grid, TaxonomyPage, and LocationPage leave it undefined. Used here as the manage/public
+   * discriminant — see {@link getClickEligibility}.
+   */
+  currentCollectionId?: number;
 }
 
 /** Whether an item navigates via href (`isSlugNav`) and/or has a meaningful click action. */
@@ -72,9 +78,17 @@ export interface ClickEligibility {
 
 /**
  * Derive click eligibility for a content item. Slug-bearing items (collection cards — the only
- * blocks that carry a slug) navigate via href and that navigation WINS over `onImageClick`:
- * client-gallery select mode sets `onImageClick` grid-wide, and without this a child card would
- * silently become a download target carrying its content-table id instead of a link.
+ * blocks that carry a slug) navigate via href, and on the PUBLIC surface that navigation WINS
+ * over `onImageClick`: client-gallery select mode sets `onImageClick` grid-wide, and without
+ * this a child card would silently become a download target carrying its content-table id
+ * instead of a link.
+ *
+ * The manage grid (EditModeLayer) also sets `onImageClick` grid-wide, but there the handler is
+ * the router: it pushes `manageHref(childSlug)` so an admin drilling into a child collection
+ * STAYS in manage mode, and it is also what makes a card click a no-op while a cover image or a
+ * capture-date source is being picked. `currentCollectionId` is the manage/public discriminant
+ * (only EditModeLayer threads it down), so on that surface the handler keeps winning.
+ *
  * IMAGE/GIF fullscreen stays on `onClick`. TEXT and reorder mode produce no action.
  */
 export function getClickEligibility(input: ClickEligibilityInput): ClickEligibility {
@@ -85,9 +99,13 @@ export function getClickEligibility(input: ClickEligibilityInput): ClickEligibil
     onImageClick,
     enableFullScreenView,
     onFullScreenImageClick,
+    currentCollectionId,
   } = input;
 
-  const isSlugNav = !!hasSlug && !isReorderMode && contentType !== 'TEXT';
+  const isManage = currentCollectionId != null;
+
+  const isSlugNav =
+    !!hasSlug && !isReorderMode && contentType !== 'TEXT' && !(isManage && !!onImageClick);
 
   const hasClickHandler =
     contentType !== 'TEXT' &&

--- a/app/components/Content/collectionContentRendererUtils.ts
+++ b/app/components/Content/collectionContentRendererUtils.ts
@@ -71,10 +71,11 @@ export interface ClickEligibility {
 }
 
 /**
- * Derive click eligibility for a content item. COLLECTION tiles navigate via href; IMAGE/GIF
- * fullscreen stays on `onClick`. TEXT and reorder mode produce no action; slug-only navigation
- * fires when `hasSlug` is set and no `onImageClick` is present; otherwise a handler exists when
- * `onImageClick` or fullscreen is configured.
+ * Derive click eligibility for a content item. Slug-bearing items (collection cards — the only
+ * blocks that carry a slug) navigate via href and that navigation WINS over `onImageClick`:
+ * client-gallery select mode sets `onImageClick` grid-wide, and without this a child card would
+ * silently become a download target carrying its content-table id instead of a link.
+ * IMAGE/GIF fullscreen stays on `onClick`. TEXT and reorder mode produce no action.
  */
 export function getClickEligibility(input: ClickEligibilityInput): ClickEligibility {
   const {
@@ -86,14 +87,12 @@ export function getClickEligibility(input: ClickEligibilityInput): ClickEligibil
     onFullScreenImageClick,
   } = input;
 
-  const isSlugNav = !!hasSlug && !onImageClick && !isReorderMode && contentType !== 'TEXT';
+  const isSlugNav = !!hasSlug && !isReorderMode && contentType !== 'TEXT';
 
   const hasClickHandler =
     contentType !== 'TEXT' &&
     !isReorderMode &&
-    ((hasSlug !== undefined && !onImageClick) ||
-      !!onImageClick ||
-      !!(enableFullScreenView && onFullScreenImageClick));
+    (hasSlug !== undefined || !!onImageClick || !!(enableFullScreenView && onFullScreenImageClick));
 
   return { hasClickHandler, isSlugNav };
 }

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -195,13 +195,17 @@ export default function CollectionPageClient({
 
   const allCollections = useMemo(() => allContent.filter(isContentCollection), [allContent]);
 
-  const isCollectionDominant = allCollections.length > allImages.length;
+  // D7: image-derived dimensions are shown whenever the page has ANY image. The former
+  // `allCollections.length > allImages.length` comparison was constant per collection under the
+  // typed model; under mixed content it flips with a single content edit, so a sixth photo would
+  // make the Camera/Lens dropdowns reappear.
+  const hasImageFilters = allImages.length > 0;
 
   const visibility = useMemo(() => computeFilterVisibility(allImages), [allImages]);
 
   const baseCollectionOptions = useMemo<CollectionDimensions>(() => {
     const options = extractCollectionFilterOptions(allImages, allCollections);
-    if (isCollectionDominant) {
+    if (!hasImageFilters) {
       return {
         ...options,
         cameras: EMPTY_STRING_DIM,
@@ -210,7 +214,7 @@ export default function CollectionPageClient({
       };
     }
     return options;
-  }, [allImages, allCollections, isCollectionDominant]);
+  }, [allImages, allCollections, hasImageFilters]);
 
   const criteria = useMemo(() => buildCollectionCriteria(filterState), [filterState]);
 
@@ -223,9 +227,9 @@ export default function CollectionPageClient({
 
   const filteredImages = useMemo(() => filteredContent.filter(isImageContent), [filteredContent]);
 
-  // Collection-dominant (parent) pages suppress rating even when it varies — too
-  // few images for it to be a useful control there.
-  const showHighlyRated = visibility.highlyRated && !isCollectionDominant;
+  // `visibility.highlyRated` is already false below two images (canFilter), so no extra
+  // collection-count suppression is needed — see D7.
+  const showHighlyRated = visibility.highlyRated;
   const showDateSort = visibility.dateSort;
 
   const filteredAvailableOptions = useMemo(() => {

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -16,7 +16,6 @@ import {
   type FilterState,
   INITIAL_FILTER_STATE,
   initialDateSortDirection,
-  type LensType,
 } from '@/app/types/GalleryFilter';
 import {
   applyCollectionFilters,
@@ -80,9 +79,6 @@ interface CollectionPageClientProps {
   /** The viewer's GLOBAL saved (bookmarked) image ids, seeded server-side. Cross-collection. */
   initialSavedImageIds?: number[];
 }
-
-const EMPTY_STRING_DIM = { values: [] as readonly string[], filterable: true };
-const EMPTY_LENSTYPE_DIM = { values: [] as readonly LensType[], filterable: true };
 
 export default function CollectionPageClient({
   collection,
@@ -195,26 +191,19 @@ export default function CollectionPageClient({
 
   const allCollections = useMemo(() => allContent.filter(isContentCollection), [allContent]);
 
-  // D7: image-derived dimensions are shown whenever the page has ANY image. The former
+  const visibility = useMemo(() => computeFilterVisibility(allImages), [allImages]);
+
+  // D7: image-derived dimensions are shown whenever the page has ANY image, and no explicit
+  // suppression is needed to hide them otherwise — `extractCollectionFilterOptions` sources
+  // cameras/lenses/lensTypes from `allImages` alone, so a page with no images already yields
+  // empty values, and every consumer gates on `values.length`. The former
   // `allCollections.length > allImages.length` comparison was constant per collection under the
   // typed model; under mixed content it flips with a single content edit, so a sixth photo would
   // make the Camera/Lens dropdowns reappear.
-  const hasImageFilters = allImages.length > 0;
-
-  const visibility = useMemo(() => computeFilterVisibility(allImages), [allImages]);
-
-  const baseCollectionOptions = useMemo<CollectionDimensions>(() => {
-    const options = extractCollectionFilterOptions(allImages, allCollections);
-    if (!hasImageFilters) {
-      return {
-        ...options,
-        cameras: EMPTY_STRING_DIM,
-        lenses: EMPTY_STRING_DIM,
-        lensTypes: EMPTY_LENSTYPE_DIM,
-      };
-    }
-    return options;
-  }, [allImages, allCollections, hasImageFilters]);
+  const baseCollectionOptions = useMemo<CollectionDimensions>(
+    () => extractCollectionFilterOptions(allImages, allCollections),
+    [allImages, allCollections]
+  );
 
   const criteria = useMemo(() => buildCollectionCriteria(filterState), [filterState]);
 

--- a/app/components/ContentCollection/edit/hooks/useCoverImageSelection.ts
+++ b/app/components/ContentCollection/edit/hooks/useCoverImageSelection.ts
@@ -14,7 +14,6 @@ import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import { type CollectionModel, type CollectionUpdateResponseDTO } from '@/app/types/Collection';
 import { type AnyContentModel, type ContentImageModel } from '@/app/types/Content';
 import { handleApiError } from '@/app/utils/apiUtils';
-import { isParentCollection } from '@/app/utils/contentTypeGuards';
 
 import { COVER_IMAGE_FLASH_DURATION, handleCoverImageSelection } from '../collectionEditUtils';
 
@@ -49,9 +48,13 @@ export function useCoverImageSelection({
     async (imageId: number) => {
       if (!collection) return;
 
-      const imagePool = isParentCollection(collection)
-        ? (childCollectionImages as AnyContentModel[] | undefined)
-        : collection.content;
+      // UNION, not XOR (D3): a collection may hold its own images AND child-collection refs at
+      // the same time, so both are legitimate cover sources. This pool VALIDATES the pick, so
+      // narrowing it to one side would reject a legitimate cover, not just hide it in the picker.
+      const imagePool: AnyContentModel[] = [
+        ...(collection.content ?? []),
+        ...((childCollectionImages ?? []) as AnyContentModel[]),
+      ];
       const result = handleCoverImageSelection(imageId, imagePool);
 
       if (!result.success) {

--- a/app/components/ContentCollection/edit/sections/InfoTab.tsx
+++ b/app/components/ContentCollection/edit/sections/InfoTab.tsx
@@ -78,9 +78,13 @@ export function InfoTab({ edit }: InfoTabProps) {
     updateData.collectionEndDate < updateData.collectionDate
   );
 
-  const coverCandidates: ContentImageModel[] = isParent
-    ? (childCollectionImages ?? [])
-    : (collection?.content ?? []).filter(isContentImage);
+  // UNION, not XOR (D3): a collection may hold its own images AND child-collection refs at once.
+  // Mirrors the pool useCoverImageSelection validates the pick against. Deduped by id so an image
+  // present on both sides does not produce a duplicate React key in the picker grid.
+  const coverCandidates: ContentImageModel[] = [
+    ...(collection?.content ?? []).filter(isContentImage),
+    ...(childCollectionImages ?? []),
+  ].filter((img, index, all) => all.findIndex(candidate => candidate.id === img.id) === index);
 
   /**
    * The two stored discriminators are mutually exclusive (the backend rejects both true), so
@@ -282,9 +286,8 @@ export function InfoTab({ edit }: InfoTabProps) {
           </div>
         ) : (
           <p className={styles.fieldHint}>
-            {isParent
-              ? 'Add child collections with images to choose a cover.'
-              : 'Add images to this collection to choose a cover.'}
+            Add images to this collection — or a child collection that has images — to choose a
+            cover.
           </p>
         ))}
 

--- a/app/components/ContentCollection/edit/sections/StructureTab.tsx
+++ b/app/components/ContentCollection/edit/sections/StructureTab.tsx
@@ -31,7 +31,14 @@ interface StructureTabProps {
   edit: UseCollectionEditResult;
 }
 
-/** Structure tab: display/density, relationships, ratings. */
+/**
+ * Structure tab: display/density, relationships, ratings.
+ *
+ * The Presentation block (Order / Row Density) is un-gated (D4): `displayMode` and `rowsWide`
+ * stay live on the update contract for every collection, including one that holds child
+ * collections, so hiding the controls behind `isParent` was the frontend half of the
+ * "a parent holds only child collections" invariant that Rule B removes.
+ */
 export function StructureTab({ edit }: StructureTabProps) {
   const router = useRouter();
 
@@ -39,7 +46,6 @@ export function StructureTab({ edit }: StructureTabProps) {
     currentState,
     updateData,
     setUpdateField,
-    isParent,
     allCollectionsWithTagViews,
     saveTagAsCollection,
     childIds,
@@ -62,71 +68,67 @@ export function StructureTab({ edit }: StructureTabProps) {
 
   return (
     <div className={styles.tabPanel}>
-      {!isParent && (
-        <>
-          <h3 className={styles.sectionTitle}>Presentation</h3>
-          <div className={styles.formGridHalf}>
-            <div>
-              <Field label="Order" htmlFor="edit-sheet-display-mode">
-                <Select
-                  id="edit-sheet-display-mode"
-                  value={updateData.displayMode}
-                  onChange={e => setUpdateField('displayMode', e.target.value as DisplayMode)}
-                >
-                  <option value="ORDERED">Default</option>
-                  <option value="CHRONOLOGICAL">Chronological</option>
-                  <option value="FIXED">Fixed</option>
-                </Select>
-              </Field>
-            </div>
+      <h3 className={styles.sectionTitle}>Presentation</h3>
+      <div className={styles.formGridHalf}>
+        <div>
+          <Field label="Order" htmlFor="edit-sheet-display-mode">
+            <Select
+              id="edit-sheet-display-mode"
+              value={updateData.displayMode}
+              onChange={e => setUpdateField('displayMode', e.target.value as DisplayMode)}
+            >
+              <option value="ORDERED">Default</option>
+              <option value="CHRONOLOGICAL">Chronological</option>
+              <option value="FIXED">Fixed</option>
+            </Select>
+          </Field>
+        </div>
 
-            <div>
-              <Field label="Row Density" htmlFor="edit-sheet-rows-wide" hint="Default: 4">
-                <div className={styles.numberStepperWrapper}>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setUpdateField('rowsWide', Math.max(1, (updateData.rowsWide ?? 4) - 1))
-                    }
-                    className={styles.stepperButton}
-                    disabled={(updateData.rowsWide ?? 4) <= 1}
-                    aria-label="Decrease row density"
-                  >
-                    −
-                  </button>
-                  <input
-                    id="edit-sheet-rows-wide"
-                    type="number"
-                    min="1"
-                    max="10"
-                    value={updateData.rowsWide ?? ''}
-                    placeholder="4"
-                    onChange={e => {
-                      const value =
-                        e.target.value === '' ? undefined : Number.parseInt(e.target.value);
-                      if (value === undefined || (value >= 1 && value <= 10)) {
-                        setUpdateField('rowsWide', value);
-                      }
-                    }}
-                    className={styles.numberInput}
-                  />
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setUpdateField('rowsWide', Math.min(10, (updateData.rowsWide ?? 4) + 1))
-                    }
-                    className={styles.stepperButton}
-                    disabled={(updateData.rowsWide ?? 4) >= 10}
-                    aria-label="Increase row density"
-                  >
-                    +
-                  </button>
-                </div>
-              </Field>
+        <div>
+          <Field label="Row Density" htmlFor="edit-sheet-rows-wide" hint="Default: 4">
+            <div className={styles.numberStepperWrapper}>
+              <button
+                type="button"
+                onClick={() =>
+                  setUpdateField('rowsWide', Math.max(1, (updateData.rowsWide ?? 4) - 1))
+                }
+                className={styles.stepperButton}
+                disabled={(updateData.rowsWide ?? 4) <= 1}
+                aria-label="Decrease row density"
+              >
+                −
+              </button>
+              <input
+                id="edit-sheet-rows-wide"
+                type="number"
+                min="1"
+                max="10"
+                value={updateData.rowsWide ?? ''}
+                placeholder="4"
+                onChange={e => {
+                  const value =
+                    e.target.value === '' ? undefined : Number.parseInt(e.target.value);
+                  if (value === undefined || (value >= 1 && value <= 10)) {
+                    setUpdateField('rowsWide', value);
+                  }
+                }}
+                className={styles.numberInput}
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  setUpdateField('rowsWide', Math.min(10, (updateData.rowsWide ?? 4) + 1))
+                }
+                className={styles.stepperButton}
+                disabled={(updateData.rowsWide ?? 4) >= 10}
+                aria-label="Increase row density"
+              >
+                +
+              </button>
             </div>
-          </div>
-        </>
-      )}
+          </Field>
+        </div>
+      </div>
 
       <CollectionListSelector
         allCollections={allCollectionsWithTagViews}

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -1453,21 +1453,21 @@ export function useCollectionEdit({
         disabled: browseBusy,
         onClick: enterReorder,
       },
-    ];
-    if (!isParent) {
-      cells.push({
+      // Add is un-gated (D4): any collection may hold any mix of content, so holding a child
+      // collection no longer removes the ability to add images.
+      {
         key: 'add',
         label: operationLoading ? 'Uploading…' : 'Add',
         disabled: browseBusy,
         onClick: () => setIsAddMode(true),
-      });
-    }
-    cells.push({
-      key: 'edit',
-      label: 'Edit',
-      disabled: browseBusy,
-      onClick: () => setIsEditSheetOpen(true),
-    });
+      },
+      {
+        key: 'edit',
+        label: 'Edit',
+        disabled: browseBusy,
+        onClick: () => setIsEditSheetOpen(true),
+      },
+    ];
     if (onExitManage) {
       cells.push({ key: 'cancel', label: 'Cancel', onClick: onExitManage });
     }
@@ -1491,7 +1491,6 @@ export function useCollectionEdit({
     isUpdateDirty,
     handleUpdate,
     enterReorder,
-    isParent,
     onExitManage,
   ]);
 

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -118,12 +118,17 @@ export interface UseCollectionEditResult {
   currentCoverImageId?: number;
   /** The collection's saved cover image, shown in the Edit sheet (cover changes save immediately). */
   displayedCoverImage: ContentImageModel | null | undefined;
-  /** Child-collection images a PARENT picks its cover from. */
+  /**
+   * Images sourced from this collection's child collections. Since D3 this is one ARM of the
+   * cover-candidate union every collection picks from — the other being the collection's own
+   * images — not a parent-only substitute for them.
+   */
   childCollectionImages?: ContentImageModel[] | null;
   /**
    * True for parent collections (contains child-collection refs, or still carries the
-   * legacy PARENT type): hides density/display, shows the child cover picker, gates the
-   * Gallery Access section and the password-propagate-to-children confirm.
+   * legacy PARENT type). Gates the Gallery Access section and the password-propagate-to-children
+   * confirm. It no longer gates density/display (D4) or the cover picker's source pool (D3) —
+   * both are unconditional now, so do NOT reintroduce a parent gate on them.
    */
   isParent: boolean;
 
@@ -599,9 +604,9 @@ export function useCollectionEdit({
     [selectedIds, collection.content]
   );
 
-  // One parent derivation for every consumer below (child cover picker, Gallery Access
-  // section, password-propagate confirm, Add-content cell). Memoized because the content
-  // scan is O(n) over up to 500 loaded blocks per render, where the enum compare was O(1).
+  // One parent derivation for every consumer below (Gallery Access section, password-propagate
+  // confirm). Memoized because the content scan is O(n) over up to 500 loaded blocks per render,
+  // where the enum compare was O(1).
   const isParent = useMemo(() => isParentCollection(collection), [collection]);
 
   const displayedCoverImage = collection.coverImage ?? null;

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -827,11 +827,18 @@ export function hasAnyActiveFilter(filterState: FilterState): boolean {
  * Whether a COLLECTION-ref block satisfies the collection-applicable criteria.
  *
  * A collection tile carries only the dimensions the backend aggregates onto it
- * (tags/people/locations) plus its own rating — it has no camera/lens/film/date
- * of its own. Image-only criteria are therefore NOT applied here (they never
- * hide a collection tile), so toggling e.g. a film filter on a mixed page leaves
- * collection tiles in place. On a collection-dominant page (e.g. /all-collections)
- * the toolbar only surfaces the tag/people/location/rating dimensions anyway.
+ * (tags/people/locations) — it has no camera/lens/film/date of its own. Image-only
+ * criteria are therefore NOT applied here (they never hide a collection tile), so
+ * toggling e.g. a film filter on a mixed page leaves collection tiles in place.
+ * Since D7 the toolbar surfaces the camera/lens/lens-type dimensions on any page
+ * with at least one image, including collection-dominant ones, so this pass-through
+ * is what keeps those chips from wiping the page's navigation.
+ *
+ * `rating` is the same story in practice: the backend's collection-ref DTO does not
+ * serialize one, so an UNRATED tile is passed through rather than treated as rating 0.
+ * Otherwise "Highly Rated" (minRating 4) on a mixed page would delete every child card
+ * and strip the page of its only route into the sub-collections. A tile that DOES carry
+ * an explicit rating is still held to `minRating`.
  *
  * @param ref - The collection-ref block
  * @param criteria - Filter criteria (from {@link buildCollectionCriteria})
@@ -840,7 +847,7 @@ export function collectionRefMatchesCriteria(
   ref: ContentCollectionModel,
   criteria: ContentFilterCriteria
 ): boolean {
-  if (criteria.minRating !== undefined && (ref.rating ?? 0) < criteria.minRating) {
+  if (criteria.minRating !== undefined && ref.rating != null && ref.rating < criteria.minRating) {
     return false;
   }
 

--- a/app/utils/contentFilter.ts
+++ b/app/utils/contentFilter.ts
@@ -14,6 +14,7 @@ import {
   type ContentImageModel,
 } from '@/app/types/Content';
 import { type FilmFilter, type FilterState, type LensType } from '@/app/types/GalleryFilter';
+import { isCollectionCard } from '@/app/utils/contentRatingUtils';
 import { isGifContent } from '@/app/utils/contentTypeGuards';
 import { getLensType } from '@/app/utils/focalLength';
 
@@ -907,8 +908,14 @@ export function applyCollectionFilters(
  * A "dateable" content block participates in the chronological date sort: any image, or a GIF/MP4
  * that has been given a captureDate. Text, collections, and undated GIFs are NOT dateable and keep
  * their processed position (undated GIFs therefore stay at the end of a chronological collection).
+ *
+ * Child-collection CARDS are excluded explicitly: `convertCollectionContentToParallax` stamps them
+ * `contentType: 'IMAGE'`, so the plain image check would admit them, they would sort at epoch 0,
+ * and `enterReorder` would persist that as a full orderIndex re-index. Keyed on
+ * {@link isCollectionCard} (slug presence) so this can never disagree with the layout/badge code.
  */
 export function isDateable(block: AnyContentModel): boolean {
+  if (isCollectionCard(block)) return false;
   return isImageContent(block) || (isGifContent(block) && Boolean(block.captureDate));
 }
 

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -400,28 +400,15 @@ function sortNonVisibleToBottom(
 }
 
 /**
- * Reorder content to show images/text/gifs first, then collections
- */
-function reorderImagesBeforeCollections(content: AnyContentModel[]): AnyContentModel[] {
-  const nonCollections: AnyContentModel[] = [];
-  const collections: AnyContentModel[] = [];
-
-  for (const block of content) {
-    if (block.contentType === 'COLLECTION') {
-      collections.push(block);
-    } else {
-      nonCollections.push(block);
-    }
-  }
-
-  return [...nonCollections, ...collections];
-}
-
-/**
  * Process content blocks through filtering, sorting, and transformation pipeline.
  * Converts collections to parallax images and ensures proper dimensions.
  *
- * Ordering uses `block.orderIndex` directly (not `collections[].orderIndex`).
+ * Ordering uses `block.orderIndex` directly (not `collections[].orderIndex`) and is honoured
+ * VERBATIM across content types: a child-collection card sits wherever the admin put it, mixed
+ * in among images. (The former `reorderImagesBeforeCollections` pass sank every collection block
+ * to the tail; it encoded the "a parent holds only child collections" invariant and was removed
+ * with it. Row packing downstream is order-preserving, so this is the only ordering authority.)
+ *
  * When `filterVisible` is false (manage page), non-visible content is sorted to
  * the bottom after the primary orderIndex/chronological sort to preserve relative
  * order within visible and non-visible groups.
@@ -450,7 +437,6 @@ export function processContentBlocks(
     processed = sortNonVisibleToBottom(processed, collectionId);
   }
 
-  processed = reorderImagesBeforeCollections(processed);
   processed = transformCollectionBlocks(processed);
 
   return processed;

--- a/app/utils/contentTypeGuards.ts
+++ b/app/utils/contentTypeGuards.ts
@@ -256,8 +256,9 @@ export function hasChildCollectionContent(
 /**
  * Check if a collection acts as a "parent": it contains child-collection refs, or
  * still carries the legacy (admin-transitional) PARENT type. Parent collections
- * source cover-image candidates from their children, expose the Gallery Access
- * section, and offer to propagate their password to child galleries. The enum arm
+ * expose the Gallery Access section and offer to propagate their password to child
+ * galleries. Cover-image candidates are NOT gated on this: since D3 every collection
+ * picks from the union of its own images and its children's. The enum arm
  * covers a freshly created parent that has no children yet, and survives the
  * `hasChildCollectionContent` truncation bound; it goes away with the enum.
  */

--- a/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
@@ -88,22 +88,24 @@ describe('CollectionContentRenderer — slug navigation branch', () => {
     expect(link).toHaveAttribute('href', '/dolomites-2025');
   });
 
-  it('does NOT navigate via href when onImageClick is supplied (handler wins)', () => {
+  it('navigates via href even when onImageClick is supplied (slug nav wins)', () => {
     const onImageClick = jest.fn();
-    const { container } = render(
+    render(
       <CollectionContentRenderer
         {...imageProps}
         contentType="COLLECTION"
         isCollection
         hasSlug="dolomites-2025"
+        overlayText="Dolomites"
         onImageClick={onImageClick}
       />
     );
-    // With onImageClick present, isSlugNav is false → wrapper div, not a Tile/link.
-    expect(container.querySelector('a[href="/dolomites-2025"]')).toBeNull();
-    const wrapper = container.querySelector('[data-image-wrapper]')!;
-    fireEvent.click(wrapper.querySelector('div')!);
-    expect(onImageClick).toHaveBeenCalledWith(7);
+    // Select mode sets onImageClick grid-wide. A collection card must stay a link rather than
+    // become a download target carrying its content-table id.
+    const link = screen.getByRole('link', { name: 'Dolomites' });
+    expect(link).toHaveAttribute('href', '/dolomites-2025');
+    fireEvent.click(link);
+    expect(onImageClick).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.characterization.test.tsx
@@ -107,6 +107,60 @@ describe('CollectionContentRenderer — slug navigation branch', () => {
     fireEvent.click(link);
     expect(onImageClick).not.toHaveBeenCalled();
   });
+
+  it('on the MANAGE grid the card is NOT a public link and routes through onImageClick', () => {
+    // EditModeLayer sets onImageClick grid-wide AND threads currentCollectionId. Its handler
+    // pushes manageHref(childSlug), so an admin drilling into a child stays in manage mode.
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer
+        {...imageProps}
+        contentType="COLLECTION"
+        isCollection
+        hasSlug="dolomites-2025"
+        overlayText="Dolomites"
+        onImageClick={onImageClick}
+        currentCollectionId={42}
+      />
+    );
+    expect(container.querySelector('a[href="/dolomites-2025"]')).toBeNull();
+    const wrapper = container.querySelector('[data-image-wrapper]')!;
+    fireEvent.click(wrapper.querySelector('div')!);
+    expect(onImageClick).toHaveBeenCalledWith(7);
+  });
+
+  it('on the MANAGE grid a converted card (contentType IMAGE + slug) also routes to the handler', () => {
+    const onImageClick = jest.fn();
+    const { container } = render(
+      <CollectionContentRenderer
+        {...imageProps}
+        hasSlug="dolomites-2025"
+        overlayText="Dolomites"
+        onImageClick={onImageClick}
+        currentCollectionId={42}
+      />
+    );
+    expect(container.querySelector('a[href="/dolomites-2025"]')).toBeNull();
+    fireEvent.click(container.querySelector('[data-image-wrapper]')!.querySelector('div')!);
+    expect(onImageClick).toHaveBeenCalledWith(7);
+  });
+
+  it('on the MANAGE grid without onImageClick the card falls back to a slug link', () => {
+    render(
+      <CollectionContentRenderer
+        {...imageProps}
+        contentType="COLLECTION"
+        isCollection
+        hasSlug="dolomites-2025"
+        overlayText="Dolomites"
+        currentCollectionId={42}
+      />
+    );
+    expect(screen.getByRole('link', { name: 'Dolomites' })).toHaveAttribute(
+      'href',
+      '/dolomites-2025'
+    );
+  });
 });
 
 describe('CollectionContentRenderer — GIF branch', () => {

--- a/tests/components/Content/ContentBlockWithFullScreen.test.tsx
+++ b/tests/components/Content/ContentBlockWithFullScreen.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The fullscreen viewer's prev/next list must contain photographs and GIFs only. A converted
+ * child-collection card carries contentType: 'IMAGE' (convertCollectionContentToParallax), so a
+ * plain contentType check admits it — the viewer then shows a collection cover as a photo with no
+ * EXIF and no route out. The `?image=<id>` deep-link restore reads the same list.
+ */
+import '@testing-library/jest-dom';
+
+import { render } from '@testing-library/react';
+
+import ContentBlockWithFullScreen from '@/app/components/Content/ContentBlockWithFullScreen';
+import type { AnyContentModel, ContentImageModel } from '@/app/types/Content';
+
+const mockShowImage = jest.fn();
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () =>
+    function DynamicStub() {
+      return null;
+    },
+}));
+
+jest.mock('@/app/hooks/useFullScreenImage', () => ({
+  useFullScreenImage: () => ({
+    fullScreenState: null,
+    loadedImageIds: new Set<number>(),
+    showMetadata: false,
+    modalRef: { current: null },
+    zoomTargetRef: { current: null },
+    isZoomed: false,
+    immersive: false,
+    isSwiping: false,
+    showImage: mockShowImage,
+    hideImage: jest.fn(),
+    toggleMetadata: jest.fn(),
+    setLoadedImageIds: jest.fn(),
+    router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+    isOpen: false,
+    navigateToNext: jest.fn(),
+    navigateToPrevious: jest.fn(),
+  }),
+}));
+
+let capturedOnFullScreenImageClick: ((image: ContentImageModel) => void) | undefined;
+
+jest.mock('@/app/components/Content/Component', () => ({
+  __esModule: true,
+  default: (props: { onFullScreenImageClick?: (image: ContentImageModel) => void }) => {
+    capturedOnFullScreenImageClick = props.onFullScreenImageClick;
+    return <div data-testid="grid" />;
+  },
+}));
+
+const photo: ContentImageModel = {
+  id: 1,
+  contentType: 'IMAGE',
+  orderIndex: 0,
+  imageUrl: 'https://cdn.example/photo-1.jpg',
+  locations: [],
+};
+
+const collectionCard = {
+  id: 2,
+  contentType: 'IMAGE',
+  orderIndex: 1,
+  enableParallax: true,
+  imageUrl: 'https://cdn.example/cover-2.jpg',
+  slug: 'child-gallery',
+  locations: [],
+} as unknown as ContentImageModel;
+
+const gif: AnyContentModel = {
+  id: 3,
+  contentType: 'GIF',
+  orderIndex: 2,
+  gifUrl: 'https://cdn.example/clip-3.mp4',
+};
+
+const blocks: AnyContentModel[] = [photo, collectionCard, gif];
+
+beforeEach(() => {
+  mockShowImage.mockClear();
+  capturedOnFullScreenImageClick = undefined;
+  window.history.replaceState({}, '', '/');
+});
+
+describe('ContentBlockWithFullScreen — viewable list excludes collection cards', () => {
+  it('gives the viewer only the photo and the GIF when a photo is clicked', () => {
+    render(<ContentBlockWithFullScreen content={blocks} enableFullScreenView />);
+    expect(capturedOnFullScreenImageClick).toBeDefined();
+
+    capturedOnFullScreenImageClick!(photo);
+
+    expect(mockShowImage).toHaveBeenCalledTimes(1);
+    const [opened, list] = mockShowImage.mock.calls[0] as [ContentImageModel, AnyContentModel[]];
+    expect(opened.id).toBe(1);
+    expect(list.map(block => block.id)).toEqual([1, 3]);
+  });
+
+  it('does not open the viewer for a ?image= deep link pointing at a collection card', () => {
+    window.history.replaceState({}, '', '/?image=2');
+    render(<ContentBlockWithFullScreen content={blocks} enableFullScreenView />);
+    expect(mockShowImage).not.toHaveBeenCalled();
+  });
+
+  it('still opens the viewer for a ?image= deep link pointing at a real photo', () => {
+    window.history.replaceState({}, '', '/?image=3');
+    render(<ContentBlockWithFullScreen content={blocks} enableFullScreenView />);
+
+    expect(mockShowImage).toHaveBeenCalledTimes(1);
+    const [opened, list] = mockShowImage.mock.calls[0] as [ContentImageModel, AnyContentModel[]];
+    expect(opened.id).toBe(3);
+    expect(list.map(block => block.id)).toEqual([1, 3]);
+  });
+});

--- a/tests/components/Content/collectionContentRendererUtils.test.ts
+++ b/tests/components/Content/collectionContentRendererUtils.test.ts
@@ -108,7 +108,7 @@ describe('getClickEligibility', () => {
     ).toEqual({ hasClickHandler: true, isSlugNav: true });
   });
 
-  it('onImageClick beats slug nav (handler, not href)', () => {
+  it('slug nav beats onImageClick (a collection card navigates, it is not a download target)', () => {
     expect(
       getClickEligibility({
         ...base,
@@ -116,7 +116,19 @@ describe('getClickEligibility', () => {
         hasSlug: 'dolomites',
         onImageClick: jest.fn(),
       })
-    ).toEqual({ hasClickHandler: true, isSlugNav: false });
+    ).toEqual({ hasClickHandler: true, isSlugNav: true });
+  });
+
+  it('slug nav beats onImageClick for a CONVERTED card too (contentType IMAGE + slug)', () => {
+    // Post-conversion cards arrive as contentType 'IMAGE'; the slug is the discriminant.
+    expect(
+      getClickEligibility({
+        ...base,
+        contentType: 'IMAGE',
+        hasSlug: 'dolomites',
+        onImageClick: jest.fn(),
+      })
+    ).toEqual({ hasClickHandler: true, isSlugNav: true });
   });
 
   it('onImageClick alone makes an item clickable but not slug nav', () => {

--- a/tests/components/Content/collectionContentRendererUtils.test.ts
+++ b/tests/components/Content/collectionContentRendererUtils.test.ts
@@ -87,6 +87,7 @@ describe('getClickEligibility', () => {
     onImageClick: undefined as ((id: number) => void) | undefined,
     enableFullScreenView: false,
     onFullScreenImageClick: undefined,
+    currentCollectionId: undefined as number | undefined,
   };
 
   it('TEXT content is never clickable nor a slug nav', () => {
@@ -127,6 +128,31 @@ describe('getClickEligibility', () => {
         contentType: 'IMAGE',
         hasSlug: 'dolomites',
         onImageClick: jest.fn(),
+      })
+    ).toEqual({ hasClickHandler: true, isSlugNav: true });
+  });
+
+  it('on the MANAGE grid onImageClick beats slug nav (the handler is the manage router)', () => {
+    // EditModeLayer sets onImageClick grid-wide AND threads currentCollectionId. There the
+    // handler pushes manageHref(childSlug), so an admin drill-down stays in manage mode.
+    expect(
+      getClickEligibility({
+        ...base,
+        contentType: 'COLLECTION',
+        hasSlug: 'dolomites',
+        onImageClick: jest.fn(),
+        currentCollectionId: 42,
+      })
+    ).toEqual({ hasClickHandler: true, isSlugNav: false });
+  });
+
+  it('on the MANAGE grid without onImageClick (reorder pending / not ready) slug nav still applies', () => {
+    expect(
+      getClickEligibility({
+        ...base,
+        contentType: 'COLLECTION',
+        hasSlug: 'dolomites',
+        currentCollectionId: 42,
       })
     ).toEqual({ hasClickHandler: true, isSlugNav: true });
   });

--- a/tests/components/ContentCollection/CollectionEditSheet.test.tsx
+++ b/tests/components/ContentCollection/CollectionEditSheet.test.tsx
@@ -232,18 +232,17 @@ describe('CollectionEditSheet — StructureTab', () => {
     expect(screen.getByLabelText(/Row Density/)).toBeInTheDocument();
   });
 
-  it('hides Order and Row Density for parent collection', () => {
+  it('shows Order and Row Density for a parent collection too (D4)', () => {
     render(
       <CollectionEditSheet
         edit={makeEdit({
           editTab: 'structure',
           isParent: true,
-          updateData: makeUpdateData({}),
         })}
       />
     );
-    expect(screen.queryByLabelText('Order')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/Row Density/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Order')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Row Density/)).toBeInTheDocument();
   });
 
   it('shows the cover button on the Info tab', () => {

--- a/tests/components/ContentCollection/CollectionPageClient.filters.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.filters.test.tsx
@@ -115,10 +115,13 @@ describe('CollectionPageClient — image-derived filters (D7)', () => {
     expect(screen.getByTestId('grid')).toHaveAttribute('data-highly-rated', 'true');
   });
 
-  it('still suppresses image-derived dimensions when the page has no images', () => {
+  it('mounts no filter provider at all when the page has no images', () => {
     render(<CollectionPageClient collection={makeImagelessParent()} />);
     const grid = screen.getByTestId('grid');
-    // No images -> no filterable image dimensions -> the provider value is null.
+    // Not a suppression branch: cameras/lenses/lensTypes are sourced from `allImages` alone, so
+    // with no images every dimension already has zero values and `hasFilterableOptions` is false,
+    // which leaves the provider unmounted.
     expect(grid).toHaveAttribute('data-cameras', 'NO_CONTEXT');
+    expect(grid).toHaveAttribute('data-highly-rated', 'NO_CONTEXT');
   });
 });

--- a/tests/components/ContentCollection/CollectionPageClient.filters.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.filters.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * D7: image-derived filter dimensions (camera / lens / lens-type / highly-rated) must be shown
+ * whenever the page has any images at all — not gated on a collections-vs-images head count that
+ * flips with one content edit under mixed content.
+ */
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+
+import CollectionPageClient from '@/app/components/ContentCollection/CollectionPageClient';
+import type { CollectionModel } from '@/app/types/Collection';
+import type { AnyContentModel } from '@/app/types/Content';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/mixed',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () =>
+    function DynamicStub() {
+      return null;
+    },
+}));
+
+jest.mock('@/app/components/Content/ContentBlockWithFullScreen', () => {
+  const { useCollectionFilter } = jest.requireActual<{
+    useCollectionFilter: () => {
+      filterOptions: {
+        cameras: { values: readonly string[] };
+        showHighlyRated: boolean;
+      };
+    } | null;
+  }>('@/app/components/ContentCollection/CollectionFilterContext');
+
+  const MockGrid = () => {
+    const ctx = useCollectionFilter();
+    return (
+      <div
+        data-testid="grid"
+        data-cameras={ctx ? ctx.filterOptions.cameras.values.join(',') : 'NO_CONTEXT'}
+        data-highly-rated={ctx ? String(ctx.filterOptions.showHighlyRated) : 'NO_CONTEXT'}
+      />
+    );
+  };
+  return { __esModule: true, default: MockGrid };
+});
+
+function image(id: number, camera: string, captureDate: string, rating: number): AnyContentModel {
+  return {
+    id,
+    contentType: 'IMAGE',
+    orderIndex: id,
+    imageUrl: `https://cdn.example/photo-${id}.jpg`,
+    imageWidth: 1600,
+    imageHeight: 1067,
+    locations: [],
+    camera: { id, name: camera },
+    captureDate,
+    rating,
+  } as unknown as AnyContentModel;
+}
+
+function childRef(id: number): AnyContentModel {
+  return {
+    id,
+    contentType: 'COLLECTION',
+    orderIndex: id,
+    slug: `child-${id}`,
+    referencedCollectionId: id * 10,
+  } as unknown as AnyContentModel;
+}
+
+/** 3 child collections + 2 images — "collection dominant" under the old head count. */
+function makeCollectionDominant(): CollectionModel {
+  return {
+    id: 42,
+    slug: 'mixed',
+    title: 'Mixed',
+    isClient: false,
+    isBlog: false,
+    displayMode: 'ORDERED',
+    rowsWide: 4,
+    locations: [],
+    content: [
+      childRef(90),
+      childRef(91),
+      childRef(92),
+      image(1, 'Leica M6', '2024-01-01', 5),
+      image(2, 'Nikon Z6', '2024-02-02', 0),
+    ],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as unknown as CollectionModel;
+}
+
+/** No images at all — image-derived dimensions must stay hidden. */
+function makeImagelessParent(): CollectionModel {
+  return {
+    ...makeCollectionDominant(),
+    content: [childRef(90), childRef(91), childRef(92)],
+  } as unknown as CollectionModel;
+}
+
+describe('CollectionPageClient — image-derived filters (D7)', () => {
+  it('offers the Camera dimension on a page with more collections than images', () => {
+    render(<CollectionPageClient collection={makeCollectionDominant()} />);
+    expect(screen.getByTestId('grid')).toHaveAttribute('data-cameras', 'Leica M6,Nikon Z6');
+  });
+
+  it('offers Highly Rated on a page with more collections than images', () => {
+    render(<CollectionPageClient collection={makeCollectionDominant()} />);
+    expect(screen.getByTestId('grid')).toHaveAttribute('data-highly-rated', 'true');
+  });
+
+  it('still suppresses image-derived dimensions when the page has no images', () => {
+    render(<CollectionPageClient collection={makeImagelessParent()} />);
+    const grid = screen.getByTestId('grid');
+    // No images -> no filterable image dimensions -> the provider value is null.
+    expect(grid).toHaveAttribute('data-cameras', 'NO_CONTEXT');
+  });
+});

--- a/tests/components/ContentCollection/edit/hooks/useCoverImageSelection.test.tsx
+++ b/tests/components/ContentCollection/edit/hooks/useCoverImageSelection.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * useCoverImageSelection validates the picked id against a POOL before writing coverImageId, so
+ * the pool is a write path, not just a picker. Under mixed content the pool must be the UNION of
+ * the collection's own images and its child collections' images (D3).
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useCoverImageSelection } from '@/app/components/ContentCollection/edit/hooks/useCoverImageSelection';
+import { updateCollection } from '@/app/lib/api/collections';
+import type { CollectionModel } from '@/app/types/Collection';
+import type { AnyContentModel, ContentImageModel } from '@/app/types/Content';
+
+jest.mock('@/app/lib/api/collections');
+jest.mock('@/app/lib/storage/collectionStorage');
+
+const mockUpdateCollection = updateCollection as jest.MockedFunction<typeof updateCollection>;
+
+function ownImage(id: number): ContentImageModel {
+  return {
+    id,
+    contentType: 'IMAGE',
+    orderIndex: id,
+    imageUrl: `https://cdn.example/own-${id}.jpg`,
+    locations: [],
+  };
+}
+
+function childRef(id: number): AnyContentModel {
+  return {
+    id,
+    contentType: 'COLLECTION',
+    orderIndex: id,
+    slug: `child-${id}`,
+    referencedCollectionId: id * 10,
+  } as unknown as AnyContentModel;
+}
+
+/** A mixed collection: two of its own images plus one child-collection reference. */
+function makeMixedCollection(): CollectionModel {
+  return {
+    id: 42,
+    slug: 'mixed',
+    title: 'Mixed',
+    content: [ownImage(1), ownImage(2), childRef(90)],
+    locations: [],
+  } as unknown as CollectionModel;
+}
+
+function renderCoverSelection(childCollectionImages: ContentImageModel[]) {
+  const setError = jest.fn();
+  const hook = renderHook(() =>
+    useCoverImageSelection({
+      collection: makeMixedCollection(),
+      childCollectionImages,
+      setCurrentState: jest.fn(),
+      setOperationLoading: jest.fn(),
+      setError,
+    })
+  );
+  return { hook, setError };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateCollection.mockResolvedValue(null);
+});
+
+describe('useCoverImageSelection — union cover pool (D3)', () => {
+  it("accepts one of the collection's OWN images even though it also has a child ref", async () => {
+    const { hook, setError } = renderCoverSelection([ownImage(500)]);
+
+    await act(async () => {
+      await hook.result.current.handleCoverImageClick(2);
+    });
+
+    // NB the success path calls setError(null) to clear stale errors, so assert that no ERROR
+    // string was surfaced rather than that setError went untouched.
+    expect(setError).not.toHaveBeenCalledWith(expect.any(String));
+    await waitFor(() =>
+      expect(mockUpdateCollection).toHaveBeenCalledWith(42, { id: 42, coverImageId: 2 })
+    );
+  });
+
+  it('accepts a CHILD collection image on the same collection', async () => {
+    const { hook, setError } = renderCoverSelection([ownImage(500)]);
+
+    await act(async () => {
+      await hook.result.current.handleCoverImageClick(500);
+    });
+
+    // NB the success path calls setError(null) to clear stale errors, so assert that no ERROR
+    // string was surfaced rather than that setError went untouched.
+    expect(setError).not.toHaveBeenCalledWith(expect.any(String));
+    await waitFor(() =>
+      expect(mockUpdateCollection).toHaveBeenCalledWith(42, { id: 42, coverImageId: 500 })
+    );
+  });
+
+  it('still rejects an id that is in neither pool', async () => {
+    const { hook, setError } = renderCoverSelection([ownImage(500)]);
+
+    await act(async () => {
+      await hook.result.current.handleCoverImageClick(9999);
+    });
+
+    expect(setError).toHaveBeenCalledWith('Invalid cover image selection. Please try again.');
+    expect(mockUpdateCollection).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
+++ b/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
@@ -159,6 +159,11 @@ describe('InfoTab — cover picker offers the union of own and child images (D3)
 
   it('never offers a non-image block as a cover candidate', () => {
     renderPicker();
-    expect(screen.queryByRole('button', { name: /child-90/ })).not.toBeInTheDocument();
+    // childRef(90) carries no `title`, so if it slipped past the isContentImage filter it would
+    // render with the picker's fallback accessible name. Asserting on the slug would be vacuous:
+    // the slug never reaches the aria-label.
+    expect(screen.queryByRole('button', { name: 'Set image as cover' })).not.toBeInTheDocument();
+    // Own 1, Own 2 (deduped), Child 500 — the COLLECTION ref excluded.
+    expect(screen.getAllByRole('button', { name: /as cover$/ })).toHaveLength(3);
   });
 });

--- a/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
+++ b/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
@@ -13,7 +13,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { InfoTab } from '@/app/components/ContentCollection/edit/sections/InfoTab';
 import { type CollectionUpdateRequest } from '@/app/types/Collection';
-import { makeEdit, makeUpdateData } from '@/tests/fixtures/collectionEditFixtures';
+import { makeEdit, makeState, makeUpdateData } from '@/tests/fixtures/collectionEditFixtures';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
@@ -97,5 +97,68 @@ describe('InfoTab — end-date input wiring', () => {
   it('labels the collection-date input too (retrofitted alongside the end date)', () => {
     renderInfoTab({ collectionDate: '2026-03-01' });
     expect(screen.getByLabelText('Collection Date')).toHaveValue('2026-03-01');
+  });
+});
+
+describe('InfoTab — cover picker offers the union of own and child images (D3)', () => {
+  const ownImage = (id: number) => ({
+    id,
+    contentType: 'IMAGE' as const,
+    orderIndex: id,
+    imageUrl: `https://cdn.example/own-${id}.jpg`,
+    title: `Own ${id}`,
+    locations: [],
+  });
+
+  const childRef = (id: number) => ({
+    id,
+    contentType: 'COLLECTION' as const,
+    orderIndex: id,
+    slug: `child-${id}`,
+    referencedCollectionId: id * 10,
+  });
+
+  const childImage = (id: number) => ({
+    id,
+    contentType: 'IMAGE' as const,
+    orderIndex: id,
+    imageUrl: `https://cdn.example/child-${id}.jpg`,
+    title: `Child ${id}`,
+    locations: [],
+  });
+
+  function renderPicker() {
+    render(
+      <InfoTab
+        edit={makeEdit({
+          isParent: true,
+          isSelectingCoverImage: true,
+          currentState: makeState({
+            content: [ownImage(1), ownImage(2), childRef(90)],
+          }),
+          childCollectionImages: [childImage(500), ownImage(2)],
+        })}
+      />
+    );
+  }
+
+  it("offers the collection's own images even when it also holds a child reference", () => {
+    renderPicker();
+    expect(screen.getByRole('button', { name: 'Set Own 1 as cover' })).toBeInTheDocument();
+  });
+
+  it("offers the child collection's images too", () => {
+    renderPicker();
+    expect(screen.getByRole('button', { name: 'Set Child 500 as cover' })).toBeInTheDocument();
+  });
+
+  it('lists an image that is in both pools exactly once', () => {
+    renderPicker();
+    expect(screen.getAllByRole('button', { name: 'Set Own 2 as cover' })).toHaveLength(1);
+  });
+
+  it('never offers a non-image block as a cover candidate', () => {
+    renderPicker();
+    expect(screen.queryByRole('button', { name: /child-90/ })).not.toBeInTheDocument();
   });
 });

--- a/tests/components/ContentCollection/useCollectionEdit.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.test.tsx
@@ -278,13 +278,23 @@ describe('useCollectionEdit', () => {
       expect(labels).toEqual(['Select', 'Reorder', 'Add', 'Edit']);
     });
 
-    it('browse hides Add for parent-type collections', () => {
+    it('browse keeps Add for a collection that holds child collections (D4)', () => {
       const { result } = renderEdit({
         enabled: false,
-        collection: makeCollection({ type: CollectionType.PARENT }),
+        collection: makeCollection({
+          content: [
+            {
+              id: 900,
+              contentType: 'COLLECTION',
+              orderIndex: 0,
+              slug: 'child-gallery',
+              referencedCollectionId: 901,
+            },
+          ] as AnyContentModel[],
+        }),
       });
       const labels = result.current.bottomBarCells.map(c => c.label);
-      expect(labels).toEqual(['Select', 'Reorder', 'Edit']);
+      expect(labels).toEqual(['Select', 'Reorder', 'Add', 'Edit']);
     });
 
     it('browse keeps Reorder enabled for CHRONOLOGICAL displayMode (auto-converts on click)', () => {

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -31,7 +31,9 @@ import { sortByDate } from '@/app/utils/sortByDate';
 
 // ─── Test Fixtures ───
 
-function makeImage(overrides: Partial<ContentImageModel> = {}): ContentImageModel {
+function makeImage(
+  overrides: Partial<ContentImageModel> & { slug?: string; enableParallax?: true } = {}
+): ContentImageModel {
   return {
     id: 1,
     contentType: 'IMAGE',
@@ -1397,6 +1399,20 @@ describe('isDateable', () => {
 
   it('is false for non-image, non-gif content', () => {
     expect(isDateable(makeTextBlock())).toBe(false);
+  });
+
+  it('is false for a converted collection card (contentType IMAGE, but carries a slug)', () => {
+    // convertCollectionContentToParallax stamps contentType: 'IMAGE' on child-collection
+    // cards. They have no captureDate, so treating them as dateable sorts them at epoch 0 —
+    // and enterReorder PERSISTS that order as a full re-index. Slug presence is the live
+    // discriminant (see isCollectionCard in contentRatingUtils).
+    const card = makeImage({ id: 500, slug: 'child-collection', enableParallax: true });
+    expect(isDateable(card as AnyContentModel)).toBe(false);
+  });
+
+  it('is false for a collection card even when it carries a captureDate', () => {
+    const card = makeImage({ id: 501, slug: 'child-collection', captureDate: '2024-01-01' });
+    expect(isDateable(card as AnyContentModel)).toBe(false);
   });
 });
 

--- a/tests/utils/contentFilter.test.ts
+++ b/tests/utils/contentFilter.test.ts
@@ -1322,6 +1322,21 @@ describe('applyCollectionFilters', () => {
 
     expect(result.map(c => c.id)).toEqual([4001]);
   });
+
+  it('Highly Rated on a mixed page filters images but keeps every unrated child card', () => {
+    // The backend does not serialize a rating onto collection refs, so minRating must not
+    // wipe the page's only navigation into its sub-collections.
+    const child1 = makeCollectionRef({ id: 5001 });
+    const child2 = makeCollectionRef({ id: 5002 });
+    const child3 = makeCollectionRef({ id: 5003 });
+    const rated = makeImage({ id: 5, rating: 5 });
+    const unrated = makeImage({ id: 6, rating: 1 });
+    const mixed: AnyContentModel[] = [child1, rated, child2, unrated, child3];
+
+    const result = applyCollectionFilters(mixed, [rated, unrated], { minRating: 4 }, []);
+
+    expect(result.map(c => c.id)).toEqual([5001, 5, 5002, 5003]);
+  });
 });
 
 describe('collectionRefMatchesCriteria', () => {
@@ -1345,10 +1360,19 @@ describe('collectionRefMatchesCriteria', () => {
     expect(collectionRefMatchesCriteria(ref, { tags: ['Italy', 'Iceland'] })).toBe(true);
   });
 
-  it('respects minRating', () => {
+  it('respects minRating when the ref carries an explicit rating', () => {
     const ref = makeCollectionRef({ rating: 3 });
     expect(collectionRefMatchesCriteria(ref, { minRating: 4 })).toBe(false);
     expect(collectionRefMatchesCriteria(ref, { minRating: 3 })).toBe(true);
+  });
+
+  it('passes an UNRATED ref through minRating rather than treating it as rating 0', () => {
+    // The backend's collection-ref DTO does not serialize a rating; treating the absent
+    // field as 0 would make "Highly Rated" delete every child card on a mixed page.
+    expect(collectionRefMatchesCriteria(makeCollectionRef(), { minRating: 4 })).toBe(true);
+    expect(
+      collectionRefMatchesCriteria(makeCollectionRef({ rating: null }), { minRating: 4 })
+    ).toBe(true);
   });
 
   it('returns true when no collection-applicable criteria are set', () => {

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -1634,4 +1634,64 @@ describe('processContentForDisplay', () => {
   });
 });
 
+describe('processContentForDisplay — row packing is order-preserving (D2 characterization)', () => {
+  /**
+   * A child-collection card in the exact shape the pipeline hands to processContentForDisplay:
+   * processContentBlocks runs transformCollectionBlocks first, so the layout engine never sees a
+   * raw COLLECTION block in production. Converting here keeps the characterization honest (the
+   * converted card carries clamped cover dimensions and a slug; a raw block carries neither).
+   */
+  function card(id: number): ContentParallaxImageModel {
+    return convertCollectionContentToParallax(createCollectionContent(id));
+  }
+
+  /** Flatten rows to content ids, dropping the synthetic blank spacers buildRows pads with. */
+  function flatIds(rows: RowWithPatternAndSizes[]): (number | undefined)[] {
+    return rows
+      .flatMap(row => row.items)
+      .filter(item => !isBlankContent(item.content))
+      .map(item => item.content.id);
+  }
+
+  it('emits mixed image + collection content in input order across rows (desktop)', () => {
+    const content: AnyContentModel[] = [
+      createHorizontalImage(1, 3),
+      card(2),
+      createHorizontalImage(3, 3),
+      card(4),
+      createHorizontalImage(5, 3),
+    ];
+    const rows = processContentForDisplay(content, 1000);
+    expect(flatIds(rows)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('emits mixed image + collection content in input order across rows (mobile)', () => {
+    const content: AnyContentModel[] = [
+      createHorizontalImage(1, 3),
+      card(2),
+      createHorizontalImage(3, 3),
+      card(4),
+    ];
+    const rows = processContentForDisplay(content, 400, 4, { isMobile: true });
+    expect(flatIds(rows)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('packs a collection card into a row alongside images rather than onto its own row', () => {
+    // A converted card rates 4 (getEffectiveRating keys on slug presence) and its 1920x1080 cover
+    // is clamped by clampParallaxDimensions into the 4:5..5:4 band, so it is a normal-cost row
+    // member. With a generous row-width budget it shares a row with images.
+    const content: AnyContentModel[] = [
+      createHorizontalImage(1, 1),
+      card(2),
+      createHorizontalImage(3, 1),
+    ];
+    const rows = processContentForDisplay(content, 1000, 6);
+    const rowWithCard = rows.find(row => row.items.some(item => item.content.id === 2));
+    expect(rowWithCard).toBeDefined();
+    expect(rowWithCard!.items.filter(item => !isBlankContent(item.content)).length).toBeGreaterThan(
+      1
+    );
+  });
+});
+
 // chunkContent, reorderLonelyVerticals, calculateContentSizes deleted — BoxTree pipeline handles all sizing

--- a/tests/utils/contentLayout.test.ts
+++ b/tests/utils/contentLayout.test.ts
@@ -264,8 +264,8 @@ describe('processContentBlocks', () => {
     });
   });
 
-  describe('Reordering images before collections', () => {
-    it('should place images before collections', () => {
+  describe('Honouring orderIndex across content types (D2)', () => {
+    it('places collection cards at their saved orderIndex, interleaved with images', () => {
       const content: AnyContentModel[] = [
         createCollectionContent(1, { orderIndex: 1 }),
         createImageContent(2, { orderIndex: 2 }),
@@ -274,21 +274,16 @@ describe('processContentBlocks', () => {
       ];
       const result = processContentBlocks(content);
 
-      // First two should be images (IDs 2 and 3)
-      expect(result[0]?.id).toBe(2);
-      expect(result[1]?.id).toBe(3);
+      expect(result.map(block => block.id)).toEqual([1, 2, 3, 4]);
 
-      // Last two should be collections (IDs 1 and 4, converted to parallax)
-      expect(result[2]?.id).toBe(1);
-      expect(result[3]?.id).toBe(4);
-      // After transformation, they should be parallax images with slug
-      expect((result[2] as ContentParallaxImageModel).enableParallax).toBe(true);
+      // Collection blocks are still converted to parallax cards — just not relocated.
+      expect((result[0] as ContentParallaxImageModel).enableParallax).toBe(true);
+      expect((result[0] as ContentParallaxImageModel).slug).toBe('collection-1');
       expect((result[3] as ContentParallaxImageModel).enableParallax).toBe(true);
-      expect((result[2] as ContentParallaxImageModel).slug).toBe('collection-1');
       expect((result[3] as ContentParallaxImageModel).slug).toBe('collection-4');
     });
 
-    it('should preserve relative order within images and collections groups', () => {
+    it('interleaves alternating collections and images strictly by orderIndex', () => {
       const content: AnyContentModel[] = [
         createCollectionContent(1, { orderIndex: 1 }),
         createImageContent(2, { orderIndex: 2 }),
@@ -299,15 +294,7 @@ describe('processContentBlocks', () => {
       ];
       const result = processContentBlocks(content);
 
-      // Images should come first in their order: 2, 4, 5
-      expect(result[0]?.id).toBe(2);
-      expect(result[1]?.id).toBe(4);
-      expect(result[2]?.id).toBe(5);
-
-      // Collections should come after in their order: 1, 3, 6
-      expect(result[3]?.id).toBe(1);
-      expect(result[4]?.id).toBe(3);
-      expect(result[5]?.id).toBe(6);
+      expect(result.map(block => block.id)).toEqual([1, 2, 3, 4, 5, 6]);
     });
 
     it('should handle content with only images', () => {
@@ -343,7 +330,7 @@ describe('processContentBlocks', () => {
       }
     });
 
-    it('should work with text and other content types', () => {
+    it('keeps text, image and collection blocks in orderIndex order', () => {
       const content: AnyContentModel[] = [
         createCollectionContent(1, { orderIndex: 1 }),
         createTextContent(2, { orderIndex: 2 }),
@@ -351,17 +338,13 @@ describe('processContentBlocks', () => {
       ];
       const result = processContentBlocks(content);
 
-      // Text and image should come first (non-collections)
-      expect(result[0]?.id).toBe(2);
-      expect(result[1]?.id).toBe(3);
-
-      // Collection should come last (converted to parallax with slug)
-      expect(result[2]?.id).toBe(1);
-      expect((result[2] as ContentParallaxImageModel).enableParallax).toBe(true);
-      expect((result[2] as ContentParallaxImageModel).slug).toBe('collection-1');
+      expect(result.map(block => block.id)).toEqual([1, 2, 3]);
+      expect((result[0] as ContentParallaxImageModel).enableParallax).toBe(true);
+      expect((result[0] as ContentParallaxImageModel).slug).toBe('collection-1');
+      expect(result[1]?.contentType).toBe('TEXT');
     });
 
-    it('should work with chronological display mode', () => {
+    it('honours chronological order across collections and images alike', () => {
       const content: AnyContentModel[] = [
         createCollectionContent(1, {
           orderIndex: 1,
@@ -382,13 +365,8 @@ describe('processContentBlocks', () => {
       ];
       const result = processContentBlocks(content, true, undefined, 'CHRONOLOGICAL');
 
-      // Images should come first, sorted by createdAt: 3 (Jan 2), 2 (Jan 3)
-      expect(result[0]?.id).toBe(3);
-      expect(result[1]?.id).toBe(2);
-
-      // Collections should come after, sorted by createdAt: 1 (Jan 1), 4 (Jan 4)
-      expect(result[2]?.id).toBe(1);
-      expect(result[3]?.id).toBe(4);
+      // Pure createdAt order: collection(Jan 1), image(Jan 2), image(Jan 3), collection(Jan 4).
+      expect(result.map(block => block.id)).toEqual([1, 3, 2, 4]);
     });
   });
 
@@ -411,28 +389,22 @@ describe('processContentBlocks', () => {
       ];
       const result = processContentBlocks(content, true, 1);
 
-      // Should be filtered (visible: false removed) - 3 items remain
+      // Filtered: the visible:false image is dropped, 3 items remain.
       expect(result).toHaveLength(3);
 
-      // Images should come before collections
-      // After sorting by orderIndex: image(1), image(2), collection(0)
-      // After reordering: images first [image(1), image(2)], then collections [collection(0)]
-      const firstTwoItems = result.slice(0, 2);
-      const lastItem = result[2];
+      // orderIndex is honoured verbatim, so the collection card sits FIRST because its
+      // orderIndex is 0 — not last because it is a collection.
+      // NB the fixtures collide on id 1: result[0] is the COLLECTION, result[1] is the IMAGE.
+      const first = result[0] as ContentParallaxImageModel;
+      expect(first.id).toBe(1);
+      expect(first.enableParallax).toBe(true);
+      expect(first.slug).toBe('collection-1');
 
-      // First two items should be regular images (without slug)
-      for (const item of firstTwoItems) {
-        expect((item as ContentParallaxImageModel).slug).toBeUndefined();
-      }
-
-      // Last item should be the converted collection (with slug and enableParallax)
-      expect((lastItem as ContentParallaxImageModel).enableParallax).toBe(true);
-      expect((lastItem as ContentParallaxImageModel).slug).toBe('collection-1');
-      expect(lastItem?.id).toBe(1); // This is the collection
-
-      // Verify the images are in the correct order (1, then 2)
-      expect(firstTwoItems[0]?.id).toBe(1);
-      expect(firstTwoItems[1]?.id).toBe(2);
+      // The two surviving images follow in orderIndex order and are not converted (no slug).
+      expect(result[1]?.id).toBe(1);
+      expect(result[2]?.id).toBe(2);
+      expect((result[1] as ContentParallaxImageModel).slug).toBeUndefined();
+      expect((result[2] as ContentParallaxImageModel).slug).toBeUndefined();
     });
 
     it('should handle empty array', () => {

--- a/tests/utils/sortByDate.test.ts
+++ b/tests/utils/sortByDate.test.ts
@@ -57,3 +57,38 @@ describe('toChronologicalOrder', () => {
     expect(toChronologicalOrder(processed).map(c => c.id)).toEqual([1, 2]);
   });
 });
+
+describe('toChronologicalOrder — collection cards (R9)', () => {
+  /** A child-collection card as produced by convertCollectionContentToParallax. */
+  function makeCollectionCard(id: number, slug: string): ContentImageModel {
+    return {
+      id,
+      contentType: 'IMAGE',
+      orderIndex: 0,
+      imageUrl: `https://example.com/cover-${id}.jpg`,
+      locations: [],
+      slug,
+    } as ContentImageModel & { slug: string };
+  }
+
+  it('leaves a trailing collection card in its slot instead of hoisting it to epoch 0', () => {
+    // NB the card must NOT sit first in the input: an undated card sorts to position 0 anyway,
+    // so a leading card cannot distinguish fixed from broken. It sits last here.
+    const img1 = makeImage({ id: 1, captureDate: '2024-01-05', createdAt: '2024-06-01' });
+    const img2 = makeImage({ id: 3, captureDate: '2024-01-01', createdAt: '2024-06-02' });
+    const card = makeCollectionCard(900, 'child-gallery');
+    const processed: AnyContentModel[] = [img1, img2, card];
+
+    // The card holds the last slot; only the two images swap between the two dateable slots.
+    expect(toChronologicalOrder(processed).map(c => c.id)).toEqual([3, 1, 900]);
+  });
+
+  it('does not let a card displace an image when the card sits mid-list', () => {
+    const img1 = makeImage({ id: 1, captureDate: '2024-01-05', createdAt: '2024-06-01' });
+    const card = makeCollectionCard(900, 'child-gallery');
+    const img2 = makeImage({ id: 3, captureDate: '2024-01-01', createdAt: '2024-06-02' });
+    const processed: AnyContentModel[] = [img1, card, img2];
+
+    expect(toChronologicalOrder(processed).map(c => c.id)).toEqual([3, 900, 1]);
+  });
+});


### PR DESCRIPTION
Prepares the frontend to render a collection that holds images **and** child collections in any mix. Nothing can produce such a collection until the backend's U4 ships — this lands first so the pipeline can already render one the instant it becomes possible.

## What changes for a person using the site

- A collection's contents now render in the order you arranged them. Previously images were silently hoisted above child collections regardless of your ordering.
- The cover-image picker for a collection with children now offers **both** its own images and its children's, instead of one or the other.
- The "Add content" button and the Presentation settings are no longer hidden on collections that have children.
- Image filters (camera, lens) appear whenever a page has images, instead of vanishing when child collections outnumber them.
- Collection cards no longer appear in the fullscreen image viewer's next/prev cycle, and no longer get sorted as if they had capture dates.

## Review-round fixes included

Three independent reviewers caught that letting slug-navigation win over the click handler also fired in **admin manage mode**, so clicking a child collection card would leave manage mode for the public page. Fixed by scoping the rule to the public path only.

Also fixed: engaging the "Highly Rated" filter deleted every child-collection card with no rating, wiping the page's only navigation.

## Verification
`tsc` clean · **171 suites / 2769 tests, 0 failures** · eslint 0 problems · stylelint clean · `next build --webpack` succeeds.

Test-title set diff vs main: exactly 8 removed, 29 added — every removal accounted for by the plan.

## Not done
The manual browser smoke (plan step 12.6) needs a human. Four behaviours are unit-pinned but unverified in a real browser: mixed-content ordering, the cover picker union, the un-gated Add cell, and filter visibility.

Gated on U1 (merged). Gates U4 together with U2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)