### PR TITLE
feat(metadata): surface more image metadata, harden collection dirty-state

### DIFF
--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -18,7 +18,13 @@ import {
   updateCollection,
   updateCollectionRating,
 } from '@/app/lib/api/collections';
-import { createGif, createImages, createTextContent, updateImages } from '@/app/lib/api/content';
+import {
+  createGif,
+  createImages,
+  createTextContent,
+  updateGif,
+  updateImages,
+} from '@/app/lib/api/content';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import {
   type CollectionListModel,
@@ -50,6 +56,7 @@ import {
 import { buildLocationsDiff, convertLocationsToModels } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
 import { manageHref } from '@/app/utils/manageUrl';
+import { hasObjectChanges } from '@/app/utils/objectComparison';
 import { toChronologicalOrder } from '@/app/utils/sortByDate';
 import { buildTagsDiff, convertTagsToModels } from '@/app/utils/tagUtils';
 
@@ -77,6 +84,55 @@ const EMPTY_CONTENT: AnyContentModel[] = [];
 
 function isAnimatedMediaFile(file: File): boolean {
   return ANIMATED_MEDIA_MIME_TYPES.has(file.type) || ANIMATED_MEDIA_EXTENSION_REGEX.test(file.name);
+}
+
+/**
+ * Push a collection's locations down onto every piece of content that has none of its own.
+ *
+ * Giving a collection a location is a statement about where its content was shot, so anything in
+ * it that is not already placed inherits that location. Content the admin has already located is
+ * never touched — a per-image override outranks the collection-wide default.
+ *
+ * Images go out as one batched PATCH; GIF/MP4 blocks have no batch endpoint and are patched
+ * individually. All requests are issued together, and a single rejection fails the whole call so
+ * the caller can surface one error rather than a partial-success state.
+ *
+ * @param content - The collection's current content blocks.
+ * @param locationIds - IDs of the collection's saved locations.
+ * @returns True when at least one block was updated (the caller then refetches), false when
+ *   everything already had a location and no request was made.
+ */
+async function inheritLocationsToContent(
+  content: readonly AnyContentModel[],
+  locationIds: number[]
+): Promise<boolean> {
+  const hasNoLocation = (item: { locations?: LocationModel[] | null }) => !item.locations?.length;
+
+  const imagesWithoutLocation = content.filter(
+    (item): item is ContentImageModel => isContentImage(item) && hasNoLocation(item)
+  );
+  const gifsWithoutLocation = content.filter(
+    (item): item is ContentGifModel => isGifContent(item) && hasNoLocation(item)
+  );
+
+  if (imagesWithoutLocation.length === 0 && gifsWithoutLocation.length === 0) {
+    return false;
+  }
+
+  const requests: Promise<unknown>[] = gifsWithoutLocation.map(gif =>
+    updateGif(gif.id, { locations: { prev: locationIds } })
+  );
+
+  if (imagesWithoutLocation.length > 0) {
+    const imageUpdates: ContentImageUpdateRequest[] = imagesWithoutLocation.map(img => ({
+      id: img.id,
+      locations: { prev: locationIds },
+    }));
+    requests.push(updateImages(imageUpdates));
+  }
+
+  await Promise.all(requests);
+  return true;
 }
 
 export type ManageMode = 'browse' | 'select' | 'reorder' | 'add' | 'edit' | 'pick-date';
@@ -553,10 +609,27 @@ export function useCollectionEdit({
   };
   const manageMode = deriveManageMode();
 
-  const isUpdateDirty = useMemo(
-    () => (collection ? Object.keys(buildUpdatePayload(updateData, collection)).length > 1 : false),
-    [updateData, collection]
-  );
+  /**
+   * Dirty = the payload we would send differs from the payload an *untouched* buffer would send.
+   *
+   * Deliberately not "the payload has any field beyond id". `seedUpdateData` fabricates defaults
+   * for fields the API may not send — `displayMode` is nullable on the backend entity (no
+   * @NotNull, no @Builder.Default) and the seed forces 'CHRONOLOGICAL' for it. `buildUpdatePayload`
+   * then diffs that fabricated default against the null original, emits a `displayMode` key on
+   * every render, and the collection reads dirty forever: Save sits enabled and primary on load,
+   * and the exit button never relaxes to "Close".
+   *
+   * Re-baselining against the pristine seed cancels fabricated defaults out on both sides. It is
+   * field-agnostic, so it also covers `visibility` (currently @NotNull, so safe today) and any
+   * field dropped from the API later — this same trap previously fired through `type`, before the
+   * typeless refactor removed that field.
+   */
+  const isUpdateDirty = useMemo(() => {
+    if (!collection) return false;
+    const pristine = buildUpdatePayload(seedUpdateData(collection), collection);
+    const current = buildUpdatePayload(updateData, collection);
+    return hasObjectChanges(current, pristine);
+  }, [updateData, collection, seedUpdateData]);
 
   const resetToBrowse = useCallback(() => {
     setIsMultiSelectMode(false);
@@ -657,38 +730,26 @@ export function useCollectionEdit({
             !locationsUpdate.remove?.length &&
             (locationsUpdate.prev?.length || locationsUpdate.newValue?.length)
           ) {
-            const resolvedLocations = response.collection.locations ?? [];
-            if (resolvedLocations.length > 0) {
-              const imagesWithoutLocation = (collection.content ?? []).filter(
-                (item): item is ContentImageModel =>
-                  item.contentType === 'IMAGE' && (!item.locations || item.locations.length === 0)
-              );
-
-              if (imagesWithoutLocation.length > 0) {
-                const imageUpdates: ContentImageUpdateRequest[] = imagesWithoutLocation.map(
-                  img => ({
-                    id: img.id,
-                    locations: { prev: resolvedLocations.map(l => l.id) },
-                  })
-                );
-                updateImages(imageUpdates)
-                  .then(async () => {
-                    const refreshed = await getCollectionUpdateMetadata(response.collection.slug);
-                    if (refreshed) {
-                      setCurrentState(refreshed);
-                      collectionStorage.update(refreshed.collection.slug, refreshed.collection);
-                      collectionStorage.updateFull(refreshed.collection.slug, refreshed);
-                    }
-                  })
-                  .catch((error_: unknown) => {
-                    logger.error(
-                      'useCollectionEdit',
-                      'Failed to inherit locations to images',
-                      error_
-                    );
-                    setError('Collection saved, but failed to inherit locations to images.');
-                  });
-              }
+            const resolvedLocationIds = (response.collection.locations ?? []).map(l => l.id);
+            if (resolvedLocationIds.length > 0) {
+              inheritLocationsToContent(collection.content ?? [], resolvedLocationIds)
+                .then(async inherited => {
+                  if (!inherited) return;
+                  const refreshed = await getCollectionUpdateMetadata(response.collection.slug);
+                  if (refreshed) {
+                    setCurrentState(refreshed);
+                    collectionStorage.update(refreshed.collection.slug, refreshed.collection);
+                    collectionStorage.updateFull(refreshed.collection.slug, refreshed);
+                  }
+                })
+                .catch((error_: unknown) => {
+                  logger.error(
+                    'useCollectionEdit',
+                    'Failed to inherit locations to content',
+                    error_
+                  );
+                  setError('Collection saved, but failed to inherit locations to its content.');
+                });
             }
           }
         }
@@ -1464,7 +1525,11 @@ export function useCollectionEdit({
           disabled: !isUpdateDirty || saving || isLoading,
           onClick: () => void handleUpdate(),
         },
-        { key: 'cancel', label: 'Cancel', onClick: resetToBrowse },
+        {
+          key: 'cancel',
+          label: isUpdateDirty ? 'Cancel' : 'Close',
+          onClick: resetToBrowse,
+        },
       ];
     }
 
@@ -1500,7 +1565,13 @@ export function useCollectionEdit({
       },
     ];
     if (onExitManage) {
-      cells.push({ key: 'cancel', label: 'Cancel', onClick: onExitManage });
+      // "Close" when nothing has been edited (nothing to discard); "Cancel" once there are
+      // unsaved changes, signalling that leaving abandons them. Matches the metadata sheet.
+      cells.push({
+        key: 'cancel',
+        label: isUpdateDirty ? 'Cancel' : 'Close',
+        onClick: onExitManage,
+      });
     }
     return cells;
   }, [

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -17,9 +17,15 @@ import { IMAGE } from '@/app/constants';
 import styles from '@/app/styles/fullscreen-image.module.scss';
 import { type CollectionModel } from '@/app/types/Collection';
 import type { ViewableContent } from '@/app/types/Content';
+import { formatLongDate } from '@/app/utils/formatDateRange';
 import { canDownloadCollection } from '@/app/utils/galleryAccess';
 
-import { isGifBlock, resolveDisplayDate, resolveDisplayLocations } from './fullScreenModalUtils';
+import {
+  isGifBlock,
+  resolveDisplayDate,
+  resolveDisplayFilmStock,
+  resolveDisplayLocations,
+} from './fullScreenModalUtils';
 
 type ImageBlock = ViewableContent;
 
@@ -111,7 +117,8 @@ export function FullScreenModal({
   // Resolve locations/date: image fields take priority, falling back to the collection. GIF blocks
   // carry neither, so they fall straight through to the collection.
   const displayLocations = resolveDisplayLocations(currentImage, collectionData, isGif);
-  const displayDate = resolveDisplayDate(currentImage, collectionData, isGif);
+  const displayDate = formatLongDate(resolveDisplayDate(currentImage, collectionData, isGif));
+  const displayFilmStock = resolveDisplayFilmStock(currentImage, isGif);
 
   const currentImageLoaded = loadedImageIds.has(currentImage.id);
   const hasPrevious = fullScreenState.currentIndex > 0;
@@ -184,6 +191,9 @@ export function FullScreenModal({
                       {currentImage.title}
                     </div>
                   )}
+                  {currentImage.caption && (
+                    <div className={styles.metadataCaption}>{currentImage.caption}</div>
+                  )}
                   {currentImage.author && (
                     <div className={styles.metadataItem}>{currentImage.author}</div>
                   )}
@@ -224,18 +234,35 @@ export function FullScreenModal({
                       {currentImage.lens && <span>{currentImage.lens.name}</span>}
                     </div>
                   )}
+                  {displayFilmStock && (
+                    <div className={styles.metadataItem}>{displayFilmStock}</div>
+                  )}
                   {!isGif &&
                     (currentImage.iso ||
                       currentImage.fStop ||
                       currentImage.shutterSpeed ||
                       currentImage.focalLength) && (
                       <div className={styles.metadataSettingsRow}>
-                        {currentImage.iso && <span>{currentImage.iso}</span>}
+                        {currentImage.iso && <span>{currentImage.iso} ISO</span>}
                         {currentImage.shutterSpeed && <span>{currentImage.shutterSpeed}</span>}
                         {currentImage.fStop && <span>{currentImage.fStop}</span>}
                         {currentImage.focalLength && <span>{currentImage.focalLength}</span>}
                       </div>
                     )}
+                  {currentImage.tags && currentImage.tags.length > 0 && (
+                    <div className={styles.metadataSection}>
+                      <div className={styles.metadataSectionRow}>
+                        <div className={styles.metadataSectionHeader}>Tags</div>
+                        <div className={styles.metadataSectionItems}>
+                          {currentImage.tags.map((t, index) => (
+                            <div key={t.id || index} className={styles.metadataSectionItem}>
+                              {t.name}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  )}
                   {!isGif && currentImage.people && currentImage.people.length > 0 && (
                     <div className={styles.metadataSection}>
                       <div className={styles.metadataSectionRow}>

--- a/app/components/FullScreenModal/fullScreenModalUtils.ts
+++ b/app/components/FullScreenModal/fullScreenModalUtils.ts
@@ -6,6 +6,7 @@
 
 import type { CollectionModel, LocationModel } from '@/app/types/Collection';
 import type { ContentGifModel, ViewableContent } from '@/app/types/Content';
+import { formatFilmFormat } from '@/app/utils/filmFormat';
 
 /**
  * Type guard for GIF content blocks. GIFs lack `captureDate` and may lack `locations`, so the
@@ -46,4 +47,19 @@ export function resolveDisplayDate(
   return !isGif && !isGifBlock(currentImage)
     ? (currentImage.captureDate ?? collectionData?.collectionDate ?? null)
     : (collectionData?.collectionDate ?? null);
+}
+
+/**
+ * Compose the film line for the equipment row — `Kodak Portra 400 · 35mm` — from the two fields
+ * the backend keeps separate. Returns an empty string unless the image is actually flagged as
+ * film, so a digital frame never shows a stray format left over from an earlier edit.
+ *
+ * `filmType` already arrives as a display name; `filmFormat` is a raw enum and is labelled here.
+ */
+export function resolveDisplayFilmStock(currentImage: ViewableContent, isGif: boolean): string {
+  if (isGif || isGifBlock(currentImage) || !currentImage.isFilm) {
+    return '';
+  }
+  const parts = [currentImage.filmType, formatFilmFormat(currentImage.filmFormat)].filter(Boolean);
+  return parts.join(' · ');
 }

--- a/app/components/Metadata/MetadataModal.module.scss
+++ b/app/components/Metadata/MetadataModal.module.scss
@@ -158,6 +158,37 @@
   font-variant-numeric: tabular-nums;
 }
 
+// Definition list of non-editable facts (capture date, filename, dimensions...). Label column is
+// fixed so the values align into a readable column; the value wraps rather than overflowing on a
+// long raw filename.
+.readOnlyList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.readOnlyRow {
+  display: grid;
+  grid-template-columns: 6.5rem 1fr;
+  gap: var(--space-3);
+  align-items: baseline;
+}
+
+.readOnlyLabel {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-on-surface-muted);
+}
+
+.readOnlyValue {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
 .formInput,
 .formTextarea,
 .formSelect {

--- a/app/components/Metadata/MetadataModal.tsx
+++ b/app/components/Metadata/MetadataModal.tsx
@@ -24,6 +24,7 @@ import styles from './MetadataModal.module.scss';
 import CameraSettingsSection from './sections/CameraSettingsSection';
 import EssentialInfoSection from './sections/EssentialInfoSection';
 import MediaPreview from './sections/MediaPreview';
+import ReadOnlyInfoSection from './sections/ReadOnlyInfoSection';
 import TagsPeopleSection from './sections/TagsPeopleSection';
 import type { EditableContent } from './types';
 
@@ -182,6 +183,7 @@ export default function MetadataModal({
                   availableTags={availableTags}
                   availablePeople={availablePeople}
                 />
+                {!isBulkEdit && <ReadOnlyInfoSection content={previewImage} />}
               </div>
 
               <div

--- a/app/components/Metadata/sections/EssentialInfoSection.tsx
+++ b/app/components/Metadata/sections/EssentialInfoSection.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/app/components/ui/Field/Input';
 import { Select } from '@/app/components/ui/Field/Select';
 import { Textarea } from '@/app/components/ui/Field/Textarea';
 import type { CollectionListModel, LocationModel } from '@/app/types/Collection';
+import { formatLongDate } from '@/app/utils/formatDateRange';
 
 import type { ImageUpdateState } from '../hooks/useMetadataState';
 import modalStyles from '../MetadataModal.module.scss';
@@ -195,7 +196,7 @@ export default function EssentialInfoSection({
               grid, so this button closes the sheet and hands off to pick mode. */}
           <div className={modalStyles.inlineActionRow}>
             <span className={modalStyles.inlineActionValue}>
-              {updateState.captureDate ? updateState.captureDate.split('T')[0] : 'Not set'}
+              {updateState.captureDate ? formatLongDate(updateState.captureDate) : 'Not set'}
             </span>
             <Button
               size="sm"

--- a/app/components/Metadata/sections/ReadOnlyInfoSection.tsx
+++ b/app/components/Metadata/sections/ReadOnlyInfoSection.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { isGifContent } from '@/app/utils/contentTypeGuards';
+import { formatLongDate } from '@/app/utils/formatDateRange';
+
+import modalStyles from '../MetadataModal.module.scss';
+import type { EditableContent } from '../types';
+
+/**
+ * Build the label/value rows for the read-only panel, skipping anything the content block
+ * doesn't carry so the list never renders an "—" placeholder row.
+ *
+ * Capture date is omitted for GIF/MP4 blocks: they have no EXIF, and their date is surfaced (and
+ * changed) by the pick-a-reference-image row in {@link EssentialInfoSection} instead.
+ */
+function buildRows(content: EditableContent): Array<{ label: string; value: string }> {
+  const isGif = isGifContent(content);
+  const width = isGif ? content.width : content.imageWidth;
+  const height = isGif ? content.height : content.imageHeight;
+
+  const rows: Array<{ label: string; value: string }> = [];
+
+  if (!isGif && content.captureDate) {
+    rows.push({ label: 'Captured', value: formatLongDate(content.captureDate) });
+  }
+  if (!isGif && content.rawFileName) {
+    rows.push({ label: 'File', value: content.rawFileName });
+  }
+  if (width && height) {
+    rows.push({ label: 'Dimensions', value: `${width} × ${height}` });
+  }
+  if (content.createdAt) {
+    rows.push({ label: 'Uploaded', value: formatLongDate(content.createdAt) });
+  }
+  rows.push({ label: 'Content ID', value: String(content.id) });
+
+  return rows;
+}
+
+export interface ReadOnlyInfoSectionProps {
+  /** The single content block being edited. Bulk edit does not render this section. */
+  content: EditableContent;
+}
+
+/**
+ * Read-only companion to the editable form sections: the facts about a content block that the
+ * admin cannot change but still needs to see while editing — capture date, source filename,
+ * pixel dimensions, upload time, and the content ID used when cross-referencing the backend.
+ */
+export default function ReadOnlyInfoSection({
+  content,
+}: ReadOnlyInfoSectionProps): React.JSX.Element {
+  const rows = buildRows(content);
+
+  return (
+    <div className={modalStyles.formSection}>
+      <h3 className={modalStyles.sectionHeading}>File Information</h3>
+
+      <dl className={modalStyles.readOnlyList}>
+        {rows.map(row => (
+          <div key={row.label} className={modalStyles.readOnlyRow}>
+            <dt className={modalStyles.readOnlyLabel}>{row.label}</dt>
+            <dd className={modalStyles.readOnlyValue}>{row.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/app/styles/fullscreen-image.module.scss
+++ b/app/styles/fullscreen-image.module.scss
@@ -278,6 +278,19 @@
   }
 }
 
+// Sits directly under the title. Italic and slightly dimmed so a sentence of prose reads as
+// the photographer's note rather than another metadata field.
+.metadataCaption {
+  margin-bottom: 8px;
+  color: var(--scrim-light-70);
+  font-style: italic;
+  line-height: 1.4;
+
+  @media (width > 768px) and (height >= 600px) {
+    margin-bottom: 10px;
+  }
+}
+
 .metadataSeparator {
   color: var(--scrim-light-50);
   margin: 0 4px;

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -83,8 +83,8 @@ export interface ContentImageModel extends Content {
   /**
    * Film-specific metadata - only used when isFilm is true
    */
-  filmType?: string | null; // Enum name (e.g., "KODAK_PORTRA_400")
-  filmFormat?: string | null; // Enum name (e.g., "MM_35")
+  filmType?: string | null; // Display name (e.g., "Kodak Portra 400") — backend sends getDisplayName()
+  filmFormat?: string | null; // Enum name (e.g., "MM_35") — label via formatFilmFormat()
 
   /**
    * Relationships to tags, people, camera, and lens

--- a/app/utils/filmFormat.ts
+++ b/app/utils/filmFormat.ts
@@ -1,0 +1,29 @@
+/**
+ * Display names for the backend `FilmFormat` enum.
+ *
+ * `ContentImageModel.filmFormat` carries the raw enum name (`MM_35`), not a label — the admin
+ * editor resolves it against the fetched `FilmFormatDTO[]`, but public surfaces like the
+ * fullscreen metadata overlay have no such list and would otherwise print `MM_35` verbatim.
+ *
+ * Mirrors `edens.zac.backend` `types/FilmFormat.java`. An unmapped value falls through
+ * unchanged rather than rendering as blank, so a newly added backend format is visibly wrong
+ * instead of silently missing.
+ */
+
+const FILM_FORMAT_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  MM_35: '35mm',
+  MM_120: '120',
+};
+
+/**
+ * Resolve a `FilmFormat` enum name to its human label.
+ *
+ * @param filmFormat - Backend enum name, e.g. `MM_35`.
+ * @returns The display label (`35mm`), the input verbatim when unmapped, or an empty string.
+ */
+export function formatFilmFormat(filmFormat?: string | null): string {
+  if (!filmFormat) {
+    return '';
+  }
+  return FILM_FORMAT_DISPLAY_NAMES[filmFormat] ?? filmFormat;
+}

--- a/app/utils/formatDateRange.ts
+++ b/app/utils/formatDateRange.ts
@@ -31,6 +31,21 @@ const MONTHS_SHORT = [
   'Dec',
 ] as const;
 
+const MONTHS_LONG = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
 export interface DateParts {
   year: number;
   month: number;
@@ -82,6 +97,53 @@ function formatMonthDay(parts: DateParts): string {
 /** `Mar 3, 2026` — month abbreviation, day, and year. */
 function formatMonthDayYear(parts: DateParts): string {
   return `${formatMonthDay(parts)}, ${parts.year}`;
+}
+
+/**
+ * English ordinal suffix for a day-of-month: `1st`, `2nd`, `3rd`, `4th`, `11th`, `21st`, `31st`.
+ * The 11–13 teens are the exception to the trailing-digit rule and are checked first.
+ */
+function ordinalSuffix(day: number): string {
+  if (day >= 11 && day <= 13) {
+    return 'th';
+  }
+  switch (day % 10) {
+    case 1: {
+      return 'st';
+    }
+    case 2: {
+      return 'nd';
+    }
+    case 3: {
+      return 'rd';
+    }
+    default: {
+      return 'th';
+    }
+  }
+}
+
+/**
+ * Format a single date for human display: `September 13th, 2023`.
+ *
+ * Used wherever a raw capture date would otherwise leak to the screen — the fullscreen metadata
+ * overlay and the metadata editor's read-only rows both previously rendered the backend string
+ * verbatim (`2023-10-13T02:32:00`). A time component is accepted and dropped; anything that isn't
+ * a real calendar date falls through verbatim so a malformed value stays visible rather than
+ * silently disappearing.
+ *
+ * @param iso - ISO `YYYY-MM-DD` date, optionally with a `T`/space time suffix.
+ * @returns The long-form date, the verbatim input when unparseable, or an empty string.
+ */
+export function formatLongDate(iso?: string | null): string {
+  if (!iso) {
+    return '';
+  }
+  const parts = parseIsoDateParts(iso);
+  if (!parts) {
+    return iso;
+  }
+  return `${MONTHS_LONG[parts.month - 1]} ${parts.day}${ordinalSuffix(parts.day)}, ${parts.year}`;
 }
 
 /**

--- a/tests/components/ContentCollection/CollectionPageClient.editMode.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.editMode.test.tsx
@@ -506,7 +506,7 @@ describe('CollectionPageClient — editMode true', () => {
       expect(lastCall.onImageClick).toBeUndefined();
     });
 
-    it('disables the browse cells while pending, but keeps Cancel (exit manage) enabled', async () => {
+    it('disables the browse cells while pending, but keeps Close (exit manage) enabled', async () => {
       mockGetCollectionUpdateMetadata.mockReturnValue(pendingForever());
       render(<CollectionPageClient collection={makeCollection()} editMode />);
       await flush();
@@ -515,7 +515,7 @@ describe('CollectionPageClient — editMode true', () => {
       expect(screen.getByRole('button', { name: 'Reorder' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Close' })).toBeEnabled();
     });
 
     it('mounts inline editors, enables the cells, and routes taps once the DTO resolves', async () => {

--- a/tests/components/ContentCollection/useCollectionEdit.handlers.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.handlers.test.tsx
@@ -9,7 +9,7 @@ import {
   updateCollection,
   updateCollectionRating,
 } from '@/app/lib/api/collections';
-import { createGif, createImages, updateImages } from '@/app/lib/api/content';
+import { createGif, createImages, updateGif, updateImages } from '@/app/lib/api/content';
 import { collectionStorage } from '@/app/lib/storage/collectionStorage';
 import {
   type CollectionListModel,
@@ -18,7 +18,11 @@ import {
   type GeneralMetadataDTO,
 } from '@/app/types/Collection';
 import { CollectionVisibility } from '@/app/types/CollectionVisibility';
-import { type ContentImageModel, type ContentImageUpdateResponse } from '@/app/types/Content';
+import {
+  type ContentGifModel,
+  type ContentImageModel,
+  type ContentImageUpdateResponse,
+} from '@/app/types/Content';
 import { createCollectionContent } from '@/tests/fixtures/contentFixtures';
 
 jest.mock('next/navigation', () => ({
@@ -45,6 +49,7 @@ const mockSetCollectionPeople = setCollectionPeople as jest.MockedFunction<
   typeof setCollectionPeople
 >;
 const mockUpdateImages = updateImages as jest.MockedFunction<typeof updateImages>;
+const mockUpdateGif = updateGif as jest.MockedFunction<typeof updateGif>;
 const mockCreateImages = createImages as jest.MockedFunction<typeof createImages>;
 const mockCreateGif = createGif as jest.MockedFunction<typeof createGif>;
 const mockStorageGetFull = collectionStorage.getFull as jest.MockedFunction<
@@ -268,6 +273,47 @@ describe('useCollectionEdit — handler tests', () => {
       const updateCall = mockUpdateImages.mock.calls[0]?.[0] ?? [];
       expect(updateCall).toHaveLength(1);
       expect(updateCall[0]?.id).toBe(11);
+    });
+
+    it('inherits locations to GIF/MP4 blocks lacking them, and skips content already located', async () => {
+      const locationId = 5;
+      const undatedGif = {
+        id: 21,
+        contentType: 'GIF' as const,
+        orderIndex: 1,
+        gifUrl: 'https://cdn.example.com/21.mp4',
+        locations: [],
+      } as unknown as ContentGifModel;
+      const gifAlreadyPlaced = {
+        id: 22,
+        contentType: 'GIF' as const,
+        orderIndex: 2,
+        gifUrl: 'https://cdn.example.com/22.mp4',
+        locations: [{ id: 99, name: 'Oslo', slug: 'oslo' }],
+      } as unknown as ContentGifModel;
+
+      const content = [undatedGif, gifAlreadyPlaced];
+      const responseWithLocations = makeResponse({
+        locations: [{ id: locationId, name: 'Paris', slug: 'paris' }],
+        content,
+      });
+      mockUpdateCollection.mockResolvedValue(responseWithLocations);
+      mockUpdateGif.mockResolvedValue(undatedGif);
+      mockGetCollectionUpdateMetadata.mockResolvedValue(responseWithLocations);
+
+      const collection = makeCollection({ content });
+      const { result } = renderEdit({ enabled: true, collection });
+      await waitFor(() => expect(result.current.currentState).not.toBeNull());
+
+      act(() => result.current.setUpdateField('locations', { prev: [locationId] }));
+
+      await act(async () => {
+        await result.current.handleUpdate();
+      });
+
+      await waitFor(() => expect(mockUpdateGif).toHaveBeenCalledTimes(1));
+      expect(mockUpdateGif).toHaveBeenCalledWith(21, { locations: { prev: [locationId] } });
+      expect(mockUpdateImages).not.toHaveBeenCalled();
     });
 
     it('does NOT call updateImages when the response has no locations', async () => {

--- a/tests/components/ContentCollection/useCollectionEdit.test.tsx
+++ b/tests/components/ContentCollection/useCollectionEdit.test.tsx
@@ -463,17 +463,46 @@ describe('useCollectionEdit', () => {
       expect(cancel).toBeUndefined();
     });
 
-    it('browse appends a rightmost Cancel cell that calls onExitManage when provided', () => {
+    it('browse appends a rightmost exit cell that calls onExitManage when provided', () => {
       const onExitManage = jest.fn();
       const { result } = renderEdit({ enabled: false, onExitManage });
 
       const labels = result.current.bottomBarCells.map(c => c.label);
-      expect(labels).toEqual(['Select', 'Reorder', 'Add', 'Edit', 'Cancel']);
+      expect(labels).toEqual(['Select', 'Reorder', 'Add', 'Edit', 'Close']);
 
       const cancel = result.current.bottomBarCells.find(c => c.key === 'cancel');
       expect(cancel).toBeDefined();
       cancel?.onClick?.();
       expect(onExitManage).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not dirty on load when the API omits `displayMode` (nullable on the backend entity)', () => {
+      // seedUpdateData fabricates 'CHRONOLOGICAL' for a collection with no displayMode, which made
+      // buildUpdatePayload emit a displayMode key forever — the collection read as dirty on load, so
+      // Save stayed enabled and the exit cell never relaxed to "Close". The shared fixture always
+      // sets displayMode, so only an explicitly-omitted one reproduces it.
+      const collection = makeCollection({ displayMode: undefined });
+      const { result } = renderEdit({ enabled: false, collection, onExitManage: jest.fn() });
+
+      expect(result.current.isUpdateDirty).toBe(false);
+      expect(result.current.bottomBarCells.find(c => c.key === 'cancel')?.label).toBe('Close');
+
+      act(() => result.current.setUpdateField('title', 'Renamed'));
+
+      expect(result.current.isUpdateDirty).toBe(true);
+    });
+
+    it('labels the browse exit cell "Close" until there are unsaved edits, then "Cancel"', () => {
+      const { result } = renderEdit({ onExitManage: jest.fn() });
+
+      const labelOf = () => result.current.bottomBarCells.find(c => c.key === 'cancel')?.label;
+      expect(labelOf()).toBe('Close');
+
+      act(() => {
+        result.current.setUpdateField('title', 'A new title');
+      });
+
+      expect(labelOf()).toBe('Cancel');
     });
 
     it('select Cancel returns to browse and does NOT exit manage', () => {
@@ -507,7 +536,7 @@ describe('useCollectionEdit', () => {
       expect(cells[cells.length - 3]?.key).toBe('remove');
     });
 
-    it('edit contains a primary Save (disabled when not dirty) + a rightmost Cancel', () => {
+    it('edit contains a primary Save (disabled when not dirty) + a rightmost exit cell', () => {
       const { result } = renderEdit({ enabled: false });
       act(() => result.current.enterEdit());
 
@@ -519,8 +548,20 @@ describe('useCollectionEdit', () => {
       expect(save?.label).toBe('Save');
       expect(save?.disabled).toBe(true); // not dirty yet
       expect(cancel).toBeDefined();
-      expect(cancel?.label).toBe('Cancel');
+      expect(cancel?.label).toBe('Close'); // nothing to discard yet
       expect(cells[cells.length - 1]).toBe(cancel); // always the rightmost cell
+    });
+
+    it('labels the edit-sheet exit cell "Close" until there are unsaved edits, then "Cancel"', () => {
+      const { result } = renderEdit({ enabled: false });
+      act(() => result.current.enterEdit());
+
+      const labelOf = () => result.current.bottomBarCells.find(c => c.key === 'cancel')?.label;
+      expect(labelOf()).toBe('Close');
+
+      act(() => result.current.setUpdateField('title', 'Changed'));
+
+      expect(labelOf()).toBe('Cancel');
     });
 
     it('edit Save becomes primary + enabled once a field changes', () => {

--- a/tests/components/FullScreenModal/FullScreenModal.metadata.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.metadata.test.tsx
@@ -82,17 +82,22 @@ describe('FullScreenModal — date resolution (characterization)', () => {
       img(1, { captureDate: '2024-03-01' }),
       collection({ collectionDate: '2020-01-01' })
     );
-    expect(screen.getByText('2024-03-01')).toBeInTheDocument();
+    expect(screen.getByText('March 1st, 2024')).toBeInTheDocument();
   });
 
   it('falls back to the collection collectionDate when the image has no captureDate', () => {
     renderModal(img(1, { captureDate: null }), collection({ collectionDate: '2020-01-01' }));
-    expect(screen.getByText('2020-01-01')).toBeInTheDocument();
+    expect(screen.getByText('January 1st, 2020')).toBeInTheDocument();
   });
 
   it('GIF blocks ignore any image fields and fall back to the collection collectionDate', () => {
     renderModal(gif(1), collection({ collectionDate: '2019-06-15' }));
-    expect(screen.getByText('2019-06-15')).toBeInTheDocument();
+    expect(screen.getByText('June 15th, 2019')).toBeInTheDocument();
+  });
+
+  it('drops the time component from a captureDate carrying one', () => {
+    renderModal(img(1, { captureDate: '2023-10-13T02:32:00' }), collection({}));
+    expect(screen.getByText('October 13th, 2023')).toBeInTheDocument();
   });
 });
 

--- a/tests/components/FullScreenModal/fullScreenModalUtils.test.ts
+++ b/tests/components/FullScreenModal/fullScreenModalUtils.test.ts
@@ -5,6 +5,7 @@
 import {
   isGifBlock,
   resolveDisplayDate,
+  resolveDisplayFilmStock,
   resolveDisplayLocations,
 } from '@/app/components/FullScreenModal/fullScreenModalUtils';
 import type { CollectionModel, LocationModel } from '@/app/types/Collection';
@@ -136,5 +137,38 @@ describe('resolveDisplayDate', () => {
 
   it('GIF blocks return null when the collection has no collectionDate', () => {
     expect(resolveDisplayDate(gif(), collection(), true)).toBeNull();
+  });
+});
+
+describe('resolveDisplayFilmStock', () => {
+  it('joins the film stock and the labelled format', () => {
+    expect(
+      resolveDisplayFilmStock(
+        img({ isFilm: true, filmType: 'Kodak Portra 400', filmFormat: 'MM_35' }),
+        false
+      )
+    ).toBe('Kodak Portra 400 · 35mm');
+  });
+
+  it('renders whichever half is present on its own', () => {
+    expect(resolveDisplayFilmStock(img({ isFilm: true, filmType: 'Ilford HP5' }), false)).toBe(
+      'Ilford HP5'
+    );
+    expect(resolveDisplayFilmStock(img({ isFilm: true, filmFormat: 'MM_120' }), false)).toBe('120');
+  });
+
+  it('returns nothing for a digital frame, even one carrying stale film fields', () => {
+    expect(resolveDisplayFilmStock(img({ isFilm: false, filmType: 'Kodak Gold 200' }), false)).toBe(
+      ''
+    );
+    expect(resolveDisplayFilmStock(img({ filmFormat: 'MM_35' }), false)).toBe('');
+  });
+
+  it('returns nothing for GIF/MP4 blocks, which carry no film metadata', () => {
+    expect(resolveDisplayFilmStock(gif(), true)).toBe('');
+  });
+
+  it('returns nothing when the image is film but has neither field set', () => {
+    expect(resolveDisplayFilmStock(img({ isFilm: true }), false)).toBe('');
   });
 });

--- a/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
+++ b/tests/components/Metadata/sections/EssentialInfoSection.test.tsx
@@ -222,7 +222,7 @@ describe('EssentialInfoSection', () => {
       expect(updateStateField).not.toHaveBeenCalled();
     });
 
-    it('shows the current capture date as a day, and "Not set" when absent', () => {
+    it('shows the current capture date as a long-form day, and "Not set" when absent', () => {
       const { unmount } = render(
         <EssentialInfoSection
           {...makeProps({
@@ -232,7 +232,7 @@ describe('EssentialInfoSection', () => {
           })}
         />
       );
-      expect(screen.getByText('2024-06-14')).toBeInTheDocument();
+      expect(screen.getByText('June 14th, 2024')).toBeInTheDocument();
       unmount();
 
       render(

--- a/tests/components/Metadata/sections/ReadOnlyInfoSection.test.tsx
+++ b/tests/components/Metadata/sections/ReadOnlyInfoSection.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+
+import ReadOnlyInfoSection from '@/app/components/Metadata/sections/ReadOnlyInfoSection';
+import type { ContentGifModel, ContentImageModel } from '@/app/types/Content';
+
+const imageFixture = (overrides: Partial<ContentImageModel> = {}): ContentImageModel =>
+  ({
+    id: 42,
+    contentType: 'IMAGE',
+    imageUrl: 'https://cdn.example.com/42.jpg',
+    imageWidth: 4000,
+    imageHeight: 3000,
+    captureDate: '2023-10-13T02:32:00',
+    rawFileName: '_DSC0272-Enhanced-NR.webp',
+    createdAt: '2024-01-05T18:00:00',
+    locations: [],
+    ...overrides,
+  }) as ContentImageModel;
+
+const gifFixture = (overrides: Partial<ContentGifModel> = {}): ContentGifModel =>
+  ({
+    id: 7,
+    contentType: 'GIF',
+    gifUrl: 'https://cdn.example.com/7.mp4',
+    width: 1920,
+    height: 1080,
+    captureDate: '2023-10-13T02:32:00',
+    createdAt: '2024-01-05T18:00:00',
+    ...overrides,
+  }) as ContentGifModel;
+
+describe('ReadOnlyInfoSection', () => {
+  it('renders the non-editable facts an admin needs while editing an image', () => {
+    render(<ReadOnlyInfoSection content={imageFixture()} />);
+
+    expect(screen.getByText('Captured')).toBeInTheDocument();
+    expect(screen.getByText('October 13th, 2023')).toBeInTheDocument();
+    expect(screen.getByText('_DSC0272-Enhanced-NR.webp')).toBeInTheDocument();
+    expect(screen.getByText('4000 × 3000')).toBeInTheDocument();
+    expect(screen.getByText('January 5th, 2024')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('omits rows the content block does not carry rather than rendering placeholders', () => {
+    render(
+      <ReadOnlyInfoSection
+        content={imageFixture({
+          captureDate: null,
+          rawFileName: null,
+          imageWidth: undefined,
+          imageHeight: undefined,
+          createdAt: undefined,
+        })}
+      />
+    );
+
+    expect(screen.queryByText('Captured')).not.toBeInTheDocument();
+    expect(screen.queryByText('File')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dimensions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Uploaded')).not.toBeInTheDocument();
+    expect(screen.getByText('Content ID')).toBeInTheDocument();
+  });
+
+  it('reads GIF dimensions from width/height and leaves the capture date to the editable row', () => {
+    render(<ReadOnlyInfoSection content={gifFixture()} />);
+
+    expect(screen.getByText('1920 × 1080')).toBeInTheDocument();
+    expect(screen.queryByText('Captured')).not.toBeInTheDocument();
+    expect(screen.queryByText('File')).not.toBeInTheDocument();
+  });
+});

--- a/tests/utils/filmFormat.test.ts
+++ b/tests/utils/filmFormat.test.ts
@@ -1,0 +1,18 @@
+import { formatFilmFormat } from '@/app/utils/filmFormat';
+
+describe('formatFilmFormat', () => {
+  it('maps the backend enum names to their display labels', () => {
+    expect(formatFilmFormat('MM_35')).toBe('35mm');
+    expect(formatFilmFormat('MM_120')).toBe('120');
+  });
+
+  it('passes an unmapped value through so a new backend format is visibly wrong, not missing', () => {
+    expect(formatFilmFormat('IN_4X5')).toBe('IN_4X5');
+  });
+
+  it('returns an empty string for absent input', () => {
+    expect(formatFilmFormat(null)).toBe('');
+    expect(formatFilmFormat()).toBe('');
+    expect(formatFilmFormat('')).toBe('');
+  });
+});

--- a/tests/utils/formatDateRange.test.ts
+++ b/tests/utils/formatDateRange.test.ts
@@ -1,6 +1,7 @@
 import {
   formatDateRange,
   formatDisplayDateRange,
+  formatLongDate,
   parseIsoDateParts,
 } from '@/app/utils/formatDateRange';
 
@@ -146,5 +147,42 @@ describe('parseIsoDateParts', () => {
   it('returns null for absent input', () => {
     expect(parseIsoDateParts(null)).toBeNull();
     expect(parseIsoDateParts('')).toBeNull();
+  });
+});
+
+describe('formatLongDate', () => {
+  it('renders a plain ISO date in long form', () => {
+    expect(formatLongDate('2023-09-13')).toBe('September 13th, 2023');
+  });
+
+  it('drops a time component (the shape captureDate arrives in)', () => {
+    expect(formatLongDate('2023-10-13T02:32:00')).toBe('October 13th, 2023');
+  });
+
+  it('applies st/nd/rd suffixes to the days that take them', () => {
+    expect(formatLongDate('2024-01-01')).toBe('January 1st, 2024');
+    expect(formatLongDate('2024-01-02')).toBe('January 2nd, 2024');
+    expect(formatLongDate('2024-01-03')).toBe('January 3rd, 2024');
+    expect(formatLongDate('2024-01-21')).toBe('January 21st, 2024');
+    expect(formatLongDate('2024-01-22')).toBe('January 22nd, 2024');
+    expect(formatLongDate('2024-01-23')).toBe('January 23rd, 2024');
+    expect(formatLongDate('2024-01-31')).toBe('January 31st, 2024');
+  });
+
+  it('uses "th" for the 11-13 teens rather than the trailing-digit rule', () => {
+    expect(formatLongDate('2024-01-11')).toBe('January 11th, 2024');
+    expect(formatLongDate('2024-01-12')).toBe('January 12th, 2024');
+    expect(formatLongDate('2024-01-13')).toBe('January 13th, 2024');
+  });
+
+  it('returns an unparseable value verbatim rather than blanking it', () => {
+    expect(formatLongDate('not-a-date')).toBe('not-a-date');
+    expect(formatLongDate('2026-02-30')).toBe('2026-02-30');
+  });
+
+  it('returns an empty string for absent input', () => {
+    expect(formatLongDate(null)).toBe('');
+    expect(formatLongDate()).toBe('');
+    expect(formatLongDate('')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Six related changes to how image metadata is displayed, plus a dirty-state fix found along the way.

The public fullscreen overlay and the admin metadata editor both showed less than they had available, and what they did show read like a database row (`2023-10-13T02:32:00`, a bare `2200` with no unit).

Rebased onto current `main` (post-typeless-refactor). One conflict, an import collision in `useCollectionEdit.handlers.test.tsx`, resolved by unioning both imports.

## Display

- **`formatLongDate()`** renders `October 13th, 2023`. Reuses the existing `parseIsoDateParts`, so it stays timezone-safe and tolerates the time suffix `captureDate` arrives with. Unparseable input falls through verbatim rather than blanking, so bad data stays visible.
- **ISO is labelled**: a bare `2200` now reads `2200 ISO`, matching the value-then-unit shape of `1/500 sec` and `38 mm` beside it in the same row.
- **Fullscreen overlay** gains the caption, a film line (stock + format, only when `isFilm`), and a Tags section alongside the existing People/Collections ones. Date and location were already there — the fix for those was purely the formatting.
- **New `ReadOnlyInfoSection`** in the editor: capture date, source filename, dimensions, upload date, content ID. It reads the source content block rather than the edit buffer, so nothing implies these fields are editable. Single-edit only; rows for absent fields are omitted rather than rendering placeholders.
- **`formatFilmFormat()`** maps the `FilmFormat` enum for public surfaces that have no `FilmFormatDTO` list to resolve against — the overlay would otherwise print `MM_35`. Also corrects a stale comment in `Content.ts`: `filmType` carries the *display* name (the backend sends `getDisplayName()`), only `filmFormat` is a raw enum.

## Collection locations

Giving a collection a location already cascaded down to images that had none. That path filtered on `contentType === 'IMAGE'`, so GIF/MP4 blocks were skipped even though they carry `locations` and `updateGif` accepts a `LocationUpdate`. Extracted as `inheritLocationsToContent()` and extended to cover both. Content that already has its own location is still never touched.

## Dirty state

`isUpdateDirty` read *"the payload has any field beyond id"*, which conflates a real edit with a default that `seedUpdateData` fabricated.

`displayMode` is nullable on the backend entity (no `@NotNull`, no `@Builder.Default`) while the seed forces `'CHRONOLOGICAL'`. For a collection stored without one, `buildUpdatePayload` diffs that fabricated default against the null original and emits a `displayMode` key on every render — the collection reads dirty forever, so **Save sits enabled and primary on load** and the exit button never relaxes.

Dirty now means *"the payload I would send differs from the payload a pristine seed would send"*. Fabricated defaults appear on both sides and cancel out. Save semantics are unchanged. It is field-agnostic, so it also covers `visibility` (`@NotNull` today, so safe, but seeded the same way) and anything dropped from the API later.

**Scope correction worth flagging to reviewers.** I first hit this on a pre-typeless branch where it fired through `type`, and I originally described it as affecting *every* collection. On current `main` that instance is already gone — the typeless refactor removed `type`, and `isClient`/`isBlog` are primitive `boolean` on the backend so they are always sent. Re-probing against this base, a fully-populated collection is clean under the old logic; only a null `displayMode` still triggers it. So this is a **narrower live fix plus structural hardening**, not the blanket fix I first claimed.

With it fixed, the exit button can relax: the collection browse bar and the edit sheet now read **Close** until there are unsaved edits, then **Cancel**, matching the metadata sheet's existing convention. The reorder / multi-select / add-content bars keep saying Cancel — there the button abandons an in-progress action rather than closing a form.

## Testing

`tsc` clean, **2787/2787 tests pass**, ESLint + Stylelint clean, all on the rebased base.

Added coverage for `formatLongDate`, `formatFilmFormat`, `resolveDisplayFilmStock`, `ReadOnlyInfoSection`, GIF location inheritance, and both Close/Cancel transitions.

**On fixtures masking this:** the shared `makeCollection` fixture always sets `displayMode` (and previously `type`, and now `isClient`/`isBlog`) — it is more complete than the API. That is precisely why the original label change passed its tests while being wrong in production. The regression test explicitly omits `displayMode`; I confirmed it is non-vacuous by probing the old logic, which yields `['id', 'displayMode']` for that shape.

## Not verified in a browser

The local site redirects to a sign-in gate and the dev server holds port 3000, so I could not exercise this visually. Everything here is covered by tests, but **the rendered result has not been looked at by a human** — worth opening a fullscreen image and the collection manage bar before merging, especially since the dirty-state change affects when Save is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)