### PR TITLE
Filter bar consolidation, photo-size tiers, and layout stability fixes

### DIFF
--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -10,6 +10,16 @@ import styles from './page.module.scss';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * Admin hub: the users/messages panels and the nav tiles, laid out by the shared content pipeline.
+ *
+ * `mobileChunkSize={1}` pins the hub to a single column on touch viewports. Without it the hub
+ * inherits `LAYOUT.mobileSlotWidth`, a row budget calibrated for PHOTOS, and the packer fits
+ * two items per row: the two panels land at ~212px each on a 430px phone, which is too narrow for
+ * a user list (the header controls collapse and every row ellipsizes), and portrait-covered tiles
+ * pair up as well. The pre-pipeline `AdminHubGrid` was explicitly `grid-template-columns: 1fr` on
+ * mobile; this restores that. Desktop is unaffected — the option is read only on the mobile branch.
+ */
 export default async function AdminHubPage() {
   const [tiles, ssrViewport] = await Promise.all([
     getAdminHomeTiles().catch(() => []),
@@ -28,6 +38,7 @@ export default async function AdminHubPage() {
         content={content}
         priorityBlockIndex={0}
         enableFullScreenView={false}
+        mobileChunkSize={1}
         serverContentWidth={ssrViewport?.contentWidth}
         serverViewportHeight={ssrViewport?.viewportHeight}
         serverIsMobile={ssrViewport?.isMobile}

--- a/app/(admin)/admin/roles/roles.module.scss
+++ b/app/(admin)/admin/roles/roles.module.scss
@@ -90,7 +90,7 @@
 
 .empty {
   font-size: var(--text-sm);
-  color: var(--color-fg-muted, var(--color-fg));
+  color: var(--color-on-surface-muted);
   opacity: 0.75;
 }
 

--- a/app/(admin)/admin/users/[id]/page.module.scss
+++ b/app/(admin)/admin/users/[id]/page.module.scss
@@ -73,7 +73,7 @@
   letter-spacing: 0.04em;
   padding: 2px var(--space-2);
   border-radius: var(--radius-1);
-  background: var(--color-surface-alt, var(--color-surface));
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   color: var(--color-on-surface-muted);
 }

--- a/app/components/AdminPanel/AdminPanel.module.scss
+++ b/app/components/AdminPanel/AdminPanel.module.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  background: var(--color-surface-alt, var(--color-surface));
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-1);
 }

--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -392,6 +392,10 @@ export default function CollectionContentRenderer({
                 density={collectionFilter.density}
                 densityMax={collectionFilter.densityMax}
                 onDensityChange={collectionFilter.onDensityChange}
+                densityVariant={collectionFilter.densityVariant}
+                densityTiers={collectionFilter.densityTiers}
+                activeDensityTier={collectionFilter.activeDensityTier}
+                onDensityTierSelect={collectionFilter.onDensityTierSelect}
               />
             </div>
           )}

--- a/app/components/Content/Component.tsx
+++ b/app/components/Content/Component.tsx
@@ -58,6 +58,11 @@ export interface ContentComponentProps {
    * filter toolbar and/or the download row into it. See `ProcessContentOptions.forceHeaderRail`.
    */
   forceHeaderRail?: boolean;
+  /**
+   * Mean width-cost of the collection's UNFILTERED content, so an active filter does not resize
+   * every photo. See `ProcessContentOptions.widthCostBaseline`.
+   */
+  widthCostBaseline?: number;
   /** Reorder mode props */
   isReorderMode?: boolean;
   reorderMoves?: ReorderMove[];
@@ -106,6 +111,7 @@ export default function Component({
   mobileChunkSize,
   collectionData,
   forceHeaderRail = false,
+  widthCostBaseline,
   isReorderMode = false,
   reorderMoves,
   pickedUpImageId,
@@ -165,9 +171,18 @@ export default function Component({
         viewport,
         chunkSize,
         mobileChunkSize,
-        forceHeaderRail
+        forceHeaderRail,
+        widthCostBaseline
       ),
-    [displayContent, collectionData, viewport, chunkSize, mobileChunkSize, forceHeaderRail]
+    [
+      displayContent,
+      collectionData,
+      viewport,
+      chunkSize,
+      mobileChunkSize,
+      forceHeaderRail,
+      widthCostBaseline,
+    ]
   );
 
   // Must be computed before the early returns to satisfy the Rules of Hooks.

--- a/app/components/Content/ContentBlockWithFullScreen.tsx
+++ b/app/components/Content/ContentBlockWithFullScreen.tsx
@@ -34,6 +34,8 @@ interface ContentBlockWithFullScreenProps {
   collectionData?: CollectionModel;
   /** Build the header metadata rail even with no metadata text; see {@link Component}. */
   forceHeaderRail?: boolean;
+  /** Mean width-cost of the UNFILTERED content, so filtering does not resize every photo. */
+  widthCostBaseline?: number;
   isSelectingCoverImage?: boolean;
   currentCoverImageId?: number;
   onImageClick?: (imageId: number) => void;
@@ -65,6 +67,7 @@ export default function ContentBlockWithFullScreen({
   collectionSlug,
   collectionData,
   forceHeaderRail,
+  widthCostBaseline,
   isSelectingCoverImage,
   currentCoverImageId,
   onImageClick,
@@ -93,6 +96,7 @@ export default function ContentBlockWithFullScreen({
     zoomTargetRef,
     isZoomed,
     immersive,
+    toggleImmersive,
     hideImage,
     isSwiping,
     showMetadata,
@@ -208,6 +212,7 @@ export default function ContentBlockWithFullScreen({
         mobileChunkSize={mobileChunkSize}
         collectionData={collectionData}
         forceHeaderRail={forceHeaderRail}
+        widthCostBaseline={widthCostBaseline}
         isReorderMode={isReorderMode}
         reorderMoves={reorderMoves}
         pickedUpImageId={pickedUpImageId}
@@ -247,6 +252,7 @@ export default function ContentBlockWithFullScreen({
           zoomTargetRef={zoomTargetRef}
           isZoomed={isZoomed}
           immersive={immersive}
+          toggleImmersive={toggleImmersive}
           hideImage={hideImage}
           isSwiping={isSwiping}
           showMetadata={showMetadata}

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -351,8 +351,8 @@
 }
 
 .selectStarActive .selectStarIcon {
-  fill: var(--color-star, #f5c518);
-  stroke: var(--color-star, #f5c518);
+  fill: var(--color-star);
+  stroke: var(--color-star);
 }
 
 /* Drag state styles */

--- a/app/components/Content/SaveHeart.module.scss
+++ b/app/components/Content/SaveHeart.module.scss
@@ -50,8 +50,8 @@
 }
 
 .saveHeartActive .saveHeartIcon {
-  fill: var(--color-heart, #e0245e);
-  stroke: var(--color-heart, #e0245e);
+  fill: var(--color-heart);
+  stroke: var(--color-heart);
 }
 
 /* Hover-capable devices: hide the unsaved heart at rest and reveal it on wrapper hover or keyboard

--- a/app/components/Content/componentUtils.ts
+++ b/app/components/Content/componentUtils.ts
@@ -99,7 +99,8 @@ export function buildContentRows(
   viewport: EffectiveViewport,
   chunkSize: number,
   mobileChunkSize?: number,
-  forceHeaderRail?: boolean
+  forceHeaderRail?: boolean,
+  widthCostBaseline?: number
 ): { rows: RowWithPatternAndSizes[]; layoutError: string | null } {
   if (!viewport.contentWidth) return { rows: [], layoutError: null };
   if ((!content || content.length === 0) && !collectionData) return { rows: [], layoutError: null };
@@ -117,6 +118,7 @@ export function buildContentRows(
       targetAR,
       mobileChunkSize,
       forceHeaderRail,
+      widthCostBaseline,
     });
     return { rows, layoutError: null };
   } catch (error) {

--- a/app/components/ContentCollection/CollectionFilterContext.tsx
+++ b/app/components/ContentCollection/CollectionFilterContext.tsx
@@ -59,6 +59,18 @@ interface CollectionFilterContextValue {
   densityMax: number;
   /** Receives a value in the active viewport's scale; see {@link density}. */
   onDensityChange: (value: number) => void;
+  /** `slider` gives edit mode the fine 1-`densityMax` control; visitors get the three tiers. */
+  densityVariant: 'tiers' | 'slider';
+  /** Photo-size presets on the CANONICAL desktop scale — NOT the viewport scale {@link density} uses. */
+  densityTiers: readonly { key: string; label: string; value: number }[];
+  /** Key of the tier nearest {@link density}. Highlight only — never written back to density. */
+  activeDensityTier: string;
+  /**
+   * Receives a canonical desktop-scale value from {@link densityTiers}, bypassing the viewport
+   * mapping {@link onDensityChange} applies. Halving/doubling is lossy at the Small tier, so a
+   * tier must not round-trip through the mobile scale.
+   */
+  onDensityTierSelect: (value: number) => void;
 }
 
 const CollectionFilterContext = createContext<CollectionFilterContextValue | null>(null);

--- a/app/components/ContentCollection/CollectionPageClient.tsx
+++ b/app/components/ContentCollection/CollectionPageClient.tsx
@@ -7,7 +7,13 @@ import { MeProvider } from '@/app/components/auth/MeProvider';
 import ContentBlockWithFullScreen from '@/app/components/Content/ContentBlockWithFullScreen';
 import { SavesProvider } from '@/app/components/Personal/SavesContext';
 import { type ToolbarSection } from '@/app/components/ui/FilterToolbar/FilterToolbar';
-import { fromMobileDensity, LAYOUT, toMobileDensity } from '@/app/constants';
+import {
+  DENSITY_TIERS,
+  fromMobileDensity,
+  LAYOUT,
+  nearestDensityTier,
+  toMobileDensity,
+} from '@/app/constants';
 import { useFilterUrlState } from '@/app/hooks/useFilterUrlState';
 import { useViewport } from '@/app/hooks/useViewport';
 import { type MeResponse } from '@/app/types/Auth';
@@ -32,6 +38,7 @@ import {
   mergeDateSortedImages,
 } from '@/app/utils/contentFilter';
 import { processContentBlocks } from '@/app/utils/contentLayout';
+import { getMeanWidthCost } from '@/app/utils/contentRatingUtils';
 import { isContentCollection, isGifContent } from '@/app/utils/contentTypeGuards';
 import {
   canDownloadCollection,
@@ -161,6 +168,25 @@ export default function CollectionPageClient({
     [isMobile]
   );
 
+  /**
+   * Photo-size presets on the CANONICAL desktop scale, which is the scale `density` is stored in.
+   *
+   * Deliberately not viewport-scaled like the slider: halving and doubling is lossy at the Small
+   * tier (desktop 7 -> mobile 4 -> back to 8), so routing a tier through
+   * {@link fromMobileDensity} would land a mobile visitor on a value no tier defines. Tier
+   * selections therefore bypass {@link handleDensityChange} and write their canonical value.
+   */
+  const densityTiers = useMemo(
+    () => DENSITY_TIERS.map(tier => ({ key: tier.key, label: tier.label, value: tier.desktop })),
+    []
+  );
+
+  const handleDensityTierSelect = useCallback((value: number) => {
+    setDensity(clamp(value, LAYOUT.minDensity, LAYOUT.maxDensityDesktop));
+  }, []);
+
+  const activeDensityTier = nearestDensityTier(density, false);
+
   const isClientGallery = collection.isClient === true;
 
   // A CLIENT grant on a collection whose payload carries no kind booleans is the signature of a
@@ -256,6 +282,16 @@ export default function CollectionPageClient({
 
   const filteredImages = useMemo(() => filteredContent.filter(isImageContent), [filteredContent]);
 
+  /**
+   * Photos-per-row anchor, measured on the UNFILTERED content.
+   *
+   * Width-cost scales with rating, so without this a filter that shifts the rating mix silently
+   * resized every photo: "Highly Rated" alone took a collection from ~5 per row to ~3, while the
+   * photo-size control still read Medium. The layout divides the filtered mean by this to cancel
+   * that shift; with no filter active the two are equal, so the layout is unchanged.
+   */
+  const widthCostBaseline = useMemo(() => getMeanWidthCost(allContent), [allContent]);
+
   // `visibility.highlyRated` is already false below two images (canFilter), so no extra
   // collection-count suppression is needed — see D7.
   const showHighlyRated = visibility.highlyRated;
@@ -265,34 +301,28 @@ export default function CollectionPageClient({
     if (!hasActiveFilters) return null;
     const dims = extractCollectionFilterOptions(filteredImages, allCollections);
 
-    // `dates` is OR-combined and single-valued per image, unlike every other dimension here
-    // (AND-combined). Deriving its availability from `filteredImages` -- which already reflects
-    // the active `dates` selection -- collapses every other day to "unavailable" the instant one
-    // day is selected. Re-derive it from a pass with `dates` omitted from criteria so days never
-    // grey each other out, while a day with no photos under another active filter (e.g. camera)
-    // still greys out correctly.
-    const { dates: _omitted, ...criteriaWithoutDates } = criteria;
-    const contentForDateAvailability = applyCollectionFilters(
-      allContent,
-      allImages,
-      criteriaWithoutDates
-    );
-    const imagesForDateAvailability = contentForDateAvailability.filter(isImageContent);
-    const gifsForDateAvailability = contentForDateAvailability.filter(
-      (item): item is ContentGifModel => isGifContent(item) && Boolean(item.captureDate)
-    );
-    const dateAvailability = extractCollectionFilterOptions(
-      imagesForDateAvailability,
-      allCollections,
-      gifsForDateAvailability
-    );
+    // `dates` and `lenses` are single-valued per image, so each is SELF-EXCLUSIVE: deriving its
+    // availability from `filteredImages` -- which already reflects that dimension's own active
+    // selection -- collapses every other option to "unavailable" the instant one is picked, and a
+    // disabled chip cannot be switched to. Re-derive each from a pass with its OWN key omitted, so
+    // its options never grey each other out while an option ruled out by a DIFFERENT active filter
+    // (e.g. camera) still greys out correctly. Both are single-choice in the toolbar
+    // (`EXCLUSIVE_FILTER_KEYS`), which is what makes switching the only reachable move.
+    const availabilityWithout = (key: 'dates' | 'lenses'): CollectionFilterDimensions => {
+      const { [key]: _omitted, ...selfExcluded } = criteria;
+      const content = applyCollectionFilters(allContent, allImages, selfExcluded);
+      const gifs = content.filter(
+        (item): item is ContentGifModel => isGifContent(item) && Boolean(item.captureDate)
+      );
+      return extractCollectionFilterOptions(content.filter(isImageContent), allCollections, gifs);
+    };
 
     return {
       people: dims.people.values,
       cameras: dims.cameras.values,
-      lenses: dims.lenses.values,
+      lenses: availabilityWithout('lenses').lenses.values,
       locations: dims.locations.values,
-      dates: dateAvailability.dates.values,
+      dates: availabilityWithout('dates').dates.values,
     };
   }, [hasActiveFilters, filteredImages, allCollections, criteria, allContent, allImages]);
 
@@ -362,6 +392,12 @@ export default function CollectionPageClient({
       density: displayDensity,
       densityMax,
       onDensityChange: handleDensityChange,
+      // Curators keep the fine 1-10 control so they can still land on an off-tier value; visitors
+      // get the three photo-size presets.
+      densityVariant: editMode ? ('slider' as const) : ('tiers' as const),
+      densityTiers,
+      activeDensityTier,
+      onDensityTierSelect: handleDensityTierSelect,
     }),
     [
       filterState,
@@ -374,6 +410,10 @@ export default function CollectionPageClient({
       displayDensity,
       densityMax,
       handleDensityChange,
+      editMode,
+      densityTiers,
+      activeDensityTier,
+      handleDensityTierSelect,
     ]
   );
 
@@ -405,6 +445,7 @@ export default function CollectionPageClient({
       // text of its own. Without this, `/user` (no date, no locations, no siblings) built a
       // cover-only header and silently dropped the bar.
       forceHeaderRail={hasOptions || canDownload}
+      widthCostBaseline={widthCostBaseline}
       serverContentWidth={serverContentWidth}
       serverViewportHeight={serverViewportHeight}
       serverIsMobile={serverIsMobile}

--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.module.scss
@@ -19,7 +19,7 @@
 
 .empty {
   font-size: var(--text-sm);
-  color: var(--color-fg-muted, var(--color-fg));
+  color: var(--color-on-surface-muted);
   opacity: 0.75;
 }
 
@@ -45,7 +45,7 @@
   padding: 2px var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-1);
-  color: var(--color-fg-muted, var(--color-fg));
+  color: var(--color-on-surface-muted);
 }
 
 .inheritedBadge {

--- a/app/components/ContentCollection/edit/sections/StructureTab.module.scss
+++ b/app/components/ContentCollection/edit/sections/StructureTab.module.scss
@@ -54,7 +54,7 @@
   flex-shrink: 0;
 
   &:hover:not(:disabled) {
-    background: var(--color-surface-overlay);
+    background: var(--color-surface-sunken);
   }
 
   &:disabled {

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -17,6 +17,7 @@ import { IMAGE } from '@/app/constants';
 import styles from '@/app/styles/fullscreen-image.module.scss';
 import { type CollectionModel } from '@/app/types/Collection';
 import type { ViewableContent } from '@/app/types/Content';
+import { extractAltText } from '@/app/utils/contentRendererUtils';
 import { formatLongDate } from '@/app/utils/formatDateRange';
 import { canDownloadCollection } from '@/app/utils/galleryAccess';
 
@@ -45,6 +46,8 @@ interface FullScreenModalProps {
   isZoomed: boolean;
   /** Immersive mode: when true, hide all chrome (controls + metadata) for an image-only view. */
   immersive?: boolean;
+  /** Flips immersive mode — wired to a click on the framed photo (the touch tap does the same). */
+  toggleImmersive?: () => void;
   hideImage: (e?: MouseEvent) => void;
   isSwiping: RefObject<boolean>;
   showMetadata: boolean;
@@ -64,6 +67,7 @@ export function FullScreenModal({
   zoomTargetRef,
   isZoomed,
   immersive = false,
+  toggleImmersive,
   hideImage,
   isSwiping,
   showMetadata,
@@ -124,19 +128,40 @@ export function FullScreenModal({
   const hasPrevious = fullScreenState.currentIndex > 0;
   const hasNext = fullScreenState.currentIndex < fullScreenState.images.length - 1;
 
-  const handleOverlayClick = () => {
-    // Don't dismiss on the tap that ends a swipe/pinch/pan, nor while zoomed in
-    // (a tap there is the user interacting with the zoomed photo, not closing it).
-    if (!isSwiping.current && !isZoomed) {
-      hideImage();
+  /**
+   * Where a pointer lands decides the action, mirroring the touch tap split in useFullScreenImage:
+   * the framed photo toggles immersive mode, the black letterbox around it dismisses the viewer.
+   * Without the photo branch, a plain desktop click on the image closed the viewer — the touch
+   * guards below are gesture state and never fire for a mouse.
+   *
+   * Skipped on the click that ends a swipe/pinch/pan (which also swallows the synthetic click a
+   * touch tap produces, so a tap toggles once) and while zoomed, where a click belongs to the photo.
+   */
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (isSwiping.current || isZoomed) return;
+
+    const target = event.target;
+    if (target instanceof Element && target.closest(`.${styles.imageWrapper}`)) {
+      toggleImmersive?.();
+      return;
     }
+
+    hideImage();
   };
+
+  const accessibleName = currentImage.title
+    ? `Fullscreen image: ${currentImage.title}`
+    : 'Fullscreen image';
 
   const modalContent = (
     <div
       ref={modalRef}
       className={`${styles.imageFullScreenWrapper} ${immersive ? styles.immersive : ''}`}
     >
+      <h2 id="fullscreen-title" className={styles.srOnly}>
+        {accessibleName}
+      </h2>
+
       <div className={styles.overlayContainer} onClick={handleOverlayClick}>
         <div
           className={`${styles.imageWrapper} ${currentImageLoaded ? styles.imageWrapperLoaded : ''}`}
@@ -162,7 +187,13 @@ export function FullScreenModal({
               <Image
                 key={currentImage.id}
                 src={currentImage.imageUrl}
-                alt={currentImage.title || currentImage.caption || 'Full screen image'}
+                alt={extractAltText(
+                  currentImage.alt,
+                  currentImage.title,
+                  currentImage.caption,
+                  undefined,
+                  'Full screen image'
+                )}
                 width={currentImage.imageWidth || IMAGE.defaultWidth}
                 height={currentImage.imageHeight || IMAGE.defaultHeight}
                 className={`${styles.fullScreenImage} ${currentImageLoaded ? styles.fullScreenImageLoaded : ''}`}
@@ -187,9 +218,7 @@ export function FullScreenModal({
               {showMetadata && (
                 <div className={styles.metadataContent}>
                   {currentImage.title && (
-                    <div id="fullscreen-title" className={styles.metadataTitle}>
-                      {currentImage.title}
-                    </div>
+                    <div className={styles.metadataTitle}>{currentImage.title}</div>
                   )}
                   {currentImage.caption && (
                     <div className={styles.metadataCaption}>{currentImage.caption}</div>
@@ -370,12 +399,7 @@ export function FullScreenModal({
   );
 
   return (
-    <Modal
-      open
-      onClose={hideImage}
-      variant="fullscreen"
-      labelledBy={currentImage.title ? 'fullscreen-title' : undefined}
-    >
+    <Modal open onClose={hideImage} variant="fullscreen" labelledBy="fullscreen-title">
       {modalContent}
     </Modal>
   );

--- a/app/components/InviteLinkResult/InviteLinkResult.module.scss
+++ b/app/components/InviteLinkResult/InviteLinkResult.module.scss
@@ -16,7 +16,7 @@
   font-size: var(--text-sm);
   font-family: var(--font-mono, monospace);
   word-break: break-all;
-  background: var(--color-surface-alt, var(--color-surface));
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-1);
   padding: var(--space-3) var(--space-4);

--- a/app/components/Personal/FollowButton.module.scss
+++ b/app/components/Personal/FollowButton.module.scss
@@ -44,6 +44,6 @@
 }
 
 .followButtonActive {
-  border-color: var(--color-heart, #e0245e);
-  background-color: var(--color-heart, #e0245e);
+  border-color: var(--color-heart);
+  background-color: var(--color-heart);
 }

--- a/app/components/UserForm/UserForm.module.scss
+++ b/app/components/UserForm/UserForm.module.scss
@@ -50,7 +50,7 @@
 .rolesEmpty {
   margin: 0;
   font-size: var(--text-sm);
-  color: var(--color-fg-muted);
+  color: var(--color-on-surface-muted);
 }
 
 .roleRow {

--- a/app/components/ui/FilterToolbar/DensityTierControl.module.scss
+++ b/app/components/ui/FilterToolbar/DensityTierControl.module.scss
@@ -1,0 +1,96 @@
+.group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* Sized from the same tokens as FilterChip so a segment's box is identical to a chip's: same
+   vertical padding, same font metrics, same border and radius. The bar's row height is therefore
+   set by the chips, exactly as it was before this control existed. Horizontal padding is one step
+   in (--space-2) because the glyph is a fixed square, not text of varying length. */
+.segment {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1) var(--space-2);
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  color: var(--color-fg);
+  background-color: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  opacity: 0.7;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    opacity var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    border-color: var(--color-fg);
+    opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+
+  /* Touch-target padding on coarse pointers only, and via an overlay rather than the box itself,
+     so meeting the 44px minimum never changes the toolbar's height. */
+  @media (pointer: coarse) {
+    &::after {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 100%;
+      min-width: 44px;
+      height: 100%;
+      min-height: 44px;
+      content: '';
+      transform: translate(-50%, -50%);
+    }
+  }
+}
+
+/* Same fg/bg inversion as FilterChip's .active — the one treatment in this bar that clears AA. */
+.segmentActive {
+  color: var(--color-bg);
+  background-color: var(--color-fg);
+  border-color: var(--color-fg);
+  opacity: 1;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  .cell {
+    background-color: var(--color-bg);
+  }
+}
+
+/* Square grid whose column count follows the cell count: 1 cell fills the box, 4 form a 2x2, 9 a
+   3x3. The outer box is a fixed 15px in every case, so segments never change width between tiers.
+   Driven by `:has()` rather than a modifier class so the markup stays a plain list of cells. */
+.glyph {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  width: 15px;
+  height: 15px;
+
+  &:has(.cell:only-child) {
+    grid-template-columns: 1fr;
+  }
+
+  &:has(.cell:first-child:nth-last-child(4)) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.cell {
+  background-color: var(--color-fg);
+  border-radius: 1px;
+}

--- a/app/components/ui/FilterToolbar/DensityTierControl.tsx
+++ b/app/components/ui/FilterToolbar/DensityTierControl.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import styles from './DensityTierControl.module.scss';
+
+/** One selectable photo-size preset, already resolved to the active viewport's density scale. */
+export interface DensityTier {
+  key: string;
+  /** Full accessible name, e.g. "Large photos". Never the raw density number. */
+  label: string;
+  /** Density value on the active viewport's scale. */
+  value: number;
+}
+
+interface DensityTierControlProps {
+  tiers: readonly DensityTier[];
+  /** Key of the tier nearest the current density. Highlighted, but never written back. */
+  activeKey: string;
+  onSelect: (value: number) => void;
+}
+
+/**
+ * Grid glyphs standing in for each tier, ordered large -> small. Purely decorative: the accessible
+ * name comes from the tier's own label, so these are hidden from assistive tech. A cell count that
+ * grows as photos shrink is the whole affordance — the raw density number is meaningless to a
+ * visitor and runs backwards from what they see.
+ */
+const TIER_GLYPH_CELLS: Record<string, number> = { large: 1, medium: 4, small: 9 };
+
+/** Fallback for a tier key with no glyph mapping, so an added tier degrades rather than vanishing. */
+const DEFAULT_GLYPH_CELLS = 4;
+
+/**
+ * Segmented photo-size picker: the visitor-facing replacement for the raw 1-10 density slider.
+ *
+ * Rendered as a radiogroup rather than a set of toggle buttons because the options are mutually
+ * exclusive and exactly one is always current — the same reason page sections are links, not
+ * pressed chips. The active segment reuses FilterChip's fg/bg inversion, the one treatment in this
+ * bar with adequate contrast.
+ */
+export function DensityTierControl({ tiers, activeKey, onSelect }: DensityTierControlProps) {
+  return (
+    <div className={styles.group} role="radiogroup" aria-label="Photo size">
+      {tiers.map(tier => {
+        const isActive = tier.key === activeKey;
+        return (
+          <button
+            key={tier.key}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={tier.label}
+            className={`${styles.segment} ${isActive ? styles.segmentActive : ''}`}
+            onClick={() => onSelect(tier.value)}
+          >
+            <span className={styles.glyph} aria-hidden="true">
+              {Array.from({ length: TIER_GLYPH_CELLS[tier.key] ?? DEFAULT_GLYPH_CELLS }, (_, i) => (
+                <span key={i} className={styles.cell} />
+              ))}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/ui/FilterToolbar/FilterToolbar.module.scss
+++ b/app/components/ui/FilterToolbar/FilterToolbar.module.scss
@@ -1,7 +1,11 @@
+/* Two slots on one non-wrapping row: the filter controls, which wrap internally, and the photo-size
+   control, which is pinned top-right. A single flat wrapping container let the size control land on
+   an arbitrary line, so it read as belonging to whichever filters happened to wrap beside it. */
 .toolbar {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-wrap: nowrap;
+  /* Pins the size control to the FIRST row rather than centring it against a tall wrapped stack. */
+  align-items: flex-start;
   /* Same token as the Download row's .buttonRow, so the two stacked rows space their
      controls identically. Was a hardcoded 4px, which is what --space-1 resolves to. */
   gap: var(--space-1);
@@ -13,12 +17,35 @@
   }
 }
 
+/* The wrapping half: every filter control. `min-width: 0` lets it shrink and wrap internally
+   instead of forcing the non-wrapping outer row to overflow. */
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* The pinned half. Never shrinks and never wraps, so overflowing filters wrap BELOW it. Carries no
+   height of its own: the control inside is built from the same tokens as a chip, so the row height
+   stays governed by the chips rather than by whatever sits in this slot. */
+.densitySlot {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-left: auto;
+}
+
 /* Divides the mutually-exclusive section chips from the facet controls that filter WITHIN the
    selected section. Margin rather than gap so it reads as a rule between two groups, not as a
-   third item in the row. */
+   third item in the row. Fixed height rather than `align-self: stretch`: in a wrapping container
+   stretch resolves against the TALLEST line, so the rule grew to span every wrapped row. */
 .separator {
-  align-self: stretch;
+  align-self: center;
   width: 1px;
+  height: 1.25em;
   margin: 4px var(--space-1);
   background-color: var(--color-border);
 }
@@ -87,11 +114,13 @@
   box-shadow: 0 4px 12px var(--color-overlay-soft);
 }
 
+/* Deliberately NO `margin-left: auto`: that resolves per flex LINE, so once the controls wrapped
+   the × was flung to the right edge of an arbitrary row, landing beside the photo-size control and
+   reading as though it reset that. It flows inline after the last chip instead. */
 .reset {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: auto;
   padding: 2px 8px;
   font: inherit;
   font-size: var(--text-sm);

--- a/app/components/ui/FilterToolbar/FilterToolbar.tsx
+++ b/app/components/ui/FilterToolbar/FilterToolbar.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { FilterChip } from '@/app/components/ui/FilterChip/FilterChip';
+import {
+  type DensityTier,
+  DensityTierControl,
+} from '@/app/components/ui/FilterToolbar/DensityTierControl';
 import { useClickOutside } from '@/app/hooks/useClickOutside';
 import {
   ARRAY_FILTER_KEYS,
@@ -80,11 +84,26 @@ export interface FilterToolbarProps {
   dateTwoState?: boolean;
   showHighlyRated?: boolean;
   showFilm?: boolean;
-  /** When provided, renders the row-density slider (min 1, max {@link densityMax}). */
+  /** When provided, renders the photo-size control (density min 1, max {@link densityMax}). */
   density?: number;
-  /** Upper bound of the density slider. Defaults to 10 (desktop scale). */
+  /** Upper bound of the fine slider. Defaults to 10 (desktop scale). */
   densityMax?: number;
   onDensityChange?: (value: number) => void;
+  /**
+   * Which density affordance to render. Visitors get `tiers` (three photo-size presets); edit mode
+   * gets `slider`, the fine 1-{@link densityMax} control, so a curator can still land on an
+   * off-tier value. Defaults to `tiers`.
+   */
+  densityVariant?: 'tiers' | 'slider';
+  /** Tier presets, already resolved to the same scale as {@link density}. Required for `tiers`. */
+  densityTiers?: readonly DensityTier[];
+  /** Key of the tier nearest {@link density}; drives which segment renders active. */
+  activeDensityTier?: string;
+  /**
+   * Receives a tier's value verbatim. Separate from {@link onDensityChange} because tier values are
+   * canonical desktop-scale and must not go through that handler's viewport mapping.
+   */
+  onDensityTierSelect?: (value: number) => void;
 }
 
 /**
@@ -128,10 +147,24 @@ export function FilterToolbar({
   density,
   densityMax = 10,
   onDensityChange,
+  densityVariant = 'tiers',
+  densityTiers,
+  activeDensityTier,
+  onDensityTierSelect,
 }: FilterToolbarProps) {
   const [openDropdown, setOpenDropdown] = useState<ArrayFilterKey | null>(null);
   const barRef = useRef<HTMLDivElement>(null);
-  const closeAll = useCallback(() => setOpenDropdown(null), []);
+  /**
+   * The trigger that opened the current panel. Selecting an option unmounts the focused chip, which
+   * would otherwise drop focus to `document.body` on every single selection; restoring it here
+   * keeps a keyboard user in the bar. Same on close-by-Escape and click-outside.
+   */
+  const triggerRefs = useRef<Partial<Record<ArrayFilterKey, HTMLButtonElement | null>>>({});
+
+  const closeAll = useCallback(() => {
+    if (openDropdown !== null) triggerRefs.current[openDropdown]?.focus();
+    setOpenDropdown(null);
+  }, [openDropdown]);
   useClickOutside(barRef, openDropdown !== null, closeAll);
 
   const toggleOpen = (key: ArrayFilterKey) => setOpenDropdown(prev => (prev === key ? null : key));
@@ -162,141 +195,158 @@ export function FilterToolbar({
 
   return (
     <div ref={barRef} className={styles.toolbar}>
-      {sections && sections.length > 0 && (
-        <>
-          {sections.map(section => (
-            <FilterChip
-              key={`section-${section.key}`}
-              label={section.label}
-              count={section.count}
-              active={section.key === activeSectionKey}
-              href={section.href}
-            />
-          ))}
-          <span className={styles.separator} aria-hidden="true" />
-        </>
-      )}
+      <div className={styles.controls}>
+        {sections && sections.length > 0 && (
+          <>
+            {sections.map(section => (
+              <FilterChip
+                key={`section-${section.key}`}
+                label={section.label}
+                count={section.count}
+                active={section.key === activeSectionKey}
+                href={section.href}
+              />
+            ))}
+            <span className={styles.separator} aria-hidden="true" />
+          </>
+        )}
 
-      {showDateSort && (
-        <FilterChip
-          label="Order"
-          trailing={ORDER_GLYPHS[filterState.dateSortDirection]}
-          // In two-state mode the date sort is always engaged, so the chip stays active.
-          active={dateTwoState || filterState.dateSortDirection !== 'off'}
-          onToggle={() =>
-            onFilterChange({
-              dateSortDirection: dateTwoState
-                ? cycleDateSortTwoState(filterState.dateSortDirection)
-                : cycleDateSort(filterState.dateSortDirection),
-            })
-          }
-        />
-      )}
-
-      {showHighlyRated && (
-        <FilterChip
-          label="Highly Rated"
-          count={counts?.highlyRated}
-          active={filterState.highlyRatedOnly}
-          onToggle={() => onFilterChange({ highlyRatedOnly: !filterState.highlyRatedOnly })}
-        />
-      )}
-
-      {showFilm && (
-        <FilterChip
-          label={filterState.filmFilter === 'digital' ? 'Digital' : 'Film'}
-          count={filmCount}
-          tone={filterState.filmFilter === 'digital' ? 'digital' : 'film'}
-          active={filterState.filmFilter !== 'off'}
-          onToggle={cycleFilm}
-        />
-      )}
-
-      {flatDates?.options.map(day => {
-        const isSelected = filterState.selectedDates.includes(day);
-        const available = isSelected || isOptionAvailable(filteredAvailable, 'selectedDates', day);
-        return (
+        {showDateSort && (
           <FilterChip
-            key={`date-${day}`}
-            label={flatDates.optionLabels?.[day] ?? day}
-            active={isSelected}
-            state={available ? 'available' : 'unavailable'}
-            onToggle={() => toggleArrayFilter(filterState, onFilterChange, 'selectedDates', day)}
+            label="Order"
+            trailing={ORDER_GLYPHS[filterState.dateSortDirection]}
+            // In two-state mode the date sort is always engaged, so the chip stays active.
+            active={dateTwoState || filterState.dateSortDirection !== 'off'}
+            onToggle={() =>
+              onFilterChange({
+                dateSortDirection: dateTwoState
+                  ? cycleDateSortTwoState(filterState.dateSortDirection)
+                  : cycleDateSort(filterState.dateSortDirection),
+              })
+            }
           />
-        );
-      })}
+        )}
 
-      {ARRAY_FILTER_KEYS.map(key => {
-        if (key === 'selectedDates' && flatDates) return null;
-        const dim = dimensions[key];
-        if (!dim || dim.options.length === 0) return null;
-        const selected = filterState[key] as readonly string[];
-        const isOpen = openDropdown === key;
-        return (
-          <div key={key} className={styles.dropdown}>
-            <button
-              type="button"
-              aria-haspopup="true"
-              aria-expanded={isOpen}
-              className={`${styles.dropdownTrigger} ${selected.length > 0 ? styles.dropdownTriggerActive : ''}`}
-              onClick={() => toggleOpen(key)}
-            >
-              {dim.label}
-              <span className={styles.chevron} aria-hidden="true">
-                {isOpen ? '▴' : '▾'}
-              </span>
-            </button>
-            {isOpen && (
-              <div className={styles.panel}>
-                {dim.options.map(option => {
-                  const isSelected = selected.includes(option);
-                  const available = isSelected || isOptionAvailable(filteredAvailable, key, option);
-                  return (
-                    <FilterChip
-                      key={`${key}-${option}`}
-                      label={dim.optionLabels?.[option] ?? option}
-                      count={dim.counts?.[option]}
-                      active={isSelected}
-                      state={available ? 'available' : 'unavailable'}
-                      onToggle={() => {
-                        toggleArrayFilter(filterState, onFilterChange, key, option);
-                        closeAll();
-                      }}
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        );
-      })}
+        {showHighlyRated && (
+          <FilterChip
+            label="Highly Rated"
+            count={counts?.highlyRated}
+            active={filterState.highlyRatedOnly}
+            onToggle={() => onFilterChange({ highlyRatedOnly: !filterState.highlyRatedOnly })}
+          />
+        )}
 
-      <button
-        type="button"
-        className={`${styles.reset} ${hasActiveFilters ? '' : styles.resetInactive}`}
-        onClick={resetAll}
-        disabled={!hasActiveFilters}
-        aria-label="Reset all filters"
-      >
-        ×
-      </button>
+        {showFilm && (
+          <FilterChip
+            label={filterState.filmFilter === 'digital' ? 'Digital' : 'Film'}
+            count={filmCount}
+            tone={filterState.filmFilter === 'digital' ? 'digital' : 'film'}
+            active={filterState.filmFilter !== 'off'}
+            onToggle={cycleFilm}
+          />
+        )}
+
+        {flatDates?.options.map(day => {
+          const isSelected = filterState.selectedDates.includes(day);
+          const available =
+            isSelected || isOptionAvailable(filteredAvailable, 'selectedDates', day);
+          return (
+            <FilterChip
+              key={`date-${day}`}
+              label={flatDates.optionLabels?.[day] ?? day}
+              active={isSelected}
+              state={available ? 'available' : 'unavailable'}
+              onToggle={() => toggleArrayFilter(filterState, onFilterChange, 'selectedDates', day)}
+            />
+          );
+        })}
+
+        {ARRAY_FILTER_KEYS.map(key => {
+          if (key === 'selectedDates' && flatDates) return null;
+          const dim = dimensions[key];
+          if (!dim || dim.options.length === 0) return null;
+          const selected = filterState[key] as readonly string[];
+          const isOpen = openDropdown === key;
+          return (
+            <div key={key} className={styles.dropdown}>
+              <button
+                ref={node => {
+                  triggerRefs.current[key] = node;
+                }}
+                type="button"
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+                className={`${styles.dropdownTrigger} ${selected.length > 0 ? styles.dropdownTriggerActive : ''}`}
+                onClick={() => toggleOpen(key)}
+              >
+                {dim.label}
+                <span className={styles.chevron} aria-hidden="true">
+                  {isOpen ? '▴' : '▾'}
+                </span>
+              </button>
+              {isOpen && (
+                <div className={styles.panel}>
+                  {dim.options.map(option => {
+                    const isSelected = selected.includes(option);
+                    const available =
+                      isSelected || isOptionAvailable(filteredAvailable, key, option);
+                    return (
+                      <FilterChip
+                        key={`${key}-${option}`}
+                        label={dim.optionLabels?.[option] ?? option}
+                        count={dim.counts?.[option]}
+                        active={isSelected}
+                        state={available ? 'available' : 'unavailable'}
+                        onToggle={() => {
+                          toggleArrayFilter(filterState, onFilterChange, key, option);
+                          closeAll();
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        <button
+          type="button"
+          className={`${styles.reset} ${hasActiveFilters ? '' : styles.resetInactive}`}
+          onClick={resetAll}
+          disabled={!hasActiveFilters}
+          aria-label="Reset all filters"
+        >
+          ×
+        </button>
+      </div>
 
       {onDensityChange && density !== undefined && (
-        <label className={styles.slider}>
-          {/* aria-hidden: the range input already announces its value natively. */}
-          <span className={styles.sliderLabel} aria-hidden="true">
-            Density {density}
-          </span>
-          <input
-            type="range"
-            min={1}
-            max={densityMax}
-            step={1}
-            value={density}
-            onChange={e => onDensityChange(Number(e.target.value))}
-            aria-label="Row density"
-          />
-        </label>
+        <div className={styles.densitySlot}>
+          {densityVariant === 'tiers' && densityTiers ? (
+            <DensityTierControl
+              tiers={densityTiers}
+              activeKey={activeDensityTier ?? ''}
+              onSelect={onDensityTierSelect ?? onDensityChange}
+            />
+          ) : (
+            <label className={styles.slider}>
+              {/* aria-hidden: the range input already announces its value natively. */}
+              <span className={styles.sliderLabel} aria-hidden="true">
+                Density {density}
+              </span>
+              <input
+                type="range"
+                min={1}
+                max={densityMax}
+                step={1}
+                value={density}
+                onChange={e => onDensityChange(Number(e.target.value))}
+                aria-label="Row density"
+              />
+            </label>
+          )}
+        </div>
       )}
     </div>
   );

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -73,6 +73,41 @@ export const LAYOUT = {
 // by the calibration test so code and test never drift.
 export const DENSITY_ROW_WIDTH_MULTIPLIER = 2.1;
 
+/**
+ * Visitor-facing density presets, labelled by PHOTO SIZE.
+ *
+ * Size runs INVERSE to density: `rowWidth = round(density × DENSITY_ROW_WIDTH_MULTIPLIER)`, and the
+ * viewport-derived target aspect ratio holds row AREA roughly constant ("one row per screen"), so
+ * photo size ≈ constant ÷ density. Density 2 yields large photos, density 7 small ones — which is
+ * why this control must never be labelled with the raw number or the word "Density".
+ *
+ * The values land at roughly 2 / 4 / 7 photos across (rowWidth ÷ ~2.108, the width-cost of a normal
+ * 3★ landscape). Medium reproduces the historical default exactly. `desktop` and `mobile` are
+ * values on their respective density scales — see {@link toMobileDensity}.
+ */
+export const DENSITY_TIERS = [
+  { key: 'large', label: 'Large photos', desktop: 2, mobile: 1 },
+  { key: 'medium', label: 'Medium photos', desktop: 4, mobile: 2 },
+  { key: 'small', label: 'Small photos', desktop: 7, mobile: 4 },
+] as const;
+
+export type DensityTierKey = (typeof DENSITY_TIERS)[number]['key'];
+
+/**
+ * The tier whose value sits closest to `density` on the given viewport's scale.
+ *
+ * Purely a display decision: it picks which segment renders active and NEVER rewrites the density.
+ * Collections carry off-tier stored `rowsWide` values (5, 6) that must keep driving their layout
+ * untouched, so an off-tier collection highlights its nearest segment and only snaps when a visitor
+ * actually clicks one. Ties resolve to the lower (larger-photo) tier, since {@link DENSITY_TIERS}
+ * is ordered ascending and a strict `<` comparison keeps the first of an equal pair.
+ */
+export const nearestDensityTier = (density: number, isMobile: boolean): DensityTierKey =>
+  DENSITY_TIERS.reduce((closest, tier) => {
+    const scale = (t: (typeof DENSITY_TIERS)[number]) => (isMobile ? t.mobile : t.desktop);
+    return Math.abs(scale(tier) - density) < Math.abs(scale(closest) - density) ? tier : closest;
+  }).key;
+
 // Per-rating base weight feeding the prominence value P = BASE_WEIGHT[rating] ×
 // prominenceFactor(extremeness). Higher-rated images get more visual weight.
 export const BASE_WEIGHT: Record<number, number> = {

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -82,7 +82,7 @@ export default async function ExplorePage() {
               <ul className={styles.linkList}>
                 {tags.map(tag => (
                   <li key={tag.id}>
-                    <NavLink href={`/${tag.slug}`} className={styles.directoryLink}>
+                    <NavLink href={`/tag/${tag.slug}`} className={styles.directoryLink}>
                       {tag.name}
                     </NavLink>
                   </li>

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -37,6 +37,19 @@ const TAP_SLOP = 10;
 
 const SCROLL_BLOCKING_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', ' ', 'Home', 'End'];
 
+/** Controls that own their own key handling — Space activates a button, keys type into a field. */
+const INTERACTIVE_SELECTOR = 'button, a, input, select, textarea';
+
+/**
+ * True when a key event originated on an interactive control. Scroll-blocking must skip those:
+ * `preventDefault()` on Space would otherwise silently kill button activation for keyboard users
+ * (Enter still fires, so the breakage looks like nothing at all). Guarded for non-Element targets
+ * (document/window), which have no `closest`.
+ */
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(INTERACTIVE_SELECTOR) !== null;
+}
+
 /**
  * Backwards-compatible alias for the union of content types that can open in the fullscreen
  * viewer. Now includes GIF/MP4 — see {@link ViewableContent}.
@@ -73,8 +86,10 @@ export function useFullScreenImage(): {
   zoomTargetRef: RefObject<HTMLDivElement | null>;
   /** True while the image is pinch-zoomed past 1×; gates swipe-nav and tap-to-close. */
   isZoomed: boolean;
-  /** True while immersive mode is on (all chrome hidden); touch-toggled, persists across nav. */
+  /** True while immersive mode is on (all chrome hidden); toggled by tap/click, persists across nav. */
   immersive: boolean;
+  /** Flip immersive mode. Call from a user gesture so the native fullscreen request survives. */
+  toggleImmersive: () => void;
   isSwiping: RefObject<boolean>;
   showImage: (image: ImageBlock, allImages?: ImageBlock[]) => void;
   hideImage: (e?: MouseEvent) => void;
@@ -131,6 +146,23 @@ export function useFullScreenImage(): {
     const el = zoomTargetRef.current;
     if (el) el.style.transform = '';
     setIsZoomed(false);
+  }, []);
+
+  /**
+   * Flip immersive mode (all chrome hidden, image only). Native fullscreen is requested on the way
+   * in and left on the way out — best-effort, and unsupported on iPhone WebKit, where the
+   * chrome-hide alone carries the feature. Must run inside the user gesture (touch tap or click)
+   * so the fullscreen request keeps its user activation.
+   */
+  const toggleImmersive = useCallback(() => {
+    const next = !immersiveRef.current;
+    immersiveRef.current = next;
+    setImmersive(next);
+    if (next) {
+      void requestFullscreen(modalRef.current);
+    } else {
+      void exitFullscreen();
+    }
   }, []);
 
   // Tracks whether *we* pushed a history entry for the open modal, so hideImage
@@ -285,7 +317,7 @@ export function useFullScreenImage(): {
       } else if (event.key === 'ArrowRight') {
         event.preventDefault();
         navigateToNext();
-      } else if (SCROLL_BLOCKING_KEYS.includes(event.key)) {
+      } else if (SCROLL_BLOCKING_KEYS.includes(event.key) && !isInteractiveTarget(event.target)) {
         event.preventDefault();
       }
     };
@@ -544,19 +576,10 @@ export function useFullScreenImage(): {
           if (isControlTap(e.target)) {
             // The control's own onClick handles it; nothing to do here.
           } else if (isImageTap(e.target)) {
-            // Tap on the framed photo → toggle immersive (hide/show all chrome). Native fullscreen
-            // is requested where supported (Android); on iOS WebKit it no-ops and we rely on the
-            // chrome-hide + solid-black backdrop alone. Best-effort, never throws, and runs from the
-            // touch handler so the request keeps its user activation.
-            const next = !immersiveRef.current;
-            immersiveRef.current = next;
-            setImmersive(next);
-            if (next) {
-              void requestFullscreen(modalElement);
-            } else {
-              void exitFullscreen();
-            }
-            // Swallow the synthetic click this tap produces so it doesn't also close the viewer.
+            // Tap on the framed photo → toggle immersive (hide/show all chrome). Shared with the
+            // desktop click path in FullScreenModal, so both pointer types behave identically.
+            toggleImmersive();
+            // Swallow the synthetic click this tap produces so it doesn't also toggle a second time.
             suppressTapClose();
           } else {
             // Tap on the black letterbox outside the photo → dismiss the viewer.
@@ -580,7 +603,7 @@ export function useFullScreenImage(): {
       modalElement.removeEventListener('touchmove', handleTouchMove);
       modalElement.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isOpen, navigateToNext, navigateToPrevious, isMetadataControl, hideImage]);
+  }, [isOpen, navigateToNext, navigateToPrevious, isMetadataControl, hideImage, toggleImmersive]);
 
   const toggleMetadata = useCallback((e: MouseEvent) => {
     e.stopPropagation();
@@ -596,6 +619,7 @@ export function useFullScreenImage(): {
     zoomTargetRef,
     isZoomed,
     immersive,
+    toggleImmersive,
     isSwiping,
     showImage,
     hideImage,

--- a/app/styles/fullscreen-image.module.scss
+++ b/app/styles/fullscreen-image.module.scss
@@ -31,6 +31,21 @@
   }
 }
 
+// Visually-hidden but screen-reader-accessible. Carries the dialog's accessible name (the <h2>
+// wired to aria-labelledby): the metadata panel that shows the title is collapsed by default, so
+// the name cannot live there or the dialog would usually have none.
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 // Immersive mode (tap-to-hide-chrome). On iOS WebKit native fullscreen is unavailable, so the
 // Modal's 0.9 backdrop would otherwise let the page bleed through at 10%. Paint the whole viewer
 // solid black so the framed photo (and its white matte) is the only thing visible.
@@ -275,6 +290,28 @@
 
   @media (width > 768px) and (height >= 600px) {
     margin-bottom: 8px;
+  }
+}
+
+// Location links inside a .metadataItem row. Without this they fell back to the browser default
+// #0000EE on the 80%-black panel — ~2.3:1, below WCAG AA — so they take the sibling item's colour
+// and stay distinguishable by the underline rather than by hue alone.
+.metadataLink {
+  color: var(--scrim-light-90);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: white;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--scrim-light-50);
+    outline-offset: 2px;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
   }
 }
 

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -63,6 +63,13 @@ html,
   --color-selected-indicator: rgb(220, 38, 38, 0.9);
   --color-shadow: rgb(0, 0, 0, 0.3);
 
+  /* Content affordance accents — icon fills layered over content thumbnails.
+     Like the other brand/status literals (--color-danger, --color-warning) these
+     are deliberately NOT re-declared under [data-surface='dark']: the affordance
+     must read as the same color on both surfaces. */
+  --color-heart: #e0245e; /* SaveHeart fill + FollowButton active state */
+  --color-star: #f5c518; /* ContentComponent select-star fill */
+
   /* Spacing scale */
   --space-0: 0;
   --space-1: 0.25rem;

--- a/app/types/GalleryFilter.ts
+++ b/app/types/GalleryFilter.ts
@@ -105,9 +105,22 @@ export function cycleFilmFilter(current: FilmFilter): FilmFilter {
 }
 
 /**
+ * Array dimensions whose values are mutually exclusive on a single item, making a multi-select
+ * meaningless in both combine modes: an image has exactly one capture day and exactly one lens.
+ * Two dates OR two disjoint sets (a selection that only ever widens the result); two lenses AND
+ * two disjoint sets (a selection that always yields nothing — see `lensMatchMode: 'AND'` in
+ * `buildCollectionCriteria`). Both are therefore single-choice, not accumulating.
+ */
+const EXCLUSIVE_FILTER_KEYS: readonly ArrayFilterKey[] = ['selectedDates', 'selectedLenses'];
+
+/**
  * Toggle a value in one of the array dimensions and emit a Partial update.
  * Shared by the filter toolbar and the tag-click handlers in
  * CollectionContentRenderer.
+ *
+ * Dimensions in {@link EXCLUSIVE_FILTER_KEYS} hold at most one value: picking a different option
+ * switches the selection to it, and picking the current sole selection clears the dimension. Every
+ * other dimension accumulates — picking a second tag narrows by both.
  */
 export function toggleArrayFilter(
   state: FilterState,
@@ -116,6 +129,11 @@ export function toggleArrayFilter(
   value: string
 ): void {
   const current = state[key] as readonly string[];
+  if (EXCLUSIVE_FILTER_KEYS.includes(key)) {
+    const isSoleSelection = current.length === 1 && current[0] === value;
+    onChange({ [key]: isSoleSelection ? [] : [value] });
+    return;
+  }
   const next = current.includes(value) ? current.filter(v => v !== value) : [...current, value];
   onChange({ [key]: next });
 }

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 
+import { MeProvider } from '@/app/components/auth/MeProvider';
 import CollectionPageClient from '@/app/components/ContentCollection/CollectionPageClient';
 import { AccountCard } from '@/app/components/Personal/AccountCard';
 import { FollowsProvider } from '@/app/components/Personal/FollowsContext';
@@ -91,11 +92,18 @@ interface UserPageProps {
  * stay `?tab=` links rather than joining `FilterState` because each section's blocks come from a
  * different server read, and because the choice should stay shareable and back-button-walkable.
  * Their presence is also what makes the bar render here at all — `/user` has no facet dimensions
- * of its own — which is how the page picks up the density slider and the rest of the bar chrome.
+ * of its own — which is how the page picks up the photo-size control and the rest of the bar chrome.
+ *
+ * The whole sections region is wrapped in `MeProvider` because `SendMessageButton` is a sibling of
+ * `CollectionPageClient`, not a descendant: the provider the collection stack mounts internally does
+ * not reach it, so without this wrapper `useMe()` returns null there and the send-message form opens
+ * with a blank, editable email instead of the signed-in address. `CollectionPageClient` still mounts
+ * its own provider from the same `me={principal}`, so the nested provider carries an identical value.
  *
  * No section passes a `chunkSize`, so each starts at `LAYOUT.defaultChunkSize` — the density an
- * ordinary collection page opens at. The bespoke per-section densities this page used to carry are
- * gone; the slider in the shared bar is how a section gets re-tuned now.
+ * ordinary collection page opens at, and the value the bar's Medium photo-size tier selects. The
+ * bespoke per-section densities this page used to carry are gone; the photo-size control in the
+ * shared bar is how a section gets re-tuned now.
  *
  * Load-bearing invariant: the backend's `UserPageAssembler` builds this collection with no `id`,
  * `isClient` or `isPasswordProtected` (it is assembled, not a `collection` row). That absence is
@@ -172,29 +180,31 @@ export default async function UserPage({ searchParams }: UserPageProps) {
     <PageShell pageType="default" collectionSlug={collection.slug}>
       <h1 className={styles.srOnly}>Your Space</h1>
 
-      <div className={styles.sections}>
-        <div className={styles.topBar}>
-          <SendMessageButton />
+      <MeProvider me={principal}>
+        <div className={styles.sections}>
+          <div className={styles.topBar}>
+            <SendMessageButton />
+          </div>
+
+          <FollowsProvider initialFollowedIds={followedCollectionIds}>
+            <CollectionPageClient
+              key={activeKey}
+              collection={sectionCollection}
+              serverContentWidth={ssrViewport?.contentWidth}
+              serverViewportHeight={ssrViewport?.viewportHeight}
+              serverIsMobile={ssrViewport?.isMobile}
+              me={principal}
+              initialSavedImageIds={savedImageIds}
+              sections={toolbarSections}
+              activeSectionKey={activeKey}
+            />
+          </FollowsProvider>
+
+          {active.content.length === 0 && <p className={styles.empty}>{active.emptyLabel}</p>}
+
+          <AccountCard email={principal.email} />
         </div>
-
-        <FollowsProvider initialFollowedIds={followedCollectionIds}>
-          <CollectionPageClient
-            key={activeKey}
-            collection={sectionCollection}
-            serverContentWidth={ssrViewport?.contentWidth}
-            serverViewportHeight={ssrViewport?.viewportHeight}
-            serverIsMobile={ssrViewport?.isMobile}
-            me={principal}
-            initialSavedImageIds={savedImageIds}
-            sections={toolbarSections}
-            activeSectionKey={activeKey}
-          />
-        </FollowsProvider>
-
-        {active.content.length === 0 && <p className={styles.empty}>{active.emptyLabel}</p>}
-
-        <AccountCard email={principal.email} />
-      </div>
+      </MeProvider>
     </PageShell>
   );
 }

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -8,6 +8,7 @@ import {
   type ContentTextModel,
   type TextBlockItem,
 } from '@/app/types/Content';
+import { getMeanWidthCost } from '@/app/utils/contentRatingUtils';
 import { isContentCollection, pickImageDimensions } from '@/app/utils/contentTypeGuards';
 import { formatDateRange } from '@/app/utils/formatDateRange';
 import {
@@ -70,6 +71,20 @@ export interface ProcessContentOptions {
    * show text leave it off, so a plain metadata-less collection still renders a full-width cover.
    */
   forceHeaderRail?: boolean;
+  /**
+   * Mean width-cost of this collection's UNFILTERED content, used to hold photos-per-row steady
+   * while a filter is active.
+   *
+   * Width-cost scales with rating, so a filter that changes the rating mix — "Highly Rated" most
+   * sharply — changes how many items fit the fixed row budget, and every photo visibly resizes even
+   * though the density control never moved. Scaling the budget by
+   * `mean(filtered) / widthCostBaseline` cancels exactly that shift while leaving RELATIVE sizing
+   * inside a row untouched: a 5★ still outweighs a 3★ beside it.
+   *
+   * Omit it (or pass the unfiltered mean itself) and the factor is 1, so an unfiltered layout is
+   * bit-for-bit what it was before this option existed.
+   */
+  widthCostBaseline?: number;
 }
 
 /**
@@ -130,11 +145,20 @@ export function processContentForDisplay(
     }
   }
 
-  const rowWidth = options?.isMobile
+  const baseRowWidth = options?.isMobile
     ? options?.mobileChunkSize !== undefined
       ? Math.round(options.mobileChunkSize * DENSITY_ROW_WIDTH_MULTIPLIER)
       : LAYOUT.mobileSlotWidth
     : Math.round(chunkSize * DENSITY_ROW_WIDTH_MULTIPLIER);
+
+  // See ProcessContentOptions.widthCostBaseline: keeps a filtered view at the same photos-per-row
+  // as the unfiltered collection. Both means must be > 0 for the ratio to mean anything.
+  const baseline = options?.widthCostBaseline ?? 0;
+  const currentMeanCost = baseline > 0 ? getMeanWidthCost(content) : 0;
+  const rowWidth =
+    baseline > 0 && currentMeanCost > 0
+      ? Math.round(baseRowWidth * (currentMeanCost / baseline))
+      : baseRowWidth;
   const effectiveGap = options?.isMobile ? LAYOUT.mobileGridGap : LAYOUT.gridGap;
   const targetAR = options?.targetAR ?? 1.5;
 

--- a/app/utils/contentRatingUtils.ts
+++ b/app/utils/contentRatingUtils.ts
@@ -129,6 +129,24 @@ export function getWidthCost(item: AnyContentModel): number {
 }
 
 /**
+ * Mean width-cost across items — the average horizontal budget one item consumes.
+ *
+ * Used as a layout BASELINE so that filtering does not silently resize the grid. Because
+ * {@link getWidthCost} scales with rating, a filtered view containing only 4-5★ images has a much
+ * higher mean cost than the same collection unfiltered, so a fixed row-width budget fits fewer of
+ * them and every photo jumps in size. Comparing the filtered mean against the unfiltered one gives
+ * the factor that cancels exactly that shift. Returns 0 for an empty set, which callers treat as
+ * "no baseline" rather than dividing by it.
+ *
+ * @param items - Items to average over
+ * @returns Mean width cost, or 0 when there is nothing to average
+ */
+export function getMeanWidthCost(items: AnyContentModel[]): number {
+  if (items.length === 0) return 0;
+  return items.reduce((sum, item) => sum + getWidthCost(item), 0) / items.length;
+}
+
+/**
  * Vertical demand (Vv): the "height" dimension of prominence.
  *
  * Vv = sqrt(P / AR)

--- a/app/utils/contentRendererUtils.ts
+++ b/app/utils/contentRendererUtils.ts
@@ -38,9 +38,13 @@ function extractImageDimensions(
 }
 
 /**
- * Extracts alt text with fallback options
+ * Extracts alt text with fallback options.
+ *
+ * Exported so every surface that renders a photo resolves alt the same way — the grid via
+ * {@link normalizeContentToRendererProps} and the fullscreen viewer directly. The authored `alt`
+ * field always wins; `title`/`caption` are only fallbacks for content that never got one.
  */
-function extractAltText(
+export function extractAltText(
   alt?: string | null,
   title?: string | null,
   caption?: string | null,

--- a/docs/browser-diagnostics.md
+++ b/docs/browser-diagnostics.md
@@ -1,0 +1,97 @@
+# Browser Diagnostics
+
+Copy-paste snippets for the DevTools console. Each one returns a **single object** so the whole
+result can be copied out of the console in one go and pasted back into a chat or issue — no
+screenshots of console output, no "what does it say now?" round-trips.
+
+The snippets below are deliberately kept on one line (guarded with `<!-- prettier-ignore -->`);
+Prettier would otherwise reflow them, and multi-line pastes get mangled by the console's
+auto-indent.
+
+## The pattern
+
+Write diagnostics as an IIFE that returns one flat object:
+
+```js
+(() => {
+  /* measure */
+  return { thing, controlValue, worstOffenders: [] };
+})();
+```
+
+Rules that make these worth reusing:
+
+- **Return, never `console.log`.** A returned object is expandable and copyable; logs are not.
+- **Include the control value, not just the suspect.** `innerWidth` next to `clientWidth` is what
+  turns "it looks wrong" into a diagnosis — a snippet reporting only the symptom can't distinguish
+  causes.
+- **Sort and cap lists** (`.sort(...).slice(0, 8)`), so a page with 400 offenders still produces a
+  pasteable result.
+- **Truncate class names** (`.slice(0, 60)`) — CSS-module hashes are long and add nothing.
+
+## Horizontal overflow: what is wider than the viewport?
+
+Returns the page-level numbers plus the widest elements crossing either edge.
+
+<!-- prettier-ignore -->
+```js
+(()=>{const d=document.documentElement,vw=d.clientWidth,o=[];document.querySelectorAll('*').forEach(e=>{const r=e.getBoundingClientRect();if(r.width||r.height){if(r.right>vw+1||r.left<-1)o.push({cls:String(e.className||'').slice(0,60),l:Math.round(r.left),right:Math.round(r.right),w:Math.round(r.width)})}});return{innerWidth,clientWidth:vw,scrollWidth:d.scrollWidth,overflow:d.scrollWidth-vw,devicePixelRatio,count:o.length,worst:o.sort((a,b)=>b.w-a.w).slice(0,8)}})()
+```
+
+Reading it:
+
+- `innerWidth !== clientWidth` — the window and the layout viewport disagree. `useViewport` measures
+  `window.innerWidth`, so the layout is being sized off the wrong number.
+- `overflow > 0` with entries in `worst` — real overflow; `worst[0]` is the element to fix.
+- `overflow: 0` and `count: 0` — the document does **not** overflow. If something still visibly pans,
+  it is not the page (see the next snippet).
+
+> `body` sets `overflow-x: clip` (`app/styles/globals.css`) and `html` is `visible`, so the clip
+> propagates to the viewport. That **clamps `scrollWidth`**, so `scrollWidth` alone is not a
+> trustworthy overflow oracle here — the per-element `getBoundingClientRect()` scan is, because rects
+> are unaffected by clipping. Always read `count`/`worst`, not just `overflow`.
+
+## Is it the page scrolling, or the DevTools device frame?
+
+In device mode, when the emulated device is wider than the DevTools viewport area, Chrome pans the
+**device frame** — which looks exactly like page overflow and crops screenshots on the right.
+
+<!-- prettier-ignore -->
+```js
+(()=>{const d=document.documentElement;const before=scrollX;scrollTo(9999,0);const forced=scrollX;scrollTo(before,0);return{scrollX_asYouLeftIt:before,scrollX_afterForcingRight:forced,clientWidth:d.clientWidth,scrollWidth:d.scrollWidth,pageCanScrollX:forced>0}})()
+```
+
+`pageCanScrollX: false` while the view visibly pans ⇒ it is the DevTools frame, not the site.
+
+Do not reason from the CSS spec about whether a page _can_ scroll — measure it. The clip-propagation
+rule above makes a confident wrong answer very easy to reach.
+
+## Layout viewport vs. what the app thinks it is
+
+Catches stale layout after a viewport change (rotate, device-mode toggle, dock resize).
+
+<!-- prettier-ignore -->
+```js
+(()=>{const d=document.documentElement;const rows=[...document.querySelectorAll('[class*=hbox],[class*=vbox]')].map(e=>Math.round(e.getBoundingClientRect().width));return{innerWidth,clientWidth:d.clientWidth,widestRow:Math.max(0,...rows),rowCount:rows.length,rows:rows.slice(0,8)}})()
+```
+
+A `widestRow` far above `clientWidth` means the BoxTree was composed for a different width than the
+one currently on screen — row widths are pixel values baked at layout time.
+
+## Headless alternative
+
+For anything that is a pure function of the layout inputs, prefer a throwaway Jest probe over the
+browser — it is deterministic and needs no auth, no server, and no viewport emulation:
+
+```ts
+const { rows } = buildContentRows(
+  content,
+  undefined,
+  { contentWidth: 430, viewportHeight: 932, isMobile: true },
+  LAYOUT.defaultChunkSize
+);
+rows.forEach(r => console.log(r.items.map(i => Math.round(i.width))));
+```
+
+This is how the admin-hub mobile packing bug was pinned down: the browser could not render `/admin`
+without an admin session, but `buildContentRows` reproduced the exact row widths in milliseconds.

--- a/tests/(admin)/admin/page.mobileLayout.test.tsx
+++ b/tests/(admin)/admin/page.mobileLayout.test.tsx
@@ -1,0 +1,67 @@
+import { buildAdminHubContent } from '@/app/(admin)/admin/adminHubContent';
+import { buildContentRows } from '@/app/components/Content/componentUtils';
+import { LAYOUT } from '@/app/constants';
+import type { AdminHomeTileApi } from '@/app/lib/api/adminHome';
+
+/**
+ * The admin hub lays out through the shared content pipeline, whose mobile row budget
+ * ({@link LAYOUT.mobileSlotWidth}) is calibrated for photos. Left at that budget the packer fits two
+ * items per row on a phone: the users/messages panels land at ~212px each — too narrow for a user
+ * list — and portrait-covered nav tiles pair up too. `mobileChunkSize={1}` restores the single
+ * column the pre-pipeline `AdminHubGrid` had via `grid-template-columns: 1fr`.
+ */
+const MOBILE_VIEWPORT = { contentWidth: 430, viewportHeight: 932, isMobile: true };
+
+const tilesWithCovers = (width: number, height: number): AdminHomeTileApi[] =>
+  ['homePage', 'all-collections', 'all-images', 'all-client-galleries'].map((tileKey, i) => ({
+    tileKey,
+    coverImageUrl: `https://cdn.example/${tileKey}.webp`,
+    coverImageWidth: width,
+    coverImageHeight: height,
+    displayOrder: i,
+  }));
+
+const layout = (tiles: AdminHomeTileApi[], mobileChunkSize?: number) =>
+  buildContentRows(
+    buildAdminHubContent(tiles),
+    undefined,
+    MOBILE_VIEWPORT,
+    LAYOUT.defaultChunkSize,
+    mobileChunkSize
+  ).rows;
+
+describe('admin hub mobile layout', () => {
+  const coverCases: [string, AdminHomeTileApi[]][] = [
+    ['no cover images', []],
+    ['landscape covers', tilesWithCovers(2400, 1600)],
+    ['portrait covers', tilesWithCovers(1600, 2400)],
+  ];
+
+  it.each(coverCases)('is one item per row on a 430px phone — %s', (_label, tiles) => {
+    const rows = layout(tiles, 1);
+
+    expect(rows).not.toHaveLength(0);
+    for (const row of rows) {
+      expect(row.items).toHaveLength(1);
+      expect(row.items.map(item => Math.round(item.width))).toEqual([MOBILE_VIEWPORT.contentWidth]);
+    }
+  });
+
+  it('never lets a row exceed the content width', () => {
+    for (const [, tiles] of coverCases) {
+      for (const row of layout(tiles, 1)) {
+        const widest = Math.max(...row.items.map(item => item.width));
+        expect(widest).toBeLessThanOrEqual(MOBILE_VIEWPORT.contentWidth + 1);
+      }
+    }
+  });
+
+  it('documents the un-pinned budget that squeezed both panels into one row', () => {
+    const [panelRow] = layout([]);
+
+    expect(panelRow?.items).toHaveLength(2);
+    for (const item of panelRow?.items ?? []) {
+      expect(item.width).toBeLessThan(MOBILE_VIEWPORT.contentWidth / 2);
+    }
+  });
+});

--- a/tests/(admin)/admin/page.test.tsx
+++ b/tests/(admin)/admin/page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { isValidElement } from 'react';
 
 import { ADMIN_TILES } from '@/app/(admin)/admin/adminTiles';
 import AdminHubPage from '@/app/(admin)/admin/page';
@@ -57,6 +58,27 @@ describe('AdminHubPage', () => {
 
     const images = container.querySelectorAll('img');
     expect(images.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('pins the content block to a single column on mobile', async () => {
+    mockGetTiles.mockResolvedValue([]);
+    const ui = await AdminHubPage();
+
+    const findMobileChunkSize = (node: unknown): number | undefined => {
+      if (Array.isArray(node)) {
+        for (const child of node) {
+          const found = findMobileChunkSize(child);
+          if (found !== undefined) return found;
+        }
+        return undefined;
+      }
+      if (!isValidElement(node)) return undefined;
+      const props = node.props as { mobileChunkSize?: number; children?: unknown };
+      if (props.mobileChunkSize !== undefined) return props.mobileChunkSize;
+      return findMobileChunkSize(props.children);
+    };
+
+    expect(findMobileChunkSize(ui)).toBe(1);
   });
 
   it('falls back gracefully when the API throws', async () => {

--- a/tests/app/user/page.test.tsx
+++ b/tests/app/user/page.test.tsx
@@ -24,8 +24,16 @@ jest.mock('@/app/components/SiteHeader/SiteHeader', () => ({
   __esModule: true,
   default: () => 'SiteHeader',
 }));
-jest.mock('@/app/components/SendMessageButton/SendMessageButton', () => ({
-  SendMessageButton: () => 'SendMessageButton',
+// SendMessageButton is deliberately NOT mocked: it is the component the MeProvider wrapper exists
+// for, so the real one has to run for the lockedEmail assertion below to mean anything. Its modal
+// is stubbed open and its form reduced to a probe that echoes the lockedEmail it was handed.
+jest.mock('@/app/components/ui/Modal/Modal', () => ({
+  Modal: ({ children }: { children: unknown }) => children,
+}));
+jest.mock('@/app/components/ContactForm/ContactForm', () => ({
+  ContactForm: ({ lockedEmail }: { lockedEmail?: string }) => (
+    <span data-locked-email={lockedEmail} />
+  ),
 }));
 jest.mock('@/app/components/Personal/FollowsContext', () => ({
   FollowsProvider: ({ children }: { children: unknown }) => children,
@@ -34,6 +42,9 @@ jest.mock('@/app/components/Personal/AccountCard', () => ({
   AccountCard: () => 'AccountCard',
 }));
 
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MeProvider } from '@/app/components/auth/MeProvider';
 import CollectionPageClient from '@/app/components/ContentCollection/CollectionPageClient';
 import { LAYOUT } from '@/app/constants';
 import { meServer } from '@/app/lib/api/auth';
@@ -125,6 +136,20 @@ describe('UserPage', () => {
     const grid = gridProps(await renderTab());
     expect(grid).not.toBeNull();
     expect(grid.me).toBe(authedPrincipal);
+  });
+
+  it('mounts SendMessageButton inside a MeProvider so its form gets a lockedEmail', async () => {
+    // SendMessageButton is a SIBLING of CollectionPageClient, so the MeProvider that the collection
+    // stack mounts internally never reaches it. Without the page-level provider, useMe() is null and
+    // the signed-in user gets a blank, editable email field instead of their locked-in address.
+    const provider = findProps(await renderTab(), MeProvider);
+    expect(provider).not.toBeNull();
+    expect(provider.me).toBe(authedPrincipal);
+
+    const markup = renderToStaticMarkup(
+      <MeProvider me={provider.me}>{provider.children}</MeProvider>
+    );
+    expect(markup).toContain('data-locked-email="c@x.com"');
   });
 
   it('defaults to Collections and passes only the COLLECTION blocks', async () => {

--- a/tests/components/ContentCollection/CollectionPageClient.dateAvailability.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.dateAvailability.test.tsx
@@ -2,14 +2,13 @@
  * Regression test for whole-branch review Finding 1 (CRITICAL): selecting one date must not
  * grey out every other date chip.
  *
- * `dates` is OR-combined and single-valued per image (a photo was captured on exactly one
- * calendar day), unlike camera/lens/people/location, which are AND-combined. Deriving the
- * bar's `filteredAvailable.dates` from `filteredImages` -- the images surviving the CURRENT
- * criteria, which already includes an active `dates` selection -- collapses every surviving
- * image onto the selected day(s), so `extractCollectionFilterOptions` reports every OTHER day
- * as absent and the toolbar renders it disabled. That defeats the multi-day conference case
- * (pick day 1 and day 3): after picking day 1, day 3's chip goes disabled and is unreachable
- * except via the bulk reset.
+ * `dates` is single-valued per image (a photo was captured on exactly one calendar day), which is
+ * why the Date dimension is single-choice in the toolbar: clicking a second day SWITCHES to it.
+ * Deriving the bar's `filteredAvailable.dates` from `filteredImages` -- the images surviving the
+ * CURRENT criteria, which already includes an active `dates` selection -- collapses every
+ * surviving image onto the selected day, so `extractCollectionFilterOptions` reports every OTHER
+ * day as absent and the toolbar renders it disabled. That makes switching impossible: after
+ * picking day 1, day 3's chip goes disabled and is unreachable except via the bulk reset.
  */
 import '@testing-library/jest-dom';
 

--- a/tests/components/ContentCollection/CollectionPageClient.headerRail.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.headerRail.test.tsx
@@ -141,8 +141,9 @@ describe('CollectionPageClient — header rail', () => {
   });
 
   it('brings the shared density control along with the bar', () => {
-    // The density slider is the visible proof that the page picked up the shared bar chrome
-    // rather than a /user-only approximation of it.
+    // The photo-size control is the visible proof that the page picked up the shared bar chrome
+    // rather than a /user-only approximation of it. Visitors get the tier radiogroup, not the
+    // raw slider -- that is edit-mode only.
     render(
       <CollectionPageClient
         collection={bareCollection([collectionCard(1)])}
@@ -151,14 +152,15 @@ describe('CollectionPageClient — header rail', () => {
         activeSectionKey="collections"
       />
     );
-    expect(screen.getByLabelText('Row density')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'Photo size' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Row density')).not.toBeInTheDocument();
   });
 
   it('renders no bar on a metadata-less collection that has nothing to put in it', () => {
     // The rail is forced only when controls will mount. An ordinary metadata-less collection
     // with no filterable dimensions keeps its full-width cover and gains no empty rail.
     render(<CollectionPageClient collection={bareCollection([collectionCard(1)])} {...ssr} />);
-    expect(screen.queryByLabelText('Row density')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup', { name: 'Photo size' })).not.toBeInTheDocument();
     expect(screen.queryAllByRole('link', { name: /collections/i })).toHaveLength(0);
   });
 });

--- a/tests/components/ContentCollection/CollectionPageClient.lensAvailability.test.tsx
+++ b/tests/components/ContentCollection/CollectionPageClient.lensAvailability.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Regression test: selecting one lens must not grey out every other lens chip.
+ *
+ * A lens is single-valued per image (a photo was shot through exactly one lens), and lenses are
+ * AND-combined (`lensMatchMode: 'AND'` in `buildCollectionCriteria`), so two selected lenses match
+ * nothing at all. The Lens dimension is therefore single-choice in the toolbar
+ * (`EXCLUSIVE_FILTER_KEYS`): clicking a second lens SWITCHES to it.
+ *
+ * That switch is only reachable if the other lens chips stay enabled. Deriving the bar's
+ * `filteredAvailable.lenses` from `filteredImages` -- the images surviving the CURRENT criteria,
+ * which already include the active lens -- collapses every surviving image onto the chosen lens,
+ * so `extractCollectionFilterOptions` reports every OTHER lens as absent and the toolbar renders
+ * it disabled. A disabled chip cannot be clicked, so the viewer would be stuck on their first
+ * pick until they hit the bulk reset.
+ */
+import '@testing-library/jest-dom';
+
+import { act, render, screen } from '@testing-library/react';
+
+import CollectionPageClient from '@/app/components/ContentCollection/CollectionPageClient';
+import type { CollectionModel } from '@/app/types/Collection';
+import type { AnyContentModel } from '@/app/types/Content';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/glass',
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () =>
+    function DynamicStub() {
+      return null;
+    },
+}));
+
+/**
+ * Stands in for the real grid (and the filter bar nested inside it): exposes the availability the
+ * page computed, plus a button that selects a lens through the page's own `onFilterChange`. Going
+ * through the context drives the real state machine rather than re-implementing it here.
+ */
+jest.mock('@/app/components/Content/ContentBlockWithFullScreen', () => {
+  const { useCollectionFilter } = jest.requireActual<{
+    useCollectionFilter: () => {
+      filteredAvailable: { lenses: readonly string[] } | null;
+      onFilterChange: (update: { selectedLenses: readonly string[] }) => void;
+    } | null;
+  }>('@/app/components/ContentCollection/CollectionFilterContext');
+
+  const MockGrid = () => {
+    const ctx = useCollectionFilter();
+    return (
+      <div>
+        <div
+          data-testid="grid"
+          data-available-lenses={
+            ctx?.filteredAvailable ? ctx.filteredAvailable.lenses.join(',') : 'NONE'
+          }
+        />
+        <button type="button" onClick={() => ctx?.onFilterChange({ selectedLenses: ['35mm'] })}>
+          pick-35mm
+        </button>
+      </div>
+    );
+  };
+  return { __esModule: true, default: MockGrid };
+});
+
+function image(id: number, lens: string): AnyContentModel {
+  return {
+    id,
+    contentType: 'IMAGE',
+    orderIndex: id,
+    imageUrl: `https://cdn.example/photo-${id}.jpg`,
+    imageWidth: 1600,
+    imageHeight: 1067,
+    locations: [],
+    lens: { id, name: lens },
+    rating: 0,
+  } as unknown as AnyContentModel;
+}
+
+/** Three lenses, so no single lens blankets the collection (`canFilter` stays true). */
+function makeThreeLensCollection(): CollectionModel {
+  return {
+    id: 9,
+    slug: 'glass',
+    title: 'Glass',
+    isClient: false,
+    isBlog: false,
+    displayMode: 'ORDERED',
+    rowsWide: 4,
+    locations: [],
+    content: [
+      image(1, '35mm'),
+      image(2, '35mm'),
+      image(3, '50mm'),
+      image(4, '85mm'),
+      image(5, '85mm'),
+    ],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as unknown as CollectionModel;
+}
+
+describe('CollectionPageClient -- lens availability', () => {
+  it('keeps every other lens available once one lens is selected', () => {
+    render(<CollectionPageClient collection={makeThreeLensCollection()} />);
+
+    act(() => {
+      screen.getByRole('button', { name: 'pick-35mm' }).click();
+    });
+
+    const available = screen.getByTestId('grid').getAttribute('data-available-lenses');
+    // The active pick AND both alternatives must stay reachable — otherwise switching lenses is
+    // impossible, since the toolbar disables an unavailable chip.
+    expect(available).toContain('35mm');
+    expect(available).toContain('50mm');
+    expect(available).toContain('85mm');
+  });
+});

--- a/tests/components/FullScreenModal/FullScreenModal.a11y.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.a11y.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Accessibility contract for FullScreenModal.
+ *
+ * Two things used to fail silently here:
+ *  - the dialog pointed `aria-labelledby` at an id that only existed inside the collapsed metadata
+ *    panel, so an open viewer usually had NO accessible name. The name now lives in a
+ *    visually-hidden <h2> that always renders.
+ *  - the viewer built its alt text from title/caption and ignored `alt`, the one field authored for
+ *    screen readers. It now resolves alt exactly like the grid does (extractAltText).
+ */
+import { render, screen } from '@testing-library/react';
+
+import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
+import type { ContentImageModel } from '@/app/types/Content';
+
+// The Modal primitive locks body scroll via useBodyScrollLock, whose cleanup calls window.scrollTo —
+// not implemented in jsdom. We only assert on ARIA and alt markup, so stub the lock.
+jest.mock('@/app/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: jest.fn() }));
+
+const img = (id: number, overrides: Partial<ContentImageModel> = {}): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: id,
+    visible: true,
+    locations: [],
+    ...overrides,
+  }) as ContentImageModel;
+
+const noop = () => {};
+
+function renderModal(image: ContentImageModel, showMetadata = false) {
+  return render(
+    <FullScreenModal
+      fullScreenState={{ images: [image], currentIndex: 0 }}
+      loadedImageIds={new Set<number>([image.id])}
+      setLoadedImageIds={noop}
+      modalRef={{ current: null }}
+      zoomTargetRef={{ current: null }}
+      isZoomed={false}
+      hideImage={noop}
+      isSwiping={{ current: false }}
+      showMetadata={showMetadata}
+      toggleMetadata={noop}
+      router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+      navigateToNext={noop}
+      navigateToPrevious={noop}
+    />
+  );
+}
+
+describe('FullScreenModal — dialog accessible name', () => {
+  it('names the dialog from the image title while the metadata panel is collapsed', () => {
+    renderModal(img(1, { title: 'Sunset Ridge' }));
+
+    expect(screen.getByRole('dialog', { name: 'Fullscreen image: Sunset Ridge' })).toBeVisible();
+  });
+
+  it('falls back to a generic name for an untitled image', () => {
+    renderModal(img(1, { title: undefined }));
+
+    expect(screen.getByRole('dialog', { name: 'Fullscreen image' })).toBeVisible();
+  });
+
+  it('keeps a single #fullscreen-title in the tree when the metadata panel is open', () => {
+    renderModal(img(1, { title: 'Sunset Ridge' }), true);
+
+    expect(document.querySelectorAll('#fullscreen-title')).toHaveLength(1);
+    expect(screen.getByRole('dialog', { name: 'Fullscreen image: Sunset Ridge' })).toBeVisible();
+    // The visible title still renders inside the panel, separate from the dialog's name.
+    expect(screen.getByText('Sunset Ridge')).toBeInTheDocument();
+  });
+});
+
+describe('FullScreenModal — image alt text', () => {
+  it('prefers the authored alt over title and caption', () => {
+    renderModal(
+      img(1, { alt: 'Low sun over a granite ridge', title: 'Sunset Ridge', caption: 'Day three' })
+    );
+
+    expect(screen.getByAltText('Low sun over a granite ridge')).toBeInTheDocument();
+  });
+
+  it('falls back to the title when no alt was authored', () => {
+    renderModal(img(1, { alt: undefined, title: 'Sunset Ridge', caption: 'Day three' }));
+
+    expect(screen.getByAltText('Sunset Ridge')).toBeInTheDocument();
+  });
+
+  it('falls back to the caption when neither alt nor title exist', () => {
+    renderModal(img(1, { alt: undefined, title: undefined, caption: 'Day three' }));
+
+    expect(screen.getByAltText('Day three')).toBeInTheDocument();
+  });
+
+  it('falls back to a generic description when the image carries no text at all', () => {
+    renderModal(img(1, { alt: undefined, title: undefined, caption: undefined }));
+
+    expect(screen.getByAltText('Full screen image')).toBeInTheDocument();
+  });
+});
+
+describe('FullScreenModal — metadata location links', () => {
+  it('styles location links so they do not fall back to the default browser link colour', () => {
+    renderModal(
+      img(1, { title: 'Sunset Ridge', locations: [{ id: 5, name: 'Banff', slug: 'banff' }] }),
+      true
+    );
+
+    expect(screen.getByRole('link', { name: 'Banff' })).toHaveClass('metadataLink');
+  });
+});

--- a/tests/components/FullScreenModal/FullScreenModal.click.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.click.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Pointer handling on the FullScreenModal overlay.
+ *
+ * Where a click lands decides the action, mirroring the touch tap split in useFullScreenImage:
+ * the framed photo toggles immersive mode, the black letterbox around it dismisses the viewer.
+ * Previously the whole overlay dismissed, so a plain desktop click on the photo closed the viewer —
+ * the `isSwiping` / `isZoomed` guards are touch-gesture state and never fire for a mouse.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
+import type { ContentImageModel } from '@/app/types/Content';
+
+// The Modal primitive locks body scroll via useBodyScrollLock, whose cleanup calls window.scrollTo —
+// not implemented in jsdom. We only assert on click routing, so stub the lock.
+jest.mock('@/app/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: jest.fn() }));
+
+const img = (id: number): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: id,
+    visible: true,
+    title: `Image ${id}`,
+    locations: [],
+  }) as ContentImageModel;
+
+const noop = () => {};
+
+function renderModal(
+  overrides: {
+    isSwiping?: { current: boolean };
+    isZoomed?: boolean;
+    hideImage?: () => void;
+    toggleImmersive?: () => void;
+  } = {}
+) {
+  const hideImage = overrides.hideImage ?? jest.fn();
+  const toggleImmersive = overrides.toggleImmersive ?? jest.fn();
+
+  render(
+    <FullScreenModal
+      fullScreenState={{ images: [img(1), img(2), img(3)], currentIndex: 1 }}
+      loadedImageIds={new Set<number>([2])}
+      setLoadedImageIds={noop}
+      modalRef={{ current: null }}
+      zoomTargetRef={{ current: null }}
+      isZoomed={overrides.isZoomed ?? false}
+      hideImage={hideImage}
+      toggleImmersive={toggleImmersive}
+      isSwiping={overrides.isSwiping ?? { current: false }}
+      showMetadata={false}
+      toggleMetadata={noop}
+      router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+      navigateToNext={noop}
+      navigateToPrevious={noop}
+    />
+  );
+
+  const overlay = screen.getByRole('dialog').querySelector('.overlayContainer');
+  if (!overlay) throw new Error('overlay container not rendered');
+
+  return { hideImage, toggleImmersive, overlay, photo: screen.getByAltText('Image 2') };
+}
+
+describe('FullScreenModal — overlay clicks', () => {
+  it('toggles immersive instead of closing when the photo itself is clicked', () => {
+    const { hideImage, toggleImmersive, photo } = renderModal();
+
+    fireEvent.click(photo);
+
+    expect(toggleImmersive).toHaveBeenCalledTimes(1);
+    expect(hideImage).not.toHaveBeenCalled();
+  });
+
+  it('closes when the letterbox around the photo is clicked', () => {
+    const { hideImage, toggleImmersive, overlay } = renderModal();
+
+    fireEvent.click(overlay);
+
+    expect(hideImage).toHaveBeenCalledTimes(1);
+    expect(toggleImmersive).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on the click that ends a swipe/pinch/pan', () => {
+    const { hideImage, toggleImmersive, overlay, photo } = renderModal({
+      isSwiping: { current: true },
+    });
+
+    fireEvent.click(photo);
+    fireEvent.click(overlay);
+
+    expect(hideImage).not.toHaveBeenCalled();
+    expect(toggleImmersive).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while the photo is zoomed', () => {
+    const { hideImage, toggleImmersive, overlay, photo } = renderModal({ isZoomed: true });
+
+    fireEvent.click(photo);
+    fireEvent.click(overlay);
+
+    expect(hideImage).not.toHaveBeenCalled();
+    expect(toggleImmersive).not.toHaveBeenCalled();
+  });
+
+  it('still closes on a letterbox click when no immersive toggle is wired up', () => {
+    const hideImage = jest.fn();
+    render(
+      <FullScreenModal
+        fullScreenState={{ images: [img(1)], currentIndex: 0 }}
+        loadedImageIds={new Set<number>([1])}
+        setLoadedImageIds={noop}
+        modalRef={{ current: null }}
+        zoomTargetRef={{ current: null }}
+        isZoomed={false}
+        hideImage={hideImage}
+        isSwiping={{ current: false }}
+        showMetadata={false}
+        toggleMetadata={noop}
+        router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+        navigateToNext={noop}
+        navigateToPrevious={noop}
+      />
+    );
+
+    const overlay = screen.getByRole('dialog').querySelector('.overlayContainer');
+    fireEvent.click(overlay!);
+    expect(hideImage).toHaveBeenCalledTimes(1);
+
+    // The photo click is swallowed rather than dismissing the viewer.
+    fireEvent.click(screen.getByAltText('Image 1'));
+    expect(hideImage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/ui/FilterToolbar.test.tsx
+++ b/tests/components/ui/FilterToolbar.test.tsx
@@ -115,9 +115,9 @@ describe('FilterToolbar', () => {
     expect(screen.getByRole('button', { name: 'sunset' })).not.toBeDisabled();
   });
 
-  it('renders the density slider when onDensityChange is provided', () => {
+  it('renders the density slider in the slider variant', () => {
     const onDensityChange = jest.fn();
-    renderToolbar({ density: 4, onDensityChange });
+    renderToolbar({ density: 4, onDensityChange, densityVariant: 'slider' });
     const slider = screen.getByLabelText('Row density') as HTMLInputElement;
     expect(slider.getAttribute('type')).toBe('range');
     expect(slider.value).toBe('4');
@@ -125,9 +125,66 @@ describe('FilterToolbar', () => {
     expect(onDensityChange).toHaveBeenCalledWith(8);
   });
 
-  it('omits the density slider when onDensityChange is not provided', () => {
+  it('omits the density control entirely when onDensityChange is not provided', () => {
     renderToolbar({});
     expect(screen.queryByLabelText('Row density')).toBeNull();
+    expect(screen.queryByRole('radiogroup', { name: 'Photo size' })).toBeNull();
+  });
+
+  describe('photo-size tiers (default visitor variant)', () => {
+    const TIERS = [
+      { key: 'large', label: 'Large photos', value: 2 },
+      { key: 'medium', label: 'Medium photos', value: 4 },
+      { key: 'small', label: 'Small photos', value: 7 },
+    ];
+
+    function renderTiers(overrides: Partial<Props> = {}) {
+      const onDensityTierSelect = jest.fn();
+      renderToolbar({
+        density: 4,
+        onDensityChange: jest.fn(),
+        densityTiers: TIERS,
+        activeDensityTier: 'medium',
+        onDensityTierSelect,
+        ...overrides,
+      });
+      return { onDensityTierSelect };
+    }
+
+    it('renders a radiogroup of tiers instead of the raw slider by default', () => {
+      renderTiers();
+      expect(screen.getByRole('radiogroup', { name: 'Photo size' })).toBeInTheDocument();
+      // The raw density number is meaningless to a visitor and runs backwards from photo size.
+      expect(screen.queryByLabelText('Row density')).toBeNull();
+    });
+
+    it('names each tier by photo size, never by the density number', () => {
+      renderTiers();
+      for (const tier of TIERS) {
+        expect(screen.getByRole('radio', { name: tier.label })).toBeInTheDocument();
+      }
+      expect(screen.queryByText(/density/i)).toBeNull();
+    });
+
+    it('marks exactly the active tier as checked', () => {
+      renderTiers();
+      expect(screen.getByRole('radio', { name: 'Medium photos' })).toBeChecked();
+      expect(screen.getByRole('radio', { name: 'Large photos' })).not.toBeChecked();
+      expect(screen.getByRole('radio', { name: 'Small photos' })).not.toBeChecked();
+    });
+
+    it('emits the tier value verbatim, bypassing the viewport-scaling handler', () => {
+      const { onDensityTierSelect } = renderTiers();
+      fireEvent.click(screen.getByRole('radio', { name: 'Small photos' }));
+      expect(onDensityTierSelect).toHaveBeenCalledWith(7);
+    });
+
+    it('highlights the nearest tier for an off-tier stored density without snapping it', () => {
+      // A collection stored at 6 keeps laying out at 6; the bar only highlights Small.
+      const { onDensityTierSelect } = renderTiers({ density: 6, activeDensityTier: 'small' });
+      expect(screen.getByRole('radio', { name: 'Small photos' })).toBeChecked();
+      expect(onDensityTierSelect).not.toHaveBeenCalled();
+    });
   });
 
   it('renders the reset button always, disabled until a filter is active', () => {
@@ -205,6 +262,48 @@ describe('FilterToolbar', () => {
     const { onFilterChange } = renderToolbar({ dimensions: threeDays });
     fireEvent.click(screen.getByRole('button', { name: /jul 21/i }));
     expect(onFilterChange).toHaveBeenCalledWith({ selectedDates: ['2026-07-21'] });
+  });
+
+  it('switches to the newly clicked date rather than selecting both', () => {
+    const { onFilterChange } = renderToolbar({
+      dimensions: threeDays,
+      filterState: { ...INITIAL_FILTER_STATE, selectedDates: ['2026-07-20'] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /jul 22/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ selectedDates: ['2026-07-22'] });
+  });
+
+  it('clears the date when the chosen chip is clicked again', () => {
+    const { onFilterChange } = renderToolbar({
+      dimensions: threeDays,
+      filterState: { ...INITIAL_FILTER_STATE, selectedDates: ['2026-07-20'] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /jul 20/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ selectedDates: [] });
+  });
+
+  it('switches the date from the dropdown fallback too', () => {
+    const options = Array.from(
+      { length: MAX_FLAT_DATE_CHIPS + 1 },
+      (_, i) => `2026-07-${String(20 + i).padStart(2, '0')}`
+    );
+    const { onFilterChange } = renderToolbar({
+      dimensions: { selectedDates: { label: 'Date', options, optionLabels: dayLabels(options) } },
+      filterState: { ...INITIAL_FILTER_STATE, selectedDates: ['2026-07-20'] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^date/i }));
+    fireEvent.click(screen.getByRole('button', { name: /jul 25/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ selectedDates: ['2026-07-25'] });
+  });
+
+  it('keeps multi-select for the accumulating dimensions', () => {
+    const { onFilterChange } = renderToolbar({
+      dimensions: { selectedTags: { label: 'Tags', options: ['sunset', 'forest'] } },
+      filterState: { ...INITIAL_FILTER_STATE, selectedTags: ['sunset'] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^tags/i }));
+    fireEvent.click(screen.getByRole('button', { name: /forest/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ selectedTags: ['sunset', 'forest'] });
   });
 
   it('still renders flat chips at exactly the threshold', () => {
@@ -369,16 +468,18 @@ describe('FilterToolbar', () => {
 
     it('renders the bar with sections alone, no facet dimensions needed', () => {
       // This is what lets /user — which has no tags/people/cameras of its own — still show the
-      // shared bar, and with it the density slider.
+      // shared bar, and with it the photo-size control.
       renderToolbar({
         sections: SECTIONS,
         activeSectionKey: 'collections',
         density: 4,
         densityMax: 10,
         onDensityChange: jest.fn(),
+        densityTiers: [{ key: 'medium', label: 'Medium photos', value: 4 }],
+        activeDensityTier: 'medium',
       });
       expect(screen.getAllByRole('link')).toHaveLength(3);
-      expect(screen.getByRole('slider', { name: /row density/i })).toBeInTheDocument();
+      expect(screen.getByRole('radiogroup', { name: 'Photo size' })).toBeInTheDocument();
     });
 
     it('keeps sections independent of the reset button', () => {

--- a/tests/explore/page.test.tsx
+++ b/tests/explore/page.test.tsx
@@ -50,7 +50,12 @@ describe('ExplorePage', () => {
     expect(screen.getByRole('heading', { name: 'Tags' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'People' })).not.toBeInTheDocument();
 
-    expect(screen.getByRole('link', { name: 'Mountains' })).toHaveAttribute('href', '/mountains');
+    // Tags target the /tag/[slug] taxonomy route, not a bare /[slug] — the latter resolves to the
+    // collection route, so it 404s or opens an unrelated collection that happens to share the slug.
+    expect(screen.getByRole('link', { name: 'Mountains' })).toHaveAttribute(
+      'href',
+      '/tag/mountains'
+    );
     expect(screen.getByRole('link', { name: 'Patagonia' })).toHaveAttribute(
       'href',
       '/location/patagonia'

--- a/tests/hooks/useFullScreenImage.keyboard.test.tsx
+++ b/tests/hooks/useFullScreenImage.keyboard.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Document-level key handling for useFullScreenImage.
+ *
+ * The open viewer swallows the page-scrolling keys (arrows, Page/Home/End, and Space) so the
+ * collection behind it never scrolls. Space is the trap: it is also the activation key for every
+ * <button> in the viewer, so an unconditional preventDefault() silently kills close / next / prev /
+ * metadata for keyboard users — Enter keeps working, which hides the breakage. These tests pin that
+ * the scroll block skips interactive targets while still firing for the page itself.
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { useFullScreenImage } from '@/app/hooks/useFullScreenImage';
+import type { ContentImageModel } from '@/app/types/Content';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const img = (id: number): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    orderIndex: id,
+    visible: true,
+  }) as ContentImageModel;
+
+/** Dispatch a bubbling, cancelable keydown from `target` and hand back the event. */
+function pressKey(target: EventTarget, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  act(() => {
+    target.dispatchEvent(event);
+  });
+  return event;
+}
+
+function openViewer() {
+  const hook = renderHook(() => useFullScreenImage());
+  act(() => {
+    hook.result.current.showImage(img(2), [img(1), img(2), img(3)]);
+  });
+  return hook;
+}
+
+describe('useFullScreenImage — keyboard handling', () => {
+  let control: HTMLButtonElement;
+
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/collection-x');
+    control = document.createElement('button');
+    control.type = 'button';
+    document.body.append(control);
+  });
+
+  afterEach(() => {
+    control.remove();
+  });
+
+  it('leaves Space alone on a button so the control still activates', () => {
+    openViewer();
+
+    const event = pressKey(control, ' ');
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('leaves Space alone on a link', () => {
+    openViewer();
+    const link = document.createElement('a');
+    link.href = '/location/banff';
+    document.body.append(link);
+
+    const event = pressKey(link, ' ');
+
+    expect(event.defaultPrevented).toBe(false);
+    link.remove();
+  });
+
+  it('still blocks Space on the page itself so the collection behind cannot scroll', () => {
+    openViewer();
+
+    const event = pressKey(document.body, ' ');
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('still blocks the other scrolling keys on the page', () => {
+    openViewer();
+
+    for (const key of ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End']) {
+      expect(pressKey(document.body, key).defaultPrevented).toBe(true);
+    }
+  });
+
+  it('keeps arrow-key navigation working while a control has focus', () => {
+    const { result } = openViewer();
+
+    pressKey(control, 'ArrowRight');
+    expect(result.current.fullScreenState?.currentIndex).toBe(2);
+
+    pressKey(control, 'ArrowLeft');
+    expect(result.current.fullScreenState?.currentIndex).toBe(1);
+  });
+
+  it('ignores keys entirely while the viewer is closed', () => {
+    renderHook(() => useFullScreenImage());
+
+    expect(pressKey(document.body, ' ').defaultPrevented).toBe(false);
+  });
+});

--- a/tests/types/GalleryFilter.test.ts
+++ b/tests/types/GalleryFilter.test.ts
@@ -87,4 +87,56 @@ describe('FilterState helpers', () => {
     toggleArrayFilter(state, u => updates.push(u), 'selectedPeople', 'Ana');
     expect(updates).toEqual([{ selectedPeople: ['Bo'] }]);
   });
+
+  it('toggleArrayFilter selects the first date into an empty dimension', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedDates', '2026-07-20');
+    expect(updates).toEqual([{ selectedDates: ['2026-07-20'] }]);
+  });
+
+  it('toggleArrayFilter switches the date instead of accumulating a second one', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedDates: ['2026-07-20'] };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedDates', '2026-07-22');
+    expect(updates).toEqual([{ selectedDates: ['2026-07-22'] }]);
+  });
+
+  it('toggleArrayFilter clears the date when the chosen one is clicked again', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedDates: ['2026-07-20'] };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedDates', '2026-07-20');
+    expect(updates).toEqual([{ selectedDates: [] }]);
+  });
+
+  it('toggleArrayFilter switches the lens instead of accumulating a second one', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedLenses: ['35mm f/1.4'] };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedLenses', '85mm f/1.8');
+    expect(updates).toEqual([{ selectedLenses: ['85mm f/1.8'] }]);
+  });
+
+  it('toggleArrayFilter clears the lens when the chosen one is clicked again', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedLenses: ['35mm f/1.4'] };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedLenses', '35mm f/1.4');
+    expect(updates).toEqual([{ selectedLenses: [] }]);
+  });
+
+  it('toggleArrayFilter still accumulates the non-exclusive dimensions', () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, selectedCameras: ['Leica M6'] };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedCameras', 'Nikon F3');
+    expect(updates).toEqual([{ selectedCameras: ['Leica M6', 'Nikon F3'] }]);
+  });
+
+  it('toggleArrayFilter narrows a multi-date URL seed down to the clicked day', () => {
+    const state: FilterState = {
+      ...INITIAL_FILTER_STATE,
+      selectedDates: ['2026-07-20', '2026-07-22'],
+    };
+    const updates: Partial<FilterState>[] = [];
+    toggleArrayFilter(state, u => updates.push(u), 'selectedDates', '2026-07-20');
+    expect(updates).toEqual([{ selectedDates: ['2026-07-20'] }]);
+  });
 });

--- a/tests/utils/contentLayoutWidthCostBaseline.test.ts
+++ b/tests/utils/contentLayoutWidthCostBaseline.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for `ProcessContentOptions.widthCostBaseline`.
+ *
+ * Width-cost scales with rating (`BASE_WEIGHT` 3★ 2.5, 4★ 3.5, 5★ 5.0), so a filter that changes
+ * the rating mix changes how many items fit the fixed row budget. Toggling "Highly Rated" took a
+ * real collection from ~5 photos per row to ~3 — every photo visibly resized while the photo-size
+ * control still read Medium. Passing the UNFILTERED mean as a baseline scales the budget to cancel
+ * that shift.
+ */
+import type { AnyContentModel } from '@/app/types/Content';
+import { processContentForDisplay, type RowWithPatternAndSizes } from '@/app/utils/contentLayout';
+import { getMeanWidthCost } from '@/app/utils/contentRatingUtils';
+import { createHorizontalImage } from '@/tests/fixtures/contentFixtures';
+
+const COMPONENT_WIDTH = 1400;
+const CHUNK_SIZE = 4;
+
+/** Photos per content row, ignoring any header row. */
+function itemsPerRow(rows: RowWithPatternAndSizes[]): number[] {
+  return rows.filter(row => row.rowType === 'content').map(row => row.items.length);
+}
+
+function layout(content: AnyContentModel[], widthCostBaseline?: number) {
+  return processContentForDisplay(content, COMPONENT_WIDTH, CHUNK_SIZE, {
+    targetAR: 1.5,
+    widthCostBaseline,
+  });
+}
+
+/** A typical mixed-rating collection: mostly 3★ with a few standouts. */
+const mixedCollection: AnyContentModel[] = [
+  ...Array.from({ length: 12 }, (_, i) => createHorizontalImage(i + 1, 3)),
+  ...Array.from({ length: 4 }, (_, i) => createHorizontalImage(i + 100, 5)),
+  ...Array.from({ length: 4 }, (_, i) => createHorizontalImage(i + 200, 4)),
+];
+
+/** What "Highly Rated" leaves behind: the 4★ and 5★ images only. */
+const highlyRatedOnly = mixedCollection.filter(
+  (item): item is ReturnType<typeof createHorizontalImage> =>
+    'rating' in item && typeof item.rating === 'number' && item.rating >= 4
+);
+
+describe('widthCostBaseline', () => {
+  it('leaves an unfiltered layout byte-identical when the baseline is its own mean', () => {
+    // The escape hatch that makes this safe to add globally: baseline === current mean -> factor 1.
+    const withoutBaseline = layout(mixedCollection);
+    const withOwnBaseline = layout(mixedCollection, getMeanWidthCost(mixedCollection));
+    expect(itemsPerRow(withOwnBaseline)).toEqual(itemsPerRow(withoutBaseline));
+  });
+
+  it('holds photos-per-row steady when a filter removes the lower-rated images', () => {
+    const unfiltered = itemsPerRow(layout(mixedCollection));
+    const baseline = getMeanWidthCost(mixedCollection);
+    const filtered = itemsPerRow(layout(highlyRatedOnly, baseline));
+
+    const mean = (counts: number[]) => counts.reduce((a, b) => a + b, 0) / counts.length;
+    // Within one photo per row. Not exact equality: rows are packed greedily against an integer
+    // budget, so the tail row and rounding still move by an item.
+    expect(Math.abs(mean(filtered) - mean(unfiltered))).toBeLessThan(1);
+  });
+
+  it('without a baseline, the same filter visibly shrinks the row — the bug this prevents', () => {
+    const unfiltered = itemsPerRow(layout(mixedCollection));
+    const filtered = itemsPerRow(layout(highlyRatedOnly));
+
+    const mean = (counts: number[]) => counts.reduce((a, b) => a + b, 0) / counts.length;
+    expect(mean(filtered)).toBeLessThan(mean(unfiltered));
+  });
+
+  it('ignores a zero or absent baseline rather than dividing by it', () => {
+    expect(itemsPerRow(layout(mixedCollection, 0))).toEqual(itemsPerRow(layout(mixedCollection)));
+  });
+
+  it('keeps relative sizing inside a row — a 5★ still outweighs a 3★ beside it', () => {
+    // Normalisation scales the row BUDGET, never an individual item's cost.
+    const three = createHorizontalImage(1, 3);
+    const five = createHorizontalImage(2, 5);
+    expect(getMeanWidthCost([five])).toBeGreaterThan(getMeanWidthCost([three]));
+  });
+});
+
+describe('getMeanWidthCost', () => {
+  it('returns 0 for an empty set so callers can treat it as "no baseline"', () => {
+    expect(getMeanWidthCost([])).toBe(0);
+  });
+
+  it('rises as the rating mix rises', () => {
+    const allThree = Array.from({ length: 4 }, (_, i) => createHorizontalImage(i, 3));
+    const allFive = Array.from({ length: 4 }, (_, i) => createHorizontalImage(i, 5));
+    expect(getMeanWidthCost(allFive)).toBeGreaterThan(getMeanWidthCost(allThree));
+  });
+});


### PR DESCRIPTION
Consolidates the collection filter bar, adds a visitor-facing photo-size control, and fixes three layout bugs that made filtering and mobile feel unstable.

## Filters

- **Dates and lens are single-select**, enforced at the type source so flat chips, the dropdown fallback, and tag-click handlers all inherit it. Multi-select was meaningless in both directions: two dates or two disjoint sets only widen, and two lenses AND together to match nothing.
- **Lens availability is derived from content that ignores the active lens.** It was previously derived from images that already reflected it, so picking one lens disabled every other lens chip — single-select alone could not switch. Dates already had this carve-out; it is now generalized.
- **Toolbar is two slots on one non-wrapping row** — filter controls that wrap internally, and a photo-size control pinned top-right. A single flat wrapping container let the size control land on an arbitrary line, reading as though it belonged to whichever filters wrapped beside it.

The size control is labelled by **photo size**, not density. Size runs inverse to the density number, so exposing the raw value would invert the expectation.

## Layout stability

**Filtering no longer resizes every photo.** Width-cost is `sqrt(P x AR)` and `P` scales with rating, so "Highly Rated" raised every item's cost against a fixed row budget — measured on a 1440px collection, photos-per-row went 5-6 → 3-4 and sample width 368px → 605px, with the density control untouched.

`processContentForDisplay` now accepts a `widthCostBaseline` (mean width-cost of the unfiltered content) and scales the row budget by `mean(filtered) / baseline`. Relative sizing inside a row is unchanged — a 5-star still outweighs a 3-star beside it. Omitting the option leaves the factor at exactly 1, so unfiltered layout is bit-for-bit identical; that is why the density calibration test is unchanged rather than re-baselined.

**Admin hub is single-column on mobile again.** The hub renders through the shared pipeline, whose mobile row budget is calibrated for photos, so at 430px the users and messages panels landed at 212px each and portrait-covered tiles paired up. Reproduced headlessly:

```
row 0: [Users 212, Messages 212]
row 1: [Home (Preview) 276, All Collections 147]
row 2: [All Images 147, Client Galleries 276]
```

The pre-pipeline `AdminHubGrid` was explicitly `grid-template-columns: 1fr` on mobile; `mobileChunkSize={1}` restores that. Read only on the mobile branch, so desktop is untouched.

## Also

- Fullscreen viewer keyboard handling, immersive toggle, and a11y coverage; `extractAltText` exported so the grid and the viewer resolve alt identically.
- Dead color-token fallbacks replaced. `--color-surface-alt` fell back to `--color-surface`, removed in an earlier sweep, and `--color-fg-muted` to `--color-fg` — both chains resolved to nothing, which is the real mechanism behind the transparent admin panels.
- `docs/browser-diagnostics.md` — console snippets that each return one object, so a diagnosis takes one paste instead of a round-trip. Includes the discriminator between real page overflow and a DevTools device-frame pan, and a note that `body{overflow-x:clip}` clamps `scrollWidth`, making it an untrustworthy overflow oracle here.

## Verification

ESLint, Stylelint, and `tsc --noEmit` all clean. 184 suites / 2906 tests pass.

Note: the `/explore` tag-link test had codified the bug it covered — asserting the broken href — so the suite was green while the feature was broken. Corrected here.

## Not addressed

Every collection page logs a `setState`-in-render warning from `useFilterUrlState`'s `router.replace`. Confirmed pre-existing (it fires on a clean load where this branch's code path returns early) and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)