### PR TITLE
feat(manage): put cover selection on the cover image itself

### DIFF
--- a/app/components/Content/CollectionContentRenderer.tsx
+++ b/app/components/Content/CollectionContentRenderer.tsx
@@ -25,6 +25,7 @@ import {
   checkImageVisibility,
   createContentClickHandler,
 } from '@/app/utils/contentComponentHandlers';
+import { COVER_IMAGE_CONTENT_ID } from '@/app/utils/contentLayout';
 import {
   buildParallaxWrapperClassName,
   buildWrapperClassName,
@@ -33,12 +34,6 @@ import {
 import { slugify } from '@/app/utils/locationUtils';
 import { logger } from '@/app/utils/logger';
 import { manageHref } from '@/app/utils/manageUrl';
-
-/**
- * Sentinel content id used by createCoverImageBlock (app/utils/contentLayout.ts) for the
- * header cover image. Lets the renderer single out the cover without a new prop.
- */
-const COVER_IMAGE_CONTENT_ID = -1;
 
 import { getClickEligibility, toCollectionDimensions } from './collectionContentRendererUtils';
 import cbStyles from './ContentComponent.module.scss';
@@ -203,6 +198,23 @@ export default function CollectionContentRenderer({
     [collectionSlug, router]
   );
 
+  // Manage-side twin of the shortcut above, pinned to the same corner of the same cover block.
+  // The two never coexist: the shortcut needs the public view, this needs the inline-edit surface,
+  // which only EditModeLayer mounts. A null `onTogglePickCover` means the active manage mode
+  // already owns grid clicks (reorder, select, pick-date), so the affordance stands down.
+  const togglePickCover = inlineEdit?.onTogglePickCover ?? null;
+  const isPickingCover = inlineEdit?.isPickingCover ?? false;
+  const showCoverPickToggle =
+    contentType === 'IMAGE' && contentId === COVER_IMAGE_CONTENT_ID && togglePickCover !== null;
+
+  const handleCoverPickClick = useCallback(
+    (event: { stopPropagation: () => void }) => {
+      event.stopPropagation();
+      togglePickCover?.();
+    },
+    [togglePickCover]
+  );
+
   if (contentType === 'TEXT') {
     // The header rail carries more than text: the filter toolbar and the client-gallery download
     // row mount into it. A collection with no metadata (no date, locations, description or
@@ -251,6 +263,19 @@ export default function CollectionContentRenderer({
                   ariaLabel="Collection title"
                 />
               </div>
+            )}
+            {/* A cover-less collection lays out a text-only header, so there is no cover to hover
+                — the rail is the only place left to start the pick from. */}
+            {inlineEdit && !inlineEdit.hasCover && togglePickCover && (
+              <button
+                type="button"
+                className={cbStyles.metadataCoverPick}
+                onClick={togglePickCover}
+                aria-pressed={isPickingCover}
+              >
+                <span aria-hidden="true">{isPickingCover ? '✕' : '🖼️'}</span>
+                {isPickingCover ? 'Cancel cover selection' : 'Set cover image'}
+              </button>
             )}
             {(dateItem || locationItem || inlineEdit) && (
               <div className={cbStyles.metadataHeaderRow}>
@@ -711,12 +736,20 @@ export default function CollectionContentRenderer({
         {imageWrapperContent}
       </div>
       {showCoverUpdateShortcut && (
+        <button type="button" className={cbStyles.coverAction} onClick={handleCoverUpdateClick}>
+          Update
+        </button>
+      )}
+      {showCoverPickToggle && (
         <button
           type="button"
-          className={cbStyles.coverUpdateShortcut}
-          onClick={handleCoverUpdateClick}
+          className={cbStyles.coverAction}
+          onClick={handleCoverPickClick}
+          aria-pressed={isPickingCover}
+          aria-label={isPickingCover ? 'Cancel cover selection' : 'Change cover image'}
         >
-          Update
+          <span aria-hidden="true">{isPickingCover ? '✕' : '🖼️'}</span>
+          {isPickingCover ? 'Cancel' : 'Cover'}
         </button>
       )}
       {!enableParallax && (

--- a/app/components/Content/ContentComponent.module.scss
+++ b/app/components/Content/ContentComponent.module.scss
@@ -398,10 +398,12 @@
   }
 }
 
-/* Localhost-only "Update" shortcut pinned to the header cover image's bottom-right corner.
-   Hidden until the cover is hovered (or the button is keyboard-focused). Height matches the
-   EditBar/FilterToolbar control row (.barCell min-height: 44px). */
-.coverUpdateShortcut {
+/* Admin-only action pinned to the header cover image's bottom-right corner: "Update" on the
+   public view (jumps to manage), the cover picker toggle on the manage grid. Never both at once.
+   Resting at low opacity keeps it discoverable without competing with the photograph; hovering
+   the cover brings it to full strength. Height matches the EditBar/FilterToolbar control row
+   (.barCell min-height: 44px). */
+.coverAction {
   position: absolute;
   right: var(--space-2);
   bottom: var(--space-2);
@@ -409,6 +411,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: var(--space-1);
   min-height: 44px;
   padding: 0 var(--space-4);
   font-family: inherit;
@@ -419,14 +422,14 @@
   border: none;
   border-radius: var(--radius-1);
   cursor: pointer;
-  opacity: 0;
+  opacity: 0.4;
   transition:
     opacity var(--duration-fast) var(--ease-standard),
     background-color var(--duration-fast) var(--ease-standard);
 
   &:hover {
     background: var(--color-fg);
-    opacity: 0.95;
+    opacity: 1;
   }
 
   &:focus-visible {
@@ -434,12 +437,23 @@
     outline: 2px solid var(--color-accent);
     outline-offset: 2px;
   }
+
+  &[aria-pressed='true'] {
+    opacity: 1;
+  }
 }
 
-/* Reveal the shortcut when the cover wrapper is hovered. The cover renders in the parallax
+/* Strengthen the action when the cover wrapper is hovered. The cover renders in the parallax
    wrapper div, which carries the data-parallax-container attribute. */
-[data-parallax-container]:hover .coverUpdateShortcut {
+[data-parallax-container]:hover .coverAction {
   opacity: 0.95;
+}
+
+/* Touch pointers have no hover state to reveal the affordance, so hold it at full strength. */
+@media (hover: none) {
+  .coverAction {
+    opacity: 0.95;
+  }
 }
 
 /* ===================== Metadata Block ===================== */
@@ -466,6 +480,40 @@
 .metadataTitleRow {
   display: flex;
   width: 100%;
+}
+
+/* Cover-pick entry point in the metadata rail. Only rendered while on-page editing a collection
+   that has no cover yet, where no cover block exists to hang the corner action off. */
+.metadataCoverPick {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: var(--space-1);
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-fg);
+  background: none;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+
+  &:hover {
+    border-color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  &[aria-pressed='true'] {
+    border-style: solid;
+    border-color: var(--color-fg);
+  }
 }
 
 .metadataTitle {

--- a/app/components/ContentCollection/edit/EditModeLayer.module.scss
+++ b/app/components/ContentCollection/edit/EditModeLayer.module.scss
@@ -20,6 +20,45 @@
   text-align: center;
 }
 
+/* Cover candidates that are NOT on the grid — images belonging to this collection's children.
+   Rides inside the pick-mode hint banner so both arms of the candidate union stay clickable
+   from the same surface. */
+.coverCandidateStrip {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: center;
+  max-width: 100%;
+  padding-top: var(--space-2);
+  overflow-x: auto;
+}
+
+.coverCandidate {
+  flex: 0 0 auto;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background: none;
+  cursor: pointer;
+  overflow: hidden;
+  line-height: 0;
+
+  &:hover {
+    border-color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  img {
+    display: block;
+    width: 96px;
+    height: 64px;
+    object-fit: cover;
+  }
+}
+
 .errorBanner {
   position: fixed;
   inset-inline: 0;

--- a/app/components/ContentCollection/edit/EditModeLayer.tsx
+++ b/app/components/ContentCollection/edit/EditModeLayer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import {
   type Dispatch,
@@ -210,15 +211,44 @@ export default function EditModeLayer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edit.enterEdit, edit.setEditTab]);
 
+  const isPickingCover = edit.manageMode === 'pick-cover';
+
+  const handleTogglePickCover = useCallback(() => {
+    edit.setIsSelectingCoverImage(!edit.isSelectingCoverImage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edit.isSelectingCoverImage, edit.setIsSelectingCoverImage]);
+
+  // Withheld from the modes that already claim grid clicks for themselves, and until the admin
+  // DTO lands — the pick writes straight through to the API, so it needs the loaded collection.
+  const canPickCover =
+    editReady && (isPickingCover || edit.manageMode === 'browse' || edit.manageMode === 'edit');
+
   const inlineEditValue = useMemo<InlineEditContextValue>(
     () => ({
       title: edit.updateData.title ?? '',
       description: edit.updateData.description ?? '',
       onCommitField: handleCommitField,
       onEditLocation: handleEditLocation,
+      onTogglePickCover: canPickCover ? handleTogglePickCover : null,
+      isPickingCover,
+      hasCover: liveCollection.coverImage != null,
     }),
-    [edit.updateData.title, edit.updateData.description, handleCommitField, handleEditLocation]
+    [
+      edit.updateData.title,
+      edit.updateData.description,
+      handleCommitField,
+      handleEditLocation,
+      canPickCover,
+      handleTogglePickCover,
+      isPickingCover,
+      liveCollection.coverImage,
+    ]
   );
+
+  // Only the child-collection arm of the cover-candidate union (D3) needs a picker of its own:
+  // the collection's own images are on the grid, where pick mode already makes them clickable,
+  // but a child's images are represented there only by the child's card.
+  const childCoverCandidates = edit.childCollectionImages ?? [];
 
   const grid = (
     <ContentBlockWithFullScreen
@@ -275,6 +305,27 @@ export default function EditModeLayer({
       {edit.manageMode === 'pick-date' && (
         <div className={styles.hintBanner} role="status">
           Click an image to copy its capture date.
+        </div>
+      )}
+
+      {isPickingCover && (
+        <div className={styles.hintBanner} role="status">
+          <span>Click any image to make it the cover.</span>
+          {childCoverCandidates.length > 0 && (
+            <div className={styles.coverCandidateStrip}>
+              {childCoverCandidates.map(img => (
+                <button
+                  type="button"
+                  key={img.id}
+                  className={styles.coverCandidate}
+                  onClick={() => edit.handleCoverImageClick(img.id)}
+                  aria-label={`Set ${img.title || 'image'} as cover`}
+                >
+                  <Image src={img.imageUrl} alt={img.title || ''} width={96} height={64} />
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/app/components/ContentCollection/edit/InlineEditContext.tsx
+++ b/app/components/ContentCollection/edit/InlineEditContext.tsx
@@ -14,6 +14,19 @@ export interface InlineEditContextValue {
   onCommitField: (field: InlineEditField, value: string) => void;
   /** Open the location picker so locations can be edited. */
   onEditLocation: () => void;
+  /**
+   * Enter or leave cover-pick mode, where a click on any grid image commits it as the cover.
+   * Null when the active manage mode already owns grid clicks (reorder, select, pick-date), which
+   * is what gates the affordance — the renderer has no other view of the manage state machine.
+   */
+  onTogglePickCover: (() => void) | null;
+  /** True while cover-pick mode is active; flips the affordance to its cancel label. */
+  isPickingCover: boolean;
+  /**
+   * Whether the collection has a cover image. False means no cover block is laid out at all, so
+   * the metadata rail — not the (absent) cover — has to carry the entry point into cover-pick.
+   */
+  hasCover: boolean;
 }
 
 const InlineEditContext = createContext<InlineEditContextValue | null>(null);

--- a/app/components/ContentCollection/edit/hooks/useImageClickHandler.ts
+++ b/app/components/ContentCollection/edit/hooks/useImageClickHandler.ts
@@ -9,6 +9,7 @@ import {
   type ContentGifModel,
   type ContentImageModel,
 } from '@/app/types/Content';
+import { COVER_IMAGE_CONTENT_ID } from '@/app/utils/contentLayout';
 import { manageHref } from '@/app/utils/manageUrl';
 
 import { handleCollectionNavigation, handleSingleImageEdit } from '../collectionEditUtils';
@@ -51,6 +52,10 @@ export function useImageClickHandler({
       }
 
       if (isSelectingCoverImage) {
+        // The header cover block is a synthetic id, not a content row, so it is never a valid
+        // pick — swallow the click rather than let it fail validation and raise an error banner.
+        // Its own hover affordance is what cancels the pick.
+        if (imageId === COVER_IMAGE_CONTENT_ID) return;
         handleCoverImageClick(imageId);
         return;
       }

--- a/app/components/ContentCollection/edit/sections/InfoTab.module.scss
+++ b/app/components/ContentCollection/edit/sections/InfoTab.module.scss
@@ -104,17 +104,6 @@
   }
 }
 
-.inlineHalfRow {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-3);
-  align-items: start;
-
-  > * {
-    min-width: 0;
-  }
-}
-
 .actionRow {
   display: flex;
   flex-wrap: wrap;
@@ -125,88 +114,4 @@
   margin: 0;
   font-size: var(--text-sm);
   color: var(--color-on-surface-muted);
-}
-
-.coverButton {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-  width: 100%;
-  height: calc(var(--text-md) * 1.5 + var(--space-2) * 2 + 2px);
-  padding: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-1);
-  background-color: var(--color-bg);
-  color: var(--color-on-surface-muted);
-  font-family: inherit;
-  font-size: var(--text-md);
-  cursor: pointer;
-  overflow: hidden;
-
-  &:hover {
-    border-color: var(--color-fg);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 2px;
-    border-color: var(--color-fg);
-  }
-}
-
-.coverButtonActive {
-  border-color: var(--color-fg);
-}
-
-.coverButtonPlaceholder {
-  font-size: var(--text-md);
-}
-
-.coverPickerGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
-  gap: var(--space-2);
-}
-
-.coverPickerItem {
-  padding: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-1);
-  background: none;
-  cursor: pointer;
-  overflow: hidden;
-  aspect-ratio: 3 / 2;
-
-  &:hover {
-    border-color: var(--color-fg);
-  }
-
-  &:focus-visible {
-    outline: var(--focus-ring);
-    outline-offset: 2px;
-  }
-
-  img {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-}
-
-.checkboxRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-5);
-}
-
-.checkboxLabel {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  cursor: pointer;
-  font-size: var(--text-sm);
-  color: var(--color-on-surface);
 }

--- a/app/components/ContentCollection/edit/sections/InfoTab.tsx
+++ b/app/components/ContentCollection/edit/sections/InfoTab.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import Image from 'next/image';
-
 import {
   LOCATION_ADD_NEW_FIELDS,
   PERSON_ADD_NEW_FIELDS,
@@ -18,8 +16,6 @@ import {
   COLLECTION_VISIBILITY_LABELS,
   CollectionVisibility,
 } from '@/app/types/CollectionVisibility';
-import { type ContentImageModel } from '@/app/types/Content';
-import { isContentImage } from '@/app/utils/contentTypeGuards';
 
 import { Button } from '../../../ui/Button/Button';
 import { type UseCollectionEditResult } from '../useCollectionEdit';
@@ -58,11 +54,6 @@ export function InfoTab({ edit }: InfoTabProps) {
     handleSaveAccess,
     handleClearPassword,
     isParent,
-    isSelectingCoverImage,
-    setIsSelectingCoverImage,
-    handleCoverImageClick,
-    displayedCoverImage,
-    childCollectionImages,
   } = edit;
 
   const collection = currentState?.collection;
@@ -77,14 +68,6 @@ export function InfoTab({ edit }: InfoTabProps) {
     updateData.collectionEndDate &&
     updateData.collectionEndDate < updateData.collectionDate
   );
-
-  // UNION, not XOR (D3): a collection may hold its own images AND child-collection refs at once.
-  // Mirrors the pool useCoverImageSelection validates the pick against. Deduped by id so an image
-  // present on both sides does not produce a duplicate React key in the picker grid.
-  const coverCandidates: ContentImageModel[] = [
-    ...(collection?.content ?? []).filter(isContentImage),
-    ...(childCollectionImages ?? []),
-  ].filter((img, index, all) => all.findIndex(candidate => candidate.id === img.id) === index);
 
   /**
    * The two stored discriminators are mutually exclusive (the backend rejects both true), so
@@ -217,79 +200,21 @@ export function InfoTab({ edit }: InfoTabProps) {
         emptyText="No locations set"
       />
 
-      <div className={styles.inlineHalfRow}>
-        <div>
-          <Field label="Visibility" htmlFor="edit-sheet-visibility">
-            <Select
-              id="edit-sheet-visibility"
-              value={updateData.visibility ?? CollectionVisibility.HIDDEN}
-              onChange={e => setUpdateField('visibility', e.target.value as CollectionVisibility)}
-            >
-              {Object.values(CollectionVisibility).map(v => (
-                <option key={v} value={v}>
-                  {COLLECTION_VISIBILITY_LABELS[v]}
-                </option>
-              ))}
-            </Select>
-          </Field>
-        </div>
-
-        <div>
-          <Field label="Cover image" htmlFor="edit-sheet-cover">
-            <button
-              type="button"
-              id="edit-sheet-cover"
-              className={`${styles.coverButton} ${
-                isSelectingCoverImage ? styles.coverButtonActive : ''
-              }`}
-              onClick={() => setIsSelectingCoverImage(!isSelectingCoverImage)}
-              aria-pressed={isSelectingCoverImage}
-              aria-label={displayedCoverImage ? 'Change cover image' : 'Set cover image'}
-            >
-              {displayedCoverImage ? (
-                <Image
-                  src={displayedCoverImage.imageUrl}
-                  alt=""
-                  fill
-                  sizes="200px"
-                  style={{ objectFit: 'cover' }}
-                  unoptimized
-                />
-              ) : (
-                <span className={styles.coverButtonPlaceholder}>Select</span>
-              )}
-            </button>
-          </Field>
-        </div>
-      </div>
-
-      {isSelectingCoverImage &&
-        (coverCandidates.length > 0 ? (
-          <div className={styles.coverPickerGrid}>
-            {coverCandidates.map(img => (
-              <button
-                type="button"
-                key={img.id}
-                className={styles.coverPickerItem}
-                onClick={() => handleCoverImageClick(img.id)}
-                aria-label={`Set ${img.title || 'image'} as cover`}
-              >
-                <Image
-                  src={img.imageUrl}
-                  alt={img.title || ''}
-                  width={120}
-                  height={90}
-                  unoptimized
-                />
-              </button>
+      <div className={styles.formGroup}>
+        <Field label="Visibility" htmlFor="edit-sheet-visibility">
+          <Select
+            id="edit-sheet-visibility"
+            value={updateData.visibility ?? CollectionVisibility.HIDDEN}
+            onChange={e => setUpdateField('visibility', e.target.value as CollectionVisibility)}
+          >
+            {Object.values(CollectionVisibility).map(v => (
+              <option key={v} value={v}>
+                {COLLECTION_VISIBILITY_LABELS[v]}
+              </option>
             ))}
-          </div>
-        ) : (
-          <p className={styles.fieldHint}>
-            Add images to this collection — or a child collection that has images — to choose a
-            cover.
-          </p>
-        ))}
+          </Select>
+        </Field>
+      </div>
 
       <div className={styles.formGroup}>
         <label className={styles.formLabel}>Tags</label>

--- a/app/components/ContentCollection/edit/useCollectionEdit.tsx
+++ b/app/components/ContentCollection/edit/useCollectionEdit.tsx
@@ -135,7 +135,14 @@ async function inheritLocationsToContent(
   return true;
 }
 
-export type ManageMode = 'browse' | 'select' | 'reorder' | 'add' | 'edit' | 'pick-date';
+export type ManageMode =
+  | 'browse'
+  | 'select'
+  | 'reorder'
+  | 'add'
+  | 'edit'
+  | 'pick-date'
+  | 'pick-cover';
 export type CollectionEditTab = 'info' | 'structure';
 
 export interface UseCollectionEditParams {
@@ -167,17 +174,19 @@ export interface UseCollectionEditResult {
     onCancelImageMove: (contentId: number) => void;
     pickedUpImageId: number | null;
   };
+  /** True while the grid is in cover-pick mode; surfaces as `manageMode === 'pick-cover'`. */
   isSelectingCoverImage: boolean;
   setIsSelectingCoverImage: (value: boolean) => void;
+  /** Commits a cover pick immediately (no Save step) and leaves cover-pick mode. */
   handleCoverImageClick: (imageId: number) => void;
   justClickedImageId: number | null;
   currentCoverImageId?: number;
-  /** The collection's saved cover image, shown in the Edit sheet (cover changes save immediately). */
-  displayedCoverImage: ContentImageModel | null | undefined;
   /**
    * Images sourced from this collection's child collections. Since D3 this is one ARM of the
    * cover-candidate union every collection picks from — the other being the collection's own
-   * images — not a parent-only substitute for them.
+   * images — not a parent-only substitute for them. Only this arm needs a picker of its own:
+   * the collection's own images are already on the grid, where cover-pick mode makes them
+   * clickable, while child-collection images are represented there only by their parent card.
    */
   childCollectionImages?: ContentImageModel[] | null;
   /**
@@ -603,6 +612,10 @@ export function useCollectionEdit({
     if (captureDateTargetId !== null) return 'pick-date';
     if (reorderState.active) return 'reorder';
     if (isMultiSelectMode) return 'select';
+    // Outranks 'edit' so the sheet steps aside for the grid while a cover is being picked. The
+    // sheet's own open flag is untouched, so cancelling the pick lands back on the sheet with the
+    // edit buffer intact — entering the pick must never discard unsaved field edits.
+    if (isSelectingCoverImage) return 'pick-cover';
     if (isEditSheetOpen) return 'edit';
     if (isAddMode) return 'add';
     return 'browse';
@@ -689,8 +702,6 @@ export function useCollectionEdit({
       isParentCollection({ content: collection.content, hasChildren: currentState?.hasChildren }),
     [collection.content, currentState?.hasChildren]
   );
-
-  const displayedCoverImage = collection.coverImage ?? null;
 
   const handleCreateNewTextBlock = useCallback(() => {
     if (!collection) return;
@@ -1434,6 +1445,12 @@ export function useCollectionEdit({
       return [{ key: 'cancel', label: 'Cancel', onClick: resetToBrowse }];
     }
 
+    // Same shape as pick-date, but cancelling only drops the pick — resetToBrowse would also
+    // close a sheet the pick was launched from and reseed its buffer.
+    if (manageMode === 'pick-cover') {
+      return [{ key: 'cancel', label: 'Cancel', onClick: () => setIsSelectingCoverImage(false) }];
+    }
+
     if (manageMode === 'reorder') {
       return [
         {
@@ -1585,6 +1602,7 @@ export function useCollectionEdit({
     selectedIds,
     handleBulkEdit,
     handleCoverImageClick,
+    setIsSelectingCoverImage,
     resetToBrowse,
     handleBulkRemove,
     handleCreateNewTextBlock,
@@ -1627,7 +1645,6 @@ export function useCollectionEdit({
     handleCoverImageClick,
     justClickedImageId,
     currentCoverImageId: collection.coverImage?.id,
-    displayedCoverImage,
     childCollectionImages: currentState?.childCollectionImages,
     isParent,
 

--- a/app/utils/contentLayout.ts
+++ b/app/utils/contentLayout.ts
@@ -25,6 +25,14 @@ import { calculateSizesFromBoxTree } from '@/app/utils/rowStructureAlgorithm';
  * Direct processing without complex normalization - works with proper Content types
  */
 
+/**
+ * Sentinel content id carried by the synthetic header cover block (see `createCoverImageBlock`).
+ * It is not a content-table row, so consumers must single it out before treating it as real
+ * content — the renderer pins the cover affordances to it, and the manage grid's click handler
+ * excludes it from being its own cover candidate.
+ */
+export const COVER_IMAGE_CONTENT_ID = -1;
+
 export interface CalculatedContentSize {
   content: AnyContentModel;
   width: number;
@@ -530,7 +538,7 @@ function createCoverImageBlock(collection: CollectionModel): ContentParallaxImag
   return {
     contentType: 'IMAGE',
     enableParallax: true,
-    id: -1,
+    id: COVER_IMAGE_CONTENT_ID,
     title: collection.title,
     imageUrl: coverImage.imageUrl,
     overlayText: collection.title,

--- a/tests/components/Content/CollectionContentRenderer.test.tsx
+++ b/tests/components/Content/CollectionContentRenderer.test.tsx
@@ -38,6 +38,17 @@ const adminPrincipal: MeResponse = {
   galleries: [],
 };
 
+/** Inert inline-edit surface; each test overrides only the fields it exercises. */
+const inlineEditBase: InlineEditContextValue = {
+  title: '',
+  description: '',
+  onCommitField: jest.fn(),
+  onEditLocation: jest.fn(),
+  onTogglePickCover: null,
+  isPickingCover: false,
+  hasCover: true,
+};
+
 const baseProps = {
   contentId: 42,
   className: 'imageSingle',
@@ -176,6 +187,7 @@ describe('CollectionContentRenderer — TEXT branch inline edit context', () => 
     const onCommitField = jest.fn();
     const onEditLocation = jest.fn();
     const ctx: InlineEditContextValue = {
+      ...inlineEditBase,
       title: 'My Trip',
       description: 'A trip writeup',
       onCommitField,
@@ -301,3 +313,109 @@ describe('CollectionContentRenderer — cover "Update" shortcut (isAdmin-gated)'
   });
 });
 
+describe('CollectionContentRenderer — cover-pick toggle on the manage grid', () => {
+  // Same sentinel-id cover block as above, but on the manage path (currentCollectionId set), so
+  // the public "Update" shortcut stands down and the inline-edit surface takes over.
+  const coverProps = {
+    contentId: -1,
+    className: 'imageSingle',
+    width: 600,
+    height: 400,
+    isMobile: false,
+    imageUrl: 'https://cdn.example.com/cover.jpg',
+    imageWidth: 600,
+    imageHeight: 400,
+    alt: 'Cover',
+    enableParallax: true,
+    contentType: 'IMAGE' as const,
+    overlayText: 'My Gallery',
+    collectionSlug: 'my-gallery',
+    currentCollectionId: 7,
+  };
+
+  function renderCover(ctx: Partial<InlineEditContextValue>, contentId = -1) {
+    render(
+      <InlineEditProvider value={{ ...inlineEditBase, ...ctx }}>
+        <CollectionContentRenderer {...coverProps} contentId={contentId} />
+      </InlineEditProvider>
+    );
+  }
+
+  beforeEach(() => {
+    mockUseMe.mockReturnValue(adminPrincipal);
+  });
+
+  it('renders the toggle on the cover block and fires it on click', () => {
+    const onTogglePickCover = jest.fn();
+    renderCover({ onTogglePickCover });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change cover image' }));
+    expect(onTogglePickCover).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips to a cancel affordance while a pick is in progress', () => {
+    renderCover({ onTogglePickCover: jest.fn(), isPickingCover: true });
+
+    const button = screen.getByRole('button', { name: 'Cancel cover selection' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByRole('button', { name: 'Change cover image' })).not.toBeInTheDocument();
+  });
+
+  it('stands down when the active manage mode owns grid clicks (null toggle)', () => {
+    renderCover({ onTogglePickCover: null });
+    expect(screen.queryByRole('button', { name: 'Change cover image' })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing on an ordinary content image — only the cover block carries it', () => {
+    renderCover({ onTogglePickCover: jest.fn() }, 123);
+    expect(screen.queryByRole('button', { name: 'Change cover image' })).not.toBeInTheDocument();
+  });
+
+  it('is absent on the public view, where no inline-edit surface is mounted', () => {
+    render(<CollectionContentRenderer {...coverProps} />);
+    expect(screen.queryByRole('button', { name: 'Change cover image' })).not.toBeInTheDocument();
+  });
+});
+
+describe('CollectionContentRenderer — cover-pick entry point for a coverless collection', () => {
+  const railProps = {
+    contentId: 42,
+    className: 'imageSingle',
+    width: 300,
+    height: 200,
+    isMobile: false,
+    imageUrl: '',
+    imageWidth: 300,
+    imageHeight: 200,
+    alt: 'metadata block',
+    enableParallax: false,
+    contentType: 'TEXT' as const,
+    textItems: [{ type: 'description' as const, value: 'A trip writeup' }],
+  };
+
+  function renderRail(ctx: Partial<InlineEditContextValue>) {
+    render(
+      <InlineEditProvider value={{ ...inlineEditBase, ...ctx }}>
+        <CollectionContentRenderer {...railProps} />
+      </InlineEditProvider>
+    );
+  }
+
+  it('offers "Set cover image" in the metadata rail when the collection has no cover', () => {
+    const onTogglePickCover = jest.fn();
+    renderRail({ hasCover: false, onTogglePickCover });
+
+    fireEvent.click(screen.getByRole('button', { name: /Set cover image/ }));
+    expect(onTogglePickCover).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds it once a cover exists — the cover block carries the toggle instead', () => {
+    renderRail({ hasCover: true, onTogglePickCover: jest.fn() });
+    expect(screen.queryByRole('button', { name: /Set cover image/ })).not.toBeInTheDocument();
+  });
+
+  it('withholds it when the active manage mode owns grid clicks (null toggle)', () => {
+    renderRail({ hasCover: false, onTogglePickCover: null });
+    expect(screen.queryByRole('button', { name: /Set cover image/ })).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/ContentCollection/CollectionEditSheet.test.tsx
+++ b/tests/components/ContentCollection/CollectionEditSheet.test.tsx
@@ -58,7 +58,9 @@ describe('CollectionEditSheet — InfoTab', () => {
 
   it('reflects the collection kind in the checkboxes', () => {
     render(
-      <CollectionEditSheet edit={makeEdit({ editTab: 'info', updateData: makeUpdateData({ isBlog: true }) })} />
+      <CollectionEditSheet
+        edit={makeEdit({ editTab: 'info', updateData: makeUpdateData({ isBlog: true }) })}
+      />
     );
     expect(screen.getByLabelText('Client gallery')).not.toBeChecked();
     expect(screen.getByLabelText('Blog')).toBeChecked();
@@ -245,13 +247,10 @@ describe('CollectionEditSheet — StructureTab', () => {
     expect(screen.getByLabelText(/Row Density/)).toBeInTheDocument();
   });
 
-  it('shows the cover button on the Info tab', () => {
-    render(<CollectionEditSheet edit={makeEdit({ editTab: 'info', isParent: false })} />);
-    expect(screen.getByRole('button', { name: /set cover image/i })).toBeInTheDocument();
-  });
-
-  it('does not show the cover button on the Structure tab', () => {
-    render(<CollectionEditSheet edit={makeEdit({ editTab: 'structure', isParent: false })} />);
+  // The cover picker moved out of the sheet and onto the grid, where the cover block itself is
+  // the affordance — see CollectionContentRenderer's cover-pick tests.
+  it.each(['info', 'structure'] as const)('carries no cover control on the %s tab', tab => {
+    render(<CollectionEditSheet edit={makeEdit({ editTab: tab, isParent: false })} />);
     expect(screen.queryByRole('button', { name: /cover image/i })).not.toBeInTheDocument();
   });
 });

--- a/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
+++ b/tests/components/ContentCollection/edit/sections/InfoTab.test.tsx
@@ -13,7 +13,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { InfoTab } from '@/app/components/ContentCollection/edit/sections/InfoTab';
 import { type CollectionUpdateRequest } from '@/app/types/Collection';
-import { makeEdit, makeState, makeUpdateData } from '@/tests/fixtures/collectionEditFixtures';
+import { makeEdit, makeUpdateData } from '@/tests/fixtures/collectionEditFixtures';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
@@ -100,70 +100,10 @@ describe('InfoTab — end-date input wiring', () => {
   });
 });
 
-describe('InfoTab — cover picker offers the union of own and child images (D3)', () => {
-  const ownImage = (id: number) => ({
-    id,
-    contentType: 'IMAGE' as const,
-    orderIndex: id,
-    imageUrl: `https://cdn.example/own-${id}.jpg`,
-    title: `Own ${id}`,
-    locations: [],
-  });
-
-  const childRef = (id: number) => ({
-    id,
-    contentType: 'COLLECTION' as const,
-    orderIndex: id,
-    slug: `child-${id}`,
-    referencedCollectionId: id * 10,
-  });
-
-  const childImage = (id: number) => ({
-    id,
-    contentType: 'IMAGE' as const,
-    orderIndex: id,
-    imageUrl: `https://cdn.example/child-${id}.jpg`,
-    title: `Child ${id}`,
-    locations: [],
-  });
-
-  function renderPicker() {
-    render(
-      <InfoTab
-        edit={makeEdit({
-          isParent: true,
-          isSelectingCoverImage: true,
-          currentState: makeState({
-            content: [ownImage(1), ownImage(2), childRef(90)],
-          }),
-          childCollectionImages: [childImage(500), ownImage(2)],
-        })}
-      />
-    );
-  }
-
-  it("offers the collection's own images even when it also holds a child reference", () => {
-    renderPicker();
-    expect(screen.getByRole('button', { name: 'Set Own 1 as cover' })).toBeInTheDocument();
-  });
-
-  it("offers the child collection's images too", () => {
-    renderPicker();
-    expect(screen.getByRole('button', { name: 'Set Child 500 as cover' })).toBeInTheDocument();
-  });
-
-  it('lists an image that is in both pools exactly once', () => {
-    renderPicker();
-    expect(screen.getAllByRole('button', { name: 'Set Own 2 as cover' })).toHaveLength(1);
-  });
-
-  it('never offers a non-image block as a cover candidate', () => {
-    renderPicker();
-    // childRef(90) carries no `title`, so if it slipped past the isContentImage filter it would
-    // render with the picker's fallback accessible name. Asserting on the slug would be vacuous:
-    // the slug never reaches the aria-label.
-    expect(screen.queryByRole('button', { name: 'Set image as cover' })).not.toBeInTheDocument();
-    // Own 1, Own 2 (deduped), Child 500 — the COLLECTION ref excluded.
-    expect(screen.getAllByRole('button', { name: /as cover$/ })).toHaveLength(3);
+describe('InfoTab — the cover picker has moved to the grid', () => {
+  it('no longer carries any cover control', () => {
+    renderInfoTab({});
+    expect(screen.queryByText('Cover image')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /cover/i })).not.toBeInTheDocument();
   });
 });

--- a/tests/fixtures/collectionEditFixtures.ts
+++ b/tests/fixtures/collectionEditFixtures.ts
@@ -14,7 +14,6 @@ import {
   type CollectionUpdateResponseDTO,
 } from '@/app/types/Collection';
 import { CollectionVisibility } from '@/app/types/CollectionVisibility';
-import { type ContentImageModel } from '@/app/types/Content';
 
 export function makeCollection(overrides: Partial<CollectionModel> = {}): CollectionModel {
   return {
@@ -124,7 +123,6 @@ export function makeEdit(
     setIsSelectingCoverImage: jest.fn(),
     handleCoverImageClick: jest.fn(),
     justClickedImageId: null,
-    displayedCoverImage: null as ContentImageModel | null,
     childCollectionImages: undefined,
 
     manageMode: 'edit',


### PR DESCRIPTION
## What

The cover picker lived in the Edit sheet, two clicks away from the thing it edits. It now lives on the manage grid, where the cover image *is* the control.

- A corner action on the header cover block rests at 40% opacity and comes to full strength when you hover the cover — `🖼️ Cover` to enter pick mode, `✕ Cancel` to leave. Touch pointers hold it visible, since they have no hover state to reveal it.
- Pick mode is a first-class manage mode (`pick-cover`), shaped like the existing `pick-date`: hint banner across the grid, Cancel-only EditBar, and a click on any grid image commits the cover immediately.
- It outranks `edit` in `deriveManageMode`, so a sheet open behind it steps aside without closing. Cancelling returns you to the sheet with unsaved field edits intact — which is why entering the pick deliberately does **not** call `resetToBrowse`.

## How

No new props thread the render chain. The affordance rides the existing `InlineEditContext`, which only `EditModeLayer` mounts — so its presence already means "manage mode, admin DTO loaded", and a null `onTogglePickCover` is what stands the button down during reorder / select / pick-date.

## Two gaps closed rather than shipped around

A straight removal would have broken two flows:

- **Cover-less collections** lay out a *text-only* header, so there is no cover to hover. The metadata rail carries a dashed `🖼️ Set cover image` button, shown only in that case.
- **Child-collection images** are the other arm of the D3 cover union and are not on the grid at all — only the child's card is. The pick-mode banner carries a scrollable strip of them, so parent collections can still pick a cover.

## Drive-by fix

Clicking the cover block *itself* during pick mode used to fail validation and raise an error banner — the sentinel id `-1` is not a content row. It is now swallowed, and the sentinel is a shared `COVER_IMAGE_CONTENT_ID` export instead of a magic number repeated across three files.

## Verification

- `tsc --noEmit` clean
- ESLint, Stylelint, Prettier clean
- **2911 tests pass across 184 suites**

New unit coverage for the toggle, the cancel state, the null-toggle stand-down, the non-cover-image case, the public-view absence, and all three rail-button states.

The union invariant guarded by the deleted InfoTab picker test is already held by `useCoverImageSelection.test.tsx`, which tests the write path rather than the picker UI.

**Not verified:** the hover/opacity feel. That is CSS-only and unasserted — worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
