### PR TITLE
Collaborator tier contract: /api/edit channel, rank-aware client gate, COLLABORATOR grants

### DIFF
--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -77,18 +77,19 @@ async function handle(req: NextRequest, context: { params: Promise<{ path: strin
   const pathParts = params.path || [];
   const targetUrl = buildTargetUrl(pathParts, req.nextUrl.search);
 
-  // Belt & suspenders: refuse anonymous admin API in production before forwarding.
-  // The backend `hasRole('ADMIN')` on the `ezac_session` cookie stays authoritative;
-  // this is a cheap early reject + defense in depth. `api/dev/**` is exempt (dev-only,
-  // @Profile-gated on the backend) and dev is unaffected (localhost admin has no login).
-  // The `startsWith('api/admin/')` match below is intentionally exact/case-sensitive
-  // (an odd-cased or bare `api/admin` path is not caught here) — that's acceptable
-  // because this check is NOT the real gate; the backend's `hasRole('ADMIN')`
-  // authorizes every request regardless of what this early check catches.
+  // Belt & suspenders: refuse anonymous admin/edit API in production before forwarding.
+  // The backend's own authorization (`hasRole('ADMIN')`, per-collection role checks on
+  // the `edit` surface) stays authoritative; this is a cheap early reject + defense in
+  // depth for both privileged surfaces. `api/dev/**` is exempt (dev-only, @Profile-gated
+  // on the backend) and dev is unaffected (localhost admin has no login).
+  // The `startsWith(...)` match below is intentionally exact/case-sensitive (an odd-cased
+  // or bare `api/admin`/`api/edit` path is not caught here) — that's acceptable because
+  // this check is NOT the real gate; the backend's own authorization authorizes every
+  // request regardless of what this early check catches.
   const resolvedPath = pathParts.join('/').replace(/^\/+/, '');
   if (
     process.env.NODE_ENV === 'production' &&
-    resolvedPath.startsWith('api/admin/') &&
+    (resolvedPath.startsWith('api/admin/') || resolvedPath.startsWith('api/edit/')) &&
     !req.cookies.get('ezac_session')?.value
   ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
+++ b/app/components/ContentCollection/edit/sections/CollectionRolesSection.tsx
@@ -149,6 +149,7 @@ export function CollectionRolesSection({
               >
                 <option value="GENERAL">General (view)</option>
                 <option value="CLIENT">Client (download/tag/star)</option>
+                <option value="COLLABORATOR">Collaborator (edit collection)</option>
               </select>
               <Button
                 variant="ghost"
@@ -193,6 +194,7 @@ export function CollectionRolesSection({
           >
             <option value="GENERAL">General</option>
             <option value="CLIENT">Client</option>
+            <option value="COLLABORATOR">Collaborator</option>
           </select>
           <Button variant="ghost" size="sm" onClick={onAddRole} disabled={!addRoleId}>
             Add
@@ -219,6 +221,7 @@ export function CollectionRolesSection({
         >
           <option value="GENERAL">General</option>
           <option value="CLIENT">Client</option>
+          <option value="COLLABORATOR">Collaborator</option>
         </select>
         <Button
           variant="ghost"

--- a/app/components/RolesPanel/RoleDetailView.tsx
+++ b/app/components/RolesPanel/RoleDetailView.tsx
@@ -204,6 +204,7 @@ export function RoleDetailView({ role, onDeleted }: RoleDetailViewProps) {
                 >
                   <option value="GENERAL">General (view)</option>
                   <option value="CLIENT">Client (download/tag/star)</option>
+                  <option value="COLLABORATOR">Collaborator (edit collection)</option>
                 </select>
                 <Button
                   variant="ghost"
@@ -238,6 +239,7 @@ export function RoleDetailView({ role, onDeleted }: RoleDetailViewProps) {
                 >
                   <option value="GENERAL">General</option>
                   <option value="CLIENT">Client</option>
+                  <option value="COLLABORATOR">Collaborator</option>
                 </select>
                 <Button variant="ghost" size="sm" onClick={onAddGrant} disabled={!addCollectionId}>
                   Add

--- a/app/lib/api/collections.ts
+++ b/app/lib/api/collections.ts
@@ -12,7 +12,6 @@ import {
   ApiError,
   fetchAdminDeleteApi,
   fetchAdminGetApi,
-  fetchAdminPatchJsonApi,
   fetchAdminPostJsonApi,
   fetchAdminPutJsonApi,
   fetchEditPatchJsonApi,

--- a/app/lib/api/collections.ts
+++ b/app/lib/api/collections.ts
@@ -15,6 +15,8 @@ import {
   fetchAdminPatchJsonApi,
   fetchAdminPostJsonApi,
   fetchAdminPutJsonApi,
+  fetchEditPatchJsonApi,
+  fetchEditPostJsonApi,
   fetchReadApi,
 } from '@/app/lib/api/core';
 import {
@@ -329,22 +331,22 @@ export async function getMetadata(): Promise<GeneralMetadataDTO | null> {
 }
 
 /**
- * PATCH /api/admin/collections/{id}/rating
+ * PATCH /api/edit/collections/{id}/rating
  * Set the rating for a collection. Pass `null` to clear.
  */
 export async function updateCollectionRating(id: number, rating: number | null): Promise<void> {
-  await fetchAdminPatchJsonApi<void>(`/collections/${id}/rating`, { rating });
+  await fetchEditPatchJsonApi<void>(`/collections/${id}/rating`, { rating });
 }
 
 /**
- * POST /api/admin/collections/{collectionId}/reorder
+ * POST /api/edit/collections/{collectionId}/reorder
  * Reorder content in a collection (supports all content types: IMAGE, COLLECTION, TEXT, GIF)
  */
 export async function reorderCollectionContent(
   collectionId: number,
   reorders: Array<{ contentId: number; newOrderIndex: number }>
 ): Promise<CollectionModel | null> {
-  return fetchAdminPostJsonApi<CollectionModel>(`/collections/${collectionId}/reorder`, {
+  return fetchEditPostJsonApi<CollectionModel>(`/collections/${collectionId}/reorder`, {
     reorders,
   });
 }

--- a/app/lib/api/core.ts
+++ b/app/lib/api/core.ts
@@ -4,6 +4,7 @@ import { logger } from '@/app/utils/logger';
 const READ = 'read';
 const WRITE = 'write';
 const ADMIN = 'admin';
+const EDIT = 'edit';
 
 /**
  * On the server, forward incoming browser cookies on outgoing fetches so that the backend
@@ -172,23 +173,30 @@ export async function fetchReadApi<T>(
   }
 }
 
+/** Maps a `fetchBase` endpoint type to its channel path segment. */
+const ENDPOINT_TYPE_TO_CHANNEL: Record<'write' | 'admin' | 'edit', string> = {
+  write: WRITE,
+  admin: ADMIN,
+  edit: EDIT,
+};
+
 /**
- * Base function for making API requests to write or admin endpoints
+ * Base function for making API requests to write, admin, or edit endpoints
  * Handles URL building, error handling, and response parsing
  *
- * @param endpointType - Type of endpoint ('write' or 'admin')
+ * @param endpointType - Type of endpoint ('write', 'admin', or 'edit')
  * @param endpoint - API endpoint path (without the base URL)
  * @param options - Fetch options
  * @returns The parsed response data
  * @throws ApiError if the request fails
  */
 const fetchBase = async <T>(
-  endpointType: 'write' | 'admin',
+  endpointType: 'write' | 'admin' | 'edit',
   endpoint: string,
   options: RequestInit
 ): Promise<T | null> => {
   try {
-    const url = buildSimpleApiUrl(endpointType === 'write' ? WRITE : ADMIN, endpoint);
+    const url = buildSimpleApiUrl(ENDPOINT_TYPE_TO_CHANNEL[endpointType], endpoint);
 
     // On the server, forward the inbound `ezac_session` cookie so the backend's
     // admin authorization (hasRole('ADMIN')) sees the acting admin's session on
@@ -308,6 +316,27 @@ export async function fetchAdminDeleteJsonApi<T>(
 ): Promise<T | null> {
   return await fetchBase<T>('admin', endpoint, {
     method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** POST JSON to the edit endpoint */
+export async function fetchEditPostJsonApi<T>(endpoint: string, body: unknown): Promise<T | null> {
+  return await fetchBase<T>('edit', endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** PATCH JSON to the edit endpoint */
+export async function fetchEditPatchJsonApi<T>(
+  endpoint: string,
+  body: unknown
+): Promise<T | null> {
+  return await fetchBase<T>('edit', endpoint, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });

--- a/app/types/Auth.ts
+++ b/app/types/Auth.ts
@@ -3,8 +3,11 @@
  * Source of truth: edens.zac.backend MeResponse / GalleryMembership.
  */
 
-/** Per-collection membership role. GENERAL = view-only; CLIENT = download + tag + star. */
-export type CollectionRole = 'GENERAL' | 'CLIENT';
+/**
+ * Per-collection membership role. GENERAL = view-only; CLIENT = download + tag + star;
+ * COLLABORATOR = client powers + curation edits.
+ */
+export type CollectionRole = 'GENERAL' | 'CLIENT' | 'COLLABORATOR';
 
 export interface GalleryMembership {
   collectionId: number;

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -1,8 +1,8 @@
 /**
  * Role-based access types — mirror the backend RBAC contract (AdminRoleController + the
  * reshaped `/api/admin/users/{id}/roles` membership endpoints). A user joins roles; a role holds
- * per-collection grants; effective access is the union across a user's roles, CLIENT beating
- * GENERAL.
+ * per-collection grants; effective access is the union across a user's roles, the highest rank
+ * winning (GENERAL < CLIENT < COLLABORATOR).
  */
 
 import { type CollectionRole } from '@/app/types/Auth';

--- a/app/types/Role.ts
+++ b/app/types/Role.ts
@@ -7,7 +7,10 @@
 
 import { type CollectionRole } from '@/app/types/Auth';
 
-/** Access a role grants on a collection. GENERAL = view-only; CLIENT = download + tag + star. */
+/**
+ * Access a role grants on a collection. GENERAL = view-only; CLIENT = download + tag + star;
+ * COLLABORATOR = client powers + curation edits.
+ */
 export type AccessLevel = CollectionRole;
 
 /** A role in the admin list (`GET /api/admin/roles`). */

--- a/app/utils/galleryAccess.ts
+++ b/app/utils/galleryAccess.ts
@@ -4,8 +4,20 @@
  * logged-in user is never admin. A CLIENT's per-collection powers come from `me.galleries`
  * (the role_collection grants surfaced by /api/auth/me).
  */
-import { type GalleryMembership, type MeResponse } from '@/app/types/Auth';
+import { type CollectionRole, type GalleryMembership, type MeResponse } from '@/app/types/Auth';
 import { type CollectionModel } from '@/app/types/Collection';
+
+/** Ladder order for per-collection roles; mirrors the backend AccessLevel ranks. */
+const ROLE_RANK: Record<CollectionRole, number> = {
+  GENERAL: 0,
+  CLIENT: 1,
+  COLLABORATOR: 2,
+};
+
+/** True when `role` grants at least `minimum`'s capabilities (rank comparison, not equality). */
+export function hasRoleAtLeast(role: CollectionRole | undefined, minimum: CollectionRole): boolean {
+  return role !== undefined && ROLE_RANK[role] >= ROLE_RANK[minimum];
+}
 
 /** The membership for a specific collection, or undefined. */
 export function findMembership(
@@ -17,7 +29,7 @@ export function findMembership(
 
 /**
  * True when the viewer may act as a client of this collection: admin (editMode) anywhere, or a
- * non-admin holding a CLIENT membership for the collection.
+ * non-admin holding a CLIENT-or-above membership for the collection.
  */
 export function isClientOfCollection(
   me: MeResponse | null,
@@ -25,7 +37,7 @@ export function isClientOfCollection(
   editMode: boolean
 ): boolean {
   if (editMode) return true;
-  return findMembership(me, collectionId)?.role === 'CLIENT';
+  return hasRoleAtLeast(findMembership(me, collectionId)?.role, 'CLIENT');
 }
 
 /**

--- a/tests/api/proxy/route.test.ts
+++ b/tests/api/proxy/route.test.ts
@@ -360,6 +360,49 @@ describe('Vercel BFF proxy /api/proxy/[...path] — anonymous admin API refusal 
     expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects an anonymous edit POST with 401 and does NOT forward', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/edit/collections/5/reorder', {
+      method: 'POST',
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ['api', 'edit', 'collections', '5', 'reorder'] }),
+    } as never);
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards an edit POST when the ezac_session cookie is present', async () => {
+    setProd();
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const req = new NextRequest('https://example.com/api/proxy/api/edit/collections/5/reorder', {
+      method: 'POST',
+      headers: {
+        cookie: 'ezac_session=abc123',
+        'content-type': 'application/json',
+        origin: 'https://example.com',
+      },
+      body: JSON.stringify({ reorders: [] }),
+    });
+    const res = await POST(req, {
+      params: Promise.resolve({ path: ['api', 'edit', 'collections', '5', 'reorder'] }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // The forwarded request carries the session cookie through to the backend.
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Headers).get('cookie')).toBe('ezac_session=abc123');
+  });
 });
 
 describe('Vercel BFF proxy /api/proxy/[...path] — real-IP header sanitization', () => {

--- a/tests/components/CollectionRolesSection.test.tsx
+++ b/tests/components/CollectionRolesSection.test.tsx
@@ -69,6 +69,22 @@ describe('CollectionRolesSection', () => {
     expect(screen.getByLabelText('Access level for ken@x.com')).toHaveValue('CLIENT');
   });
 
+  it('offers COLLABORATOR as a level option on the per-grant, add-grant, and create-grant selects', async () => {
+    await renderSection();
+
+    const grantSelect = await screen.findByLabelText('Access level for pnwer');
+    expect(within(grantSelect).getByRole('option', { name: 'Collaborator (edit collection)' }))
+      .toBeInTheDocument();
+
+    await screen.findByLabelText('Add a role');
+    const addLevelSelect = screen.getByLabelText('Access level for added role');
+    expect(within(addLevelSelect).getByRole('option', { name: 'Collaborator' })).toBeInTheDocument();
+
+    const createLevelSelect = screen.getByLabelText('Access level for created role');
+    expect(within(createLevelSelect).getByRole('option', { name: 'Collaborator' }))
+      .toBeInTheDocument();
+  });
+
   it('shows the empty state when no roles grant the collection', async () => {
     mockListCollectionRoles.mockResolvedValue([]);
     await renderSection();

--- a/tests/components/RolesPanel/RoleDetailView.test.tsx
+++ b/tests/components/RolesPanel/RoleDetailView.test.tsx
@@ -177,6 +177,25 @@ describe('RoleDetailView', () => {
     expect(within(select).queryByRole('option', { name: 'apple orchard' })).not.toBeInTheDocument();
   });
 
+  it('offers COLLABORATOR as a level option on both the per-grant and add-grant selects', async () => {
+    mockGetRole.mockResolvedValue({
+      ...BASE_DETAIL,
+      collections: [{ collectionId: 1, title: 'apple orchard', level: 'GENERAL' }],
+    });
+    mockGetCollections.mockResolvedValue([
+      makeCollection(1, 'apple orchard'),
+      makeCollection(2, 'Banff'),
+    ]);
+    await renderDetail();
+
+    const grantSelect = await screen.findByLabelText('Access level for apple orchard');
+    expect(within(grantSelect).getByRole('option', { name: 'Collaborator (edit collection)' }))
+      .toBeInTheDocument();
+
+    const addLevelSelect = screen.getByLabelText('Access level for the collection being added');
+    expect(within(addLevelSelect).getByRole('option', { name: 'Collaborator' })).toBeInTheDocument();
+  });
+
   it('confirms "Delete role", then calls onDeleted once the delete resolves', async () => {
     await renderDetail();
 

--- a/tests/lib/api/collections.test.ts
+++ b/tests/lib/api/collections.test.ts
@@ -8,12 +8,15 @@ import {
   createCollection as createCollectionApi,
   getCollectionsByLocation,
   parseCollectionArrayResponse,
+  reorderCollectionContent as reorderCollectionContentApi,
   saveCollectionFromTag,
   saveGalleryAccess,
   updateCollection as updateCollectionApi,
+  updateCollectionRating as updateCollectionRatingApi,
   validateClientGalleryAccess,
 } from '@/app/lib/api/collections';
 import { ApiError } from '@/app/lib/api/core';
+import * as core from '@/app/lib/api/core';
 import { type CollectionModel } from '@/app/types/Collection';
 import { CollectionVisibility } from '@/app/types/CollectionVisibility';
 
@@ -23,6 +26,15 @@ global.fetch = jest.fn();
 // Mock environment
 jest.mock('@/app/utils/environment', () => ({
   isLocalEnvironment: jest.fn(() => false),
+}));
+
+// Spy on the edit-channel wrappers while leaving every other core export (including
+// fetchAdminPostJsonApi/fetchAdminPatchJsonApi, used by the other functions under test in this
+// file) as the real implementation backed by the mocked global.fetch above.
+jest.mock('@/app/lib/api/core', () => ({
+  ...jest.requireActual('@/app/lib/api/core'),
+  fetchEditPostJsonApi: jest.fn(),
+  fetchEditPatchJsonApi: jest.fn(),
 }));
 
 const mockSuccessResponse = (data: unknown) => ({
@@ -687,5 +699,32 @@ describe('admin kind writes — boolean-only wire contract', () => {
         body: JSON.stringify({ title: 'Smith Wedding', isClient: true }),
       })
     );
+  });
+});
+
+describe('reorderCollectionContent / updateCollectionRating — edit tier contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Fallback for the pre-fix code path, which still calls the real (unmocked)
+    // fetchAdminPostJsonApi/fetchAdminPatchJsonApi backed by this mocked fetch.
+    (global.fetch as jest.Mock).mockResolvedValue(mockSuccessResponse({}));
+  });
+
+  it('reorderCollectionContent calls fetchEditPostJsonApi with /collections/{id}/reorder', async () => {
+    const reorders = [{ contentId: 1, newOrderIndex: 0 }];
+
+    await reorderCollectionContentApi(5, reorders);
+
+    expect(core.fetchEditPostJsonApi).toHaveBeenCalledWith('/collections/5/reorder', {
+      reorders,
+    });
+  });
+
+  it('updateCollectionRating calls fetchEditPatchJsonApi with /collections/{id}/rating', async () => {
+    await updateCollectionRatingApi(5, 3);
+
+    expect(core.fetchEditPatchJsonApi).toHaveBeenCalledWith('/collections/5/rating', {
+      rating: 3,
+    });
   });
 });

--- a/tests/lib/api/core.test.ts
+++ b/tests/lib/api/core.test.ts
@@ -10,6 +10,8 @@ import {
   fetchAdminPatchJsonApi,
   fetchAdminPostJsonApi,
   fetchAdminPutJsonApi,
+  fetchEditPatchJsonApi,
+  fetchEditPostJsonApi,
   fetchPatchJsonApi,
   fetchPostJsonApi,
   fetchPutJsonApi,
@@ -255,6 +257,44 @@ describe('fetchBase (tested via public API functions)', () => {
     });
   });
 
+  describe('edit endpoint functions', () => {
+    it('should use edit endpoint for fetchEditPostJsonApi', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await fetchEditPostJsonApi('/test', { data: 'test' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/edit'),
+        expect.objectContaining({
+          method: 'POST',
+        })
+      );
+    });
+
+    it('should use edit endpoint for fetchEditPatchJsonApi', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await fetchEditPatchJsonApi('/test', { data: 'test' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/edit'),
+        expect.objectContaining({
+          method: 'PATCH',
+        })
+      );
+    });
+  });
+
   describe('response handling', () => {
     it('should return parsed JSON for successful responses', async () => {
       const mockData = { id: 1, name: 'Test' };
@@ -383,6 +423,28 @@ describe('getApiBaseUrl — dev routes browser calls through the same-origin pro
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringMatching(/^\/api\/proxy\/api\/read\//),
+      expect.any(Object)
+    );
+  });
+
+  it('routes browser edit calls through the relative /api/proxy path', async () => {
+    Object.defineProperty(global, 'window', {
+      value: { location: { hostname: '192.168.68.60' } },
+      writable: true,
+    });
+
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ data: 'ok' }),
+    };
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+    const { fetchEditPostJsonApi: fetchEditPost } = await import('@/app/lib/api/core');
+    await fetchEditPost('/collections/5/reorder', {});
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/api\/proxy\/api\/edit\//),
       expect.any(Object)
     );
   });

--- a/tests/utils/galleryAccess.test.ts
+++ b/tests/utils/galleryAccess.test.ts
@@ -3,10 +3,11 @@
  * "what can this viewer do here" consumed by the Selects and Rating features.
  */
 
-import { type MeResponse } from '@/app/types/Auth';
+import { type CollectionRole, type MeResponse } from '@/app/types/Auth';
 import {
   canDownloadCollection,
   findMembership,
+  hasRoleAtLeast,
   isClientOfCollection,
 } from '@/app/utils/galleryAccess';
 
@@ -24,6 +25,13 @@ const generalMe: MeResponse = {
   isAdmin: false,
   mfaSatisfied: false,
   galleries: [{ collectionId: 7, role: 'GENERAL' }],
+};
+
+const collaboratorMe: MeResponse = {
+  email: 'collaborator@example.com',
+  isAdmin: false,
+  mfaSatisfied: false,
+  galleries: [{ collectionId: 7, role: 'COLLABORATOR' }],
 };
 
 describe('findMembership', () => {
@@ -50,6 +58,10 @@ describe('isClientOfCollection', () => {
     expect(isClientOfCollection(clientMe, 7, false)).toBe(true);
   });
 
+  it('is true for a user with a COLLABORATOR membership for that collection (outranks CLIENT)', () => {
+    expect(isClientOfCollection(collaboratorMe, 7, false)).toBe(true);
+  });
+
   it('is false for a user with only a GENERAL membership', () => {
     expect(isClientOfCollection(generalMe, 7, false)).toBe(false);
   });
@@ -66,6 +78,10 @@ describe('isClientOfCollection', () => {
 describe('canDownloadCollection', () => {
   it('is true for a logged-in CLIENT of the collection (role grant, any collection kind)', () => {
     expect(canDownloadCollection(clientMe, { id: 7 })).toBe(true);
+  });
+
+  it('is true for a logged-in COLLABORATOR of the collection (outranks CLIENT)', () => {
+    expect(canDownloadCollection(collaboratorMe, { id: 7 })).toBe(true);
   });
 
   it('is false for an anonymous viewer with no role grant and no cookie proof', () => {
@@ -126,5 +142,27 @@ describe('canDownloadCollection', () => {
     expect(canDownloadCollection(clientMe, null)).toBe(false);
     // eslint-disable-next-line unicorn/no-useless-undefined -- explicitly testing undefined input
     expect(canDownloadCollection(clientMe, undefined)).toBe(false);
+  });
+});
+
+describe('hasRoleAtLeast', () => {
+  it.each<[CollectionRole, CollectionRole, boolean]>([
+    // Ladder order: GENERAL < CLIENT < COLLABORATOR.
+    ['GENERAL', 'CLIENT', false],
+    ['CLIENT', 'COLLABORATOR', false],
+    ['GENERAL', 'COLLABORATOR', false],
+    ['CLIENT', 'GENERAL', true],
+    ['COLLABORATOR', 'GENERAL', true],
+    ['COLLABORATOR', 'CLIENT', true],
+    // Reflexive: a role always satisfies itself as the minimum.
+    ['GENERAL', 'GENERAL', true],
+    ['CLIENT', 'CLIENT', true],
+    ['COLLABORATOR', 'COLLABORATOR', true],
+  ])('hasRoleAtLeast(%s, %s) === %s', (role, minimum, expected) => {
+    expect(hasRoleAtLeast(role, minimum)).toBe(expected);
+  });
+
+  it('is false for an undefined role', () => {
+    expect(hasRoleAtLeast(undefined, 'GENERAL')).toBe(false);
   });
 });


### PR DESCRIPTION
Frontend contract companion to the backend's new Collaborator access tier: themancalledzac/edens.zac.backend#153. Backend-only feature work lives there; this branch is compatibility — the two should land close together, because the moved routes 404 in between.

A COLLABORATOR sits between CLIENT and admin on a per-collection ladder and **outranks CLIENT**, so every client capability (downloads, selects, rating overlays) must admit them.

## What's here

**An `edit` API channel.** `fetchBase` previously took a closed `'write' | 'admin'` union with a two-way ternary that silently mapped anything non-`'write'` to `admin`. It's now an explicit three-way mapping with no fall-through default, plus `fetchEditPostJsonApi` / `fetchEditPatchJsonApi` mirroring the admin wrappers. `getApiBaseUrl` was already generic and needed no change.

**Two moved routes repointed** (breaking on the backend side, old paths removed):

- `POST /api/admin/collections/{id}/reorder` -> `POST /api/edit/collections/{id}/reorder`
- `PATCH /api/admin/collections/{id}/rating` -> `PATCH /api/edit/collections/{id}/rating`

The prefix lives only in `core.ts`, so no caller changed — `collectionEditUtils`, `useContentReordering`, `useCollectionEdit`, and `StructureTab` are all prefix-agnostic. Neither wrapper had *any* test before this, meaning both routes could have moved wrong with a fully green suite; wrapper tests pinning the new contract were added first.

**The client gate is rank-aware.** `isClientOfCollection` compared `role === 'CLIENT'` — the only role equality comparison in the codebase, and the exact class of bug as the 2026-07-15 download-gate mismatch: a Collaborator would have read as a non-client and silently lost downloads and Selects. It now goes through a new `hasRoleAtLeast` rank helper in `galleryAccess.ts`. `canDownloadCollection` delegates to it, so both call sites are fixed by one change.

**The grant UI can display and grant COLLABORATOR.** `CollectionRole` is aliased as `AccessLevel` and doubles as the admin *write* vocabulary, rendered as hardcoded `<option value="CLIENT">` in five places. Widening the union produces no TypeScript error there (JSX string literals plus `as AccessLevel` casts), so without this a COLLABORATOR grant read back from the backend would render as an out-of-range `<select>` — displaying as "General" and silently downgrading the grant on the next save. Admins also had no way to grant the level.

## One correction to the spec's assumptions

The spec asked to "admit the `/api/edit/**` prefix in the BFF proxy allowlist." **There is no allowlist** — `app/api/proxy/[...path]/route.ts` is a catch-all, `next.config.js` has no rewrites, and the middleware matcher covers page routes only. `/api/edit/**` already forwarded.

The real change is the inverse: the production anonymous-reject fast-path covered only `api/admin/`, so moving two privileged routes to `/api/edit/` would have **removed** an existing 401 check. That prefix check now covers both surfaces. `api/read/**` stays anonymous-allowed.

## Testing

`npm run type-check`, `npm run lint`, and `npm test` all green — **212 suites, 3891 tests**. New coverage: the edit channel's base-URL shape (the only place a prefix regression fails loudly), both moved wrappers, the proxy's anonymous `api/edit/` reject and its authenticated pass-through, a `collaboratorMe` fixture through `isClientOfCollection`/`canDownloadCollection`, and the `hasRoleAtLeast` truth table.

## Deliberately not here

**Collaborator editing affordances** — showing the edit surface to a COLLABORATOR — is a new capability axis, not a gate tweak, and wants its own cycle. `requireAdmin()` is account-level with no collection argument and runs before the collection is even fetched; `editMode` is a boolean threaded four components deep with roughly a dozen consumers; `MenuDropdown` gates the only `?manage=1` entry on `isAdmin`; and `requireAdmin` early-returns in local dev, so any new gate is invisible there. Worth scoping properly rather than bolting onto this contract pass.

Note for that future work: the Structure tab's "Children (rating)" control rates `child.referencedCollectionId` — a *different* collection than the one open — so its gate can't key on the open collection. Harmless while the surface is admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
