### PR TITLE
fix(fullscreen): stop the cover click blacking out cover-only pages

### DIFF
--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -100,7 +100,13 @@ export function FullScreenModal({
   navigateToNext,
   navigateToPrevious,
 }: FullScreenModalProps) {
-  const isOpen = fullScreenState != null;
+  // Resolved BEFORE the effect, because the body class below paints the page black and must track
+  // what this component actually puts on screen — not merely that a state object exists. The render
+  // bails on an unresolvable index (see the early returns), and when the two disagreed the class
+  // went on with no overlay under it: a black page wearing its own text colors, no viewer, no way
+  // out. Keeping one derivation for both means they cannot drift apart again.
+  const currentImage = fullScreenState?.images[fullScreenState.currentIndex];
+  const isOpen = currentImage != null;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -137,10 +143,7 @@ export function FullScreenModal({
   // Target of the toggle's aria-controls. Only emitted while the panel is mounted (see below).
   const metadataPanelId = useId();
 
-  if (!fullScreenState) return null;
-
-  const currentImage = fullScreenState.images[fullScreenState.currentIndex];
-  if (!currentImage) return null;
+  if (!fullScreenState || !currentImage) return null;
 
   const isGif = isGifBlock(currentImage);
 

--- a/app/components/FullScreenModal/FullScreenModal.tsx
+++ b/app/components/FullScreenModal/FullScreenModal.tsx
@@ -77,6 +77,11 @@ interface FullScreenModalProps {
  * ARIA: `aria-controls` on the metadata toggle is emitted only while the panel is mounted —
  * a reference to an absent id is invalid (same convention as EditBar and MenuDropdown).
  *
+ * `isOpen` tracks a resolvable `currentImage`, not merely a non-null `fullScreenState`, because the
+ * effect below adds `body.fullscreen-open` — which globals.css paints solid #000 to keep the page
+ * canvas from leaking through the overlay on iOS. A state whose index resolves to nothing renders
+ * null, so gating the class on anything looser blacks out the page with no viewer on it.
+ *
  * The dialog's name and the photo's `alt` both come from `humanLabel`, the same filter the grid
  * tiles use: the backend seeds `title` from the uploaded filename, so naming the dialog straight
  * off `title` announced "Fullscreen image: DSC_4364.webp". A filename-shaped value is dropped in
@@ -100,11 +105,6 @@ export function FullScreenModal({
   navigateToNext,
   navigateToPrevious,
 }: FullScreenModalProps) {
-  // Resolved BEFORE the effect, because the body class below paints the page black and must track
-  // what this component actually puts on screen — not merely that a state object exists. The render
-  // bails on an unresolvable index (see the early returns), and when the two disagreed the class
-  // went on with no overlay under it: a black page wearing its own text colors, no viewer, no way
-  // out. Keeping one derivation for both means they cannot drift apart again.
   const currentImage = fullScreenState?.images[fullScreenState.currentIndex];
   const isOpen = currentImage != null;
 

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -169,22 +169,16 @@ export function useFullScreenImage(): {
   // pops exactly one entry and popstate (Back) is distinguished from our own pop.
   const pushedHistoryRef = useRef<boolean>(false);
 
+  /**
+   * Open the viewer on `image`, with `allImages` as the sequence prev/next walks.
+   *
+   * `image` is not always a member of `allImages`: the collection cover is synthesized at layout
+   * time with id {@link COVER_IMAGE_CONTENT_ID} and never reaches the content array behind that
+   * list. A non-member opens as a single-image list, so the viewer always shows the image that was
+   * clicked and always has one to render — a state carrying no renderable image blacks out the page
+   * (see `FullScreenModal`).
+   */
   const showImage = useCallback((image: ImageBlock, allImages?: ImageBlock[]) => {
-    // The clicked image is the intent, so the viewer opens on IT — never on whatever happens to sit
-    // at index 0. `allImages` is the surrounding list only to give prev/next something to walk, and
-    // the image is not always a member of it: the collection COVER is synthesized at layout time
-    // (id COVER_IMAGE_CONTENT_ID) and never reaches the content array `viewableBlocks` filters, so
-    // `findIndex` answers -1 for it on every page that has one.
-    //
-    // Coercing that -1 to 0 was wrong twice over. On a grid of photographs it opened the first photo
-    // instead of the cover. On a grid holding no viewable photographs at all — a user space's
-    // Collections tab, a PARENT collection, where every tile is a collection card and so excluded —
-    // it produced `{ images: [], currentIndex: 0 }`, which the modal cannot render: it returned null
-    // while its own effect had already painted `body.fullscreen-open` black, leaving a blacked-out
-    // page with no viewer on it and no close button to escape by.
-    //
-    // A non-member falls back to a single-image list. Prev/next are correctly absent — there is no
-    // sequence a cover belongs to.
     const index = allImages?.findIndex(img => img.id === image.id) ?? -1;
     const images = index === -1 ? [image] : allImages!;
 

--- a/app/hooks/useFullScreenImage.tsx
+++ b/app/hooks/useFullScreenImage.tsx
@@ -170,12 +170,27 @@ export function useFullScreenImage(): {
   const pushedHistoryRef = useRef<boolean>(false);
 
   const showImage = useCallback((image: ImageBlock, allImages?: ImageBlock[]) => {
-    const images = allImages || [image];
-    const currentIndex = allImages?.findIndex(img => img.id === image.id) ?? 0;
+    // The clicked image is the intent, so the viewer opens on IT — never on whatever happens to sit
+    // at index 0. `allImages` is the surrounding list only to give prev/next something to walk, and
+    // the image is not always a member of it: the collection COVER is synthesized at layout time
+    // (id COVER_IMAGE_CONTENT_ID) and never reaches the content array `viewableBlocks` filters, so
+    // `findIndex` answers -1 for it on every page that has one.
+    //
+    // Coercing that -1 to 0 was wrong twice over. On a grid of photographs it opened the first photo
+    // instead of the cover. On a grid holding no viewable photographs at all — a user space's
+    // Collections tab, a PARENT collection, where every tile is a collection card and so excluded —
+    // it produced `{ images: [], currentIndex: 0 }`, which the modal cannot render: it returned null
+    // while its own effect had already painted `body.fullscreen-open` black, leaving a blacked-out
+    // page with no viewer on it and no close button to escape by.
+    //
+    // A non-member falls back to a single-image list. Prev/next are correctly absent — there is no
+    // sequence a cover belongs to.
+    const index = allImages?.findIndex(img => img.id === image.id) ?? -1;
+    const images = index === -1 ? [image] : allImages!;
 
     setFullScreenState({
       images,
-      currentIndex: currentIndex !== -1 ? currentIndex : 0,
+      currentIndex: index === -1 ? 0 : index,
     });
 
     // Sync ?image=<id> onto the URL so the open viewer is deep-linkable.

--- a/tests/components/FullScreenModal/FullScreenModal.unrenderable.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.unrenderable.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The `fullscreen-open` body class must track what the viewer actually PAINTS, not merely that
+ * `fullScreenState` is non-null.
+ *
+ * `globals.css` paints both `html:has(body.fullscreen-open)` and `body.fullscreen-open` solid #000
+ * so no page canvas shows through the 90%-opaque overlay on iOS. That is only safe while the
+ * overlay is really on screen. When the state resolves to no current image the component returns
+ * null — and if the class went on anyway, the page kept its own text colors and images over a black
+ * canvas with no viewer and no close button: the "inverted colors" report on /admin/users/[id].
+ */
+import { render, screen } from '@testing-library/react';
+
+import { FullScreenModal } from '@/app/components/FullScreenModal/FullScreenModal';
+import type { ContentImageModel } from '@/app/types/Content';
+
+jest.mock('@/app/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: jest.fn() }));
+
+const img = (id: number): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    imageWidth: 1000,
+    imageHeight: 800,
+    orderIndex: id,
+    visible: true,
+    title: `Image ${id}`,
+    locations: [],
+  }) as ContentImageModel;
+
+const noop = () => {};
+
+function renderModal(fullScreenState: { images: ContentImageModel[]; currentIndex: number } | null) {
+  return render(
+    <FullScreenModal
+      fullScreenState={fullScreenState}
+      loadedImageIds={new Set<number>()}
+      setLoadedImageIds={noop}
+      modalRef={{ current: null }}
+      zoomTargetRef={{ current: null }}
+      isZoomed={false}
+      hideImage={noop}
+      toggleImmersive={noop}
+      isSwiping={{ current: false }}
+      showMetadata={false}
+      toggleMetadata={noop}
+      router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+      navigateToNext={noop}
+      navigateToPrevious={noop}
+    />
+  );
+}
+
+describe('FullScreenModal — states that render nothing', () => {
+  afterEach(() => {
+    document.body.classList.remove('fullscreen-open');
+  });
+
+  it('does not blacken the page when the state carries no images', () => {
+    renderModal({ images: [], currentIndex: 0 });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveClass('fullscreen-open');
+  });
+
+  it('does not blacken the page when currentIndex points past the end', () => {
+    renderModal({ images: [img(1)], currentIndex: 4 });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.body).not.toHaveClass('fullscreen-open');
+  });
+
+  it('still blackens the page while a real image is on screen', () => {
+    renderModal({ images: [img(1)], currentIndex: 0 });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(document.body).toHaveClass('fullscreen-open');
+  });
+
+  it('removes the class again when the viewer closes', () => {
+    const { rerender } = renderModal({ images: [img(1)], currentIndex: 0 });
+    expect(document.body).toHaveClass('fullscreen-open');
+
+    rerender(
+      <FullScreenModal
+        fullScreenState={null}
+        loadedImageIds={new Set<number>()}
+        setLoadedImageIds={noop}
+        modalRef={{ current: null }}
+        zoomTargetRef={{ current: null }}
+        isZoomed={false}
+        hideImage={noop}
+        toggleImmersive={noop}
+        isSwiping={{ current: false }}
+        showMetadata={false}
+        toggleMetadata={noop}
+        router={{ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() } as never}
+        navigateToNext={noop}
+        navigateToPrevious={noop}
+      />
+    );
+
+    expect(document.body).not.toHaveClass('fullscreen-open');
+  });
+});

--- a/tests/components/FullScreenModal/FullScreenModal.unrenderable.test.tsx
+++ b/tests/components/FullScreenModal/FullScreenModal.unrenderable.test.tsx
@@ -1,12 +1,10 @@
 /**
- * The `fullscreen-open` body class must track what the viewer actually PAINTS, not merely that
- * `fullScreenState` is non-null.
+ * The `fullscreen-open` body class must track what the viewer actually paints.
  *
- * `globals.css` paints both `html:has(body.fullscreen-open)` and `body.fullscreen-open` solid #000
- * so no page canvas shows through the 90%-opaque overlay on iOS. That is only safe while the
- * overlay is really on screen. When the state resolves to no current image the component returns
- * null — and if the class went on anyway, the page kept its own text colors and images over a black
- * canvas with no viewer and no close button: the "inverted colors" report on /admin/users/[id].
+ * globals.css paints both `html:has(body.fullscreen-open)` and `body.fullscreen-open` solid #000 so
+ * no page canvas shows through the 90%-opaque overlay on iOS. That is only safe while the overlay
+ * is on screen: a state whose index resolves to no image renders null, and the class over a null
+ * render is a black page with no viewer and no close button on it.
  */
 import { render, screen } from '@testing-library/react';
 

--- a/tests/hooks/useFullScreenImage.foreignImage.test.tsx
+++ b/tests/hooks/useFullScreenImage.foreignImage.test.tsx
@@ -1,18 +1,13 @@
 /**
- * Opening the viewer on an image that is NOT a member of the surrounding list.
+ * Opening the viewer on an image that is not a member of the surrounding list.
  *
- * The collection COVER is the real case: it is synthesized by `createCoverImageBlock` from
- * `collection.coverImage` at layout time with id `COVER_IMAGE_CONTENT_ID` (-1), so it never appears
- * in the content array that `ContentBlockWithFullScreen` filters into `viewableBlocks`. Clicking it
- * therefore calls `showImage(cover, viewableBlocks)` with a cover that no index in the list matches.
+ * The collection cover is the real case: `createCoverImageBlock` synthesizes it at layout time with
+ * id COVER_IMAGE_CONTENT_ID (-1), so it never appears in the content array that
+ * `ContentBlockWithFullScreen` filters into `viewableBlocks`. Clicking it calls
+ * `showImage(cover, viewableBlocks)` with a cover no index in that list matches.
  *
- * `findIndex` answers -1 there, and coercing that to 0 was wrong in both directions: on a grid of
- * photographs it opened the FIRST photo instead of the cover, and on a grid with no viewable
- * photographs at all (a user space's Collections tab, a PARENT collection — every tile is a
- * collection card, which `viewableBlocks` excludes) it produced `{ images: [], currentIndex: 0 }`,
- * a state the modal cannot render.
- *
- * The clicked image is the intent, so it is what the viewer must show.
+ * The viewer must open on the clicked image, and must always resolve to something renderable — a
+ * state carrying no image blacks out the page (see FullScreenModal.unrenderable).
  */
 import { act, renderHook } from '@testing-library/react';
 

--- a/tests/hooks/useFullScreenImage.foreignImage.test.tsx
+++ b/tests/hooks/useFullScreenImage.foreignImage.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Opening the viewer on an image that is NOT a member of the surrounding list.
+ *
+ * The collection COVER is the real case: it is synthesized by `createCoverImageBlock` from
+ * `collection.coverImage` at layout time with id `COVER_IMAGE_CONTENT_ID` (-1), so it never appears
+ * in the content array that `ContentBlockWithFullScreen` filters into `viewableBlocks`. Clicking it
+ * therefore calls `showImage(cover, viewableBlocks)` with a cover that no index in the list matches.
+ *
+ * `findIndex` answers -1 there, and coercing that to 0 was wrong in both directions: on a grid of
+ * photographs it opened the FIRST photo instead of the cover, and on a grid with no viewable
+ * photographs at all (a user space's Collections tab, a PARENT collection — every tile is a
+ * collection card, which `viewableBlocks` excludes) it produced `{ images: [], currentIndex: 0 }`,
+ * a state the modal cannot render.
+ *
+ * The clicked image is the intent, so it is what the viewer must show.
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { useFullScreenImage } from '@/app/hooks/useFullScreenImage';
+import type { ContentImageModel } from '@/app/types/Content';
+import { COVER_IMAGE_CONTENT_ID } from '@/app/utils/contentLayout';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const img = (id: number): ContentImageModel =>
+  ({
+    id,
+    contentType: 'IMAGE',
+    imageUrl: `https://cdn.example/${id}.jpg`,
+    orderIndex: id,
+    visible: true,
+  }) as ContentImageModel;
+
+const cover = () => img(COVER_IMAGE_CONTENT_ID);
+
+describe('useFullScreenImage — image outside the surrounding list', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/admin/users/106');
+  });
+
+  it('opens on the cover itself when the list holds no viewable photographs', () => {
+    const { result } = renderHook(() => useFullScreenImage());
+
+    act(() => {
+      result.current.showImage(cover(), []);
+    });
+
+    const state = result.current.fullScreenState;
+    expect(state?.images).toHaveLength(1);
+    expect(state?.images[state.currentIndex]?.id).toBe(COVER_IMAGE_CONTENT_ID);
+  });
+
+  it('opens on the cover, not the first grid photo, when the list is populated', () => {
+    const { result } = renderHook(() => useFullScreenImage());
+
+    act(() => {
+      result.current.showImage(cover(), [img(6), img(7), img(8)]);
+    });
+
+    const state = result.current.fullScreenState;
+    expect(state?.images[state.currentIndex]?.id).toBe(COVER_IMAGE_CONTENT_ID);
+  });
+
+  it('always resolves to a renderable image, never an empty viewer', () => {
+    const { result } = renderHook(() => useFullScreenImage());
+
+    act(() => {
+      result.current.showImage(cover(), []);
+    });
+
+    const state = result.current.fullScreenState;
+    expect(state?.images[state.currentIndex]).toBeDefined();
+  });
+
+  it('still walks the list normally for an image that IS a member', () => {
+    const { result } = renderHook(() => useFullScreenImage());
+
+    act(() => {
+      result.current.showImage(img(7), [img(6), img(7), img(8)]);
+    });
+
+    const state = result.current.fullScreenState;
+    expect(state?.images).toHaveLength(3);
+    expect(state?.currentIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## The report

Clicking the cover image on `/admin/users/106` in production "inverted the colors" on the page. No console errors, no network calls.

It is not an inversion. The page background is painted solid `#000` with the page's own content still drawn on top — which is why text stays dark and unreadable while the photos look untouched. There is no viewer and no close button, so the only way out is navigating away.

`globals.css` paints both `html:has(body.fullscreen-open)` and `body.fullscreen-open` solid `#000` on purpose, so no page canvas leaks through the 90%-opaque fullscreen overlay on iOS. That is only safe while the overlay is actually on screen. Here the class went on and the overlay never rendered.

## Root cause

The cover is synthesized at layout time by `createCoverImageBlock` with id `COVER_IMAGE_CONTENT_ID` (`-1`) — hence the `?image=-1` on the URL. It never enters the content array that `ContentBlockWithFullScreen` filters into `viewableBlocks`, so `findIndex` answers `-1` for the cover on **every** page that has one, and `showImage` coerced that `-1` to `0`.

Wrong twice over:

1. **Grid holding photographs** — opened the *first grid photo* instead of the cover. Silent and wrong on every collection page with a cover.
2. **Grid holding only collection cards** — `viewableBlocks` is empty (collection cards are excluded from it by design), so the state became `{ images: [], currentIndex: 0 }`. `FullScreenModal` returned `null` from render, while its own effect had already added `body.fullscreen-open`.

The "no errors" signature is diagnostic: a side effect that outlived its own render is silent by construction.

## Blast radius

| Surface | Affected |
| --- | --- |
| `/admin/users/[id]` Collections tab | Yes — as reported |
| `/user` (any signed-in user's own space) | **Yes** — same `UserSpace` component, same cover, same card grid |
| Collection with a cover and zero viewable images (PARENT-of-collections) | Yes |
| `/collections` | No — the synthetic parent carries no cover, so there is no cover tile |
| Every collection page with a cover | Not black, but the cover click opened the wrong photo |

`/user` is the one worth flagging: it is not admin-gated.

## The fix

- `useFullScreenImage.showImage` — a clicked image that is not a member of the surrounding list falls back to a single-image list, so the viewer always opens on the image that was actually clicked. This fixes both failure modes at the source. Prev/next are correctly absent for a cover; there is no sequence it belongs to.
- `FullScreenModal` — `currentImage` is derived once, before the effect, and the body class is gated on it. The class can no longer outlive what the component paints, so no future caller can blank the page this way.

## Behavior change

Clicking a cover now opens the **cover**, not grid photo #1. That is the intent the click implies, but it is a visible change on live collection pages and worth a look before merge.

## Verification

- 8 new tests across 2 files (`FullScreenModal.unrenderable`, `useFullScreenImage.foreignImage`), confirmed failing (5 failures) against the old code and passing after
- Full suite: **3899 passed**, 214 suites
- `tsc --noEmit` clean; eslint clean on changed files

Not verified in a browser against production — the reproduction and the fix are pinned by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)