### PR TITLE
feat(share): user share link UI - landing route, share card, recipient view

### DIFF
--- a/app/components/Personal/ShareCard.module.scss
+++ b/app/components/Personal/ShareCard.module.scss
@@ -1,0 +1,75 @@
+/* ShareCard — the share link, its send controls, and the reset, on /user.
+
+   The section shell (heading, rule, body, and the `flex: 0 0 auto` the header rail depends on)
+   comes from <Card>. Only the content inside it is styled here, mirroring AccountCard. */
+
+.hint {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.link {
+  /* Selectable as a fallback whenever the clipboard API is refused, so the link is never
+     unreachable — hence the wrap rather than an ellipsis. */
+  margin: 0 0 var(--space-2);
+  overflow-wrap: anywhere;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+
+.input {
+  flex: 1 1 12rem;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+}
+
+.note {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+}
+
+.optIns {
+  margin-top: var(--space-3);
+}
+
+.optInList {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.optInItem + .optInItem {
+  margin-top: var(--space-1);
+}
+
+.optInLabel {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface);
+  cursor: pointer;
+}
+
+.danger {
+  /* Separated by a rule, not just spacing: reset is the one control here that takes access away
+     from someone, and it should not read as a sibling of "copy" and "send". */
+  padding-top: var(--space-3);
+  margin-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}

--- a/app/components/Personal/ShareCard.tsx
+++ b/app/components/Personal/ShareCard.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/app/components/ui/Button/Button';
+import { Card } from '@/app/components/ui/Card/Card';
+import { FormError } from '@/app/components/ui/Field/FormError';
+import { ApiError } from '@/app/lib/api/core';
+import {
+  addShareCollection,
+  buildShareUrl,
+  emailShareLink,
+  removeShareCollection,
+  rotateShareLink,
+  type ShareSettings,
+  type ShareSettingsRead,
+} from '@/app/lib/api/share';
+import { type CollectionModel } from '@/app/types/Collection';
+
+import styles from './ShareCard.module.scss';
+
+export interface ShareCardProps {
+  /**
+   * Server-resolved starting state. The failure arm is kept distinct from "no link yet" on
+   * purpose — see {@link ShareSettingsRead}.
+   */
+  read: ShareSettingsRead;
+}
+
+type Phase = 'idle' | 'pending' | 'error';
+
+/** Map a failed share action to user-facing copy. */
+function mapError(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return 'Your session has expired. Sign in again to manage your link.';
+    if (error.status === 409) {
+      return 'This link was created before links could be re-shown. Reset it to get one you can copy.';
+    }
+    if (error.status === 403) return 'You no longer have access to that gallery.';
+  }
+  return fallback;
+}
+
+/**
+ * "Share" card for `/user`: the link the owner hands to a friend, client or parent, plus the
+ * controls for sending and revoking it.
+ *
+ * The link is deliberately shown in full and copyable on every visit, not just the one that
+ * created it. Sending the same link to a second person months later must not require a reset —
+ * a reset cuts off whoever is already using the first copy, which is the failure this whole
+ * feature exists to avoid. Reset is therefore presented as the destructive action it is, well
+ * away from the everyday copy and email controls.
+ *
+ * The opt-in list is off by default and covers only galleries the owner was granted access to but
+ * is not tagged in. Tagged-in work is in every share already; a gallery someone else let them into
+ * is not theirs to pass on, so sharing it has to be a deliberate act.
+ */
+export function ShareCard({ read }: ShareCardProps) {
+  const [settings, setSettings] = useState<ShareSettings | null>(read.ok ? read.settings : null);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [recipient, setRecipient] = useState('');
+  const [emailNote, setEmailNote] = useState<string | null>(null);
+  const [origin, setOrigin] = useState('');
+
+  // Read on the client so the copied link matches the origin the owner is actually on — localhost
+  // in dev, the real domain in production — without threading a base URL through from the server.
+  useEffect(() => setOrigin(window.location.origin), []);
+
+  const shareUrl = useMemo(
+    () => (settings?.token && origin ? buildShareUrl(settings.token, origin) : null),
+    [settings?.token, origin]
+  );
+
+  const optedIn = useMemo(
+    () => new Set(settings?.optedInCollectionIds ?? []),
+    [settings?.optedInCollectionIds]
+  );
+
+  const run = async (action: () => Promise<void>, fallback: string) => {
+    setError(null);
+    setEmailNote(null);
+    setPhase('pending');
+    try {
+      await action();
+      setPhase('idle');
+    } catch (error_) {
+      setError(mapError(error_, fallback));
+      setPhase('error');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard permission can be refused; the link is on screen and selectable regardless.
+      setError('Could not copy automatically — select the link above and copy it.');
+    }
+  };
+
+  const handleReset = () =>
+    run(async () => {
+      setSettings(await rotateShareLink());
+      setCopied(false);
+    }, 'Could not reset your link. Please try again.');
+
+  const handleEmail = () =>
+    run(async () => {
+      const result = await emailShareLink(recipient.trim());
+      setEmailNote(
+        result.sent
+          ? `Sent to ${recipient.trim()}.`
+          : 'Email is not switched on right now — copy the link and send it yourself.'
+      );
+      setRecipient('');
+    }, 'Could not send that email. Please try again.');
+
+  const toggleCollection = (collection: CollectionModel, include: boolean) =>
+    run(async () => {
+      await (include
+        ? addShareCollection(collection.id)
+        : removeShareCollection(collection.id));
+      setSettings(current =>
+        current
+          ? {
+              ...current,
+              optedInCollectionIds: include
+                ? [...current.optedInCollectionIds, collection.id]
+                : current.optedInCollectionIds.filter(id => id !== collection.id),
+            }
+          : current
+      );
+    }, 'Could not update what your link shows. Please try again.');
+
+  const busy = phase === 'pending';
+
+  // A failed read says nothing about whether a link exists, so the card must not offer to create
+  // one — that would read as "you have none" to someone whose link is out there working.
+  if (!read.ok) {
+    return (
+      <Card title="Share">
+        <p className={styles.hint}>Your share link is unavailable right now.</p>
+      </Card>
+    );
+  }
+
+  if (!settings?.exists) {
+    return (
+      <Card title="Share">
+        <p className={styles.hint}>
+          Create a link that shows your work to anyone you send it to. No account or password
+          needed on their side, and you can turn it off whenever you like.
+        </p>
+        <Button type="button" variant="outline" loading={busy} onClick={handleReset}>
+          Create a link
+        </Button>
+        {error && <FormError>{error}</FormError>}
+      </Card>
+    );
+  }
+
+  return (
+    <Card title="Share">
+      {shareUrl ? (
+        <>
+          <p className={styles.hint}>
+            Anyone with this link can see your work. The same link keeps working until you reset
+            it, so you can send it to as many people as you like.
+          </p>
+          <p className={styles.link}>{shareUrl}</p>
+          <div className={styles.row}>
+            <Button type="button" variant="outline" onClick={handleCopy} disabled={busy}>
+              {copied ? 'Copied' : 'Copy link'}
+            </Button>
+          </div>
+
+          <div className={styles.row}>
+            <input
+              type="email"
+              className={styles.input}
+              placeholder="Email it to someone"
+              aria-label="Send the link to this email address"
+              value={recipient}
+              onChange={event => setRecipient(event.target.value)}
+              disabled={busy}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              loading={busy}
+              disabled={!recipient.trim()}
+              onClick={handleEmail}
+            >
+              Send
+            </Button>
+          </div>
+          {emailNote && <p className={styles.note}>{emailNote}</p>}
+        </>
+      ) : (
+        <p className={styles.hint}>
+          Your link is active, but it was created before links could be shown again here. Reset it
+          to get one you can copy.
+        </p>
+      )}
+
+      {settings.candidateCollections.length > 0 && (
+        <div className={styles.optIns}>
+          <p className={styles.hint}>
+            Galleries you were given access to are not shared by default. Add any you want your
+            link to include.
+          </p>
+          <ul className={styles.optInList}>
+            {settings.candidateCollections.map(collection => (
+              <li key={collection.id} className={styles.optInItem}>
+                <label className={styles.optInLabel}>
+                  <input
+                    type="checkbox"
+                    checked={optedIn.has(collection.id)}
+                    disabled={busy}
+                    onChange={event => toggleCollection(collection, event.target.checked)}
+                  />
+                  <span>{collection.title}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className={styles.danger}>
+        <p className={styles.hint}>
+          Resetting makes a new link and stops the old one working — anyone still using it will
+          lose access.
+        </p>
+        <Button type="button" variant="outline" loading={busy} onClick={handleReset}>
+          Reset link
+        </Button>
+      </div>
+
+      {error && <FormError>{error}</FormError>}
+    </Card>
+  );
+}

--- a/app/components/UserSpace/UserSpace.tsx
+++ b/app/components/UserSpace/UserSpace.tsx
@@ -5,11 +5,7 @@ import { FollowsProvider } from '@/app/components/Personal/FollowsContext';
 import { FormError } from '@/app/components/ui/Field/FormError';
 import { type ToolbarSection } from '@/app/components/ui/FilterToolbar/FilterToolbar';
 import { EmptyState } from '@/app/components/ui/StatusText/EmptyState';
-import {
-  TAB_KEYS,
-  type TabKey,
-  type UserSpaceData,
-} from '@/app/components/UserSpace/userSpaceData';
+import { type TabKey, type UserSpaceData } from '@/app/components/UserSpace/userSpaceData';
 import { type MeResponse } from '@/app/types/Auth';
 import { type CollectionModel } from '@/app/types/Collection';
 import { type SsrViewport } from '@/app/utils/ssrViewport';
@@ -104,10 +100,12 @@ export function UserSpace({
   ssrViewport,
   railExtras = null,
 }: UserSpaceProps) {
-  const { collection, sections, followedCollectionIds, savedImageIds } = data;
+  const { collection, sections, followedCollectionIds, savedImageIds, visibleKeys } = data;
   const active = sections[activeKey];
 
-  const toolbarSections: ToolbarSection[] = TAB_KEYS.map(key => {
+  // From the data, not TAB_KEYS: a share recipient is offered Collections and Images only, since
+  // Saved and Following are the owner's private bookmarks and are absent from their view.
+  const toolbarSections: ToolbarSection[] = visibleKeys.map(key => {
     const section = sections[key];
     return {
       key,

--- a/app/components/UserSpace/userSpaceData.ts
+++ b/app/components/UserSpace/userSpaceData.ts
@@ -12,6 +12,7 @@
 import { getAllCollections } from '@/app/lib/api/collections';
 import { ApiError } from '@/app/lib/api/core';
 import { listFollowedCollectionIdsServer, listSavedImagesServer } from '@/app/lib/api/personal';
+import { getCurrentShareView, getShareView, type ShareView } from '@/app/lib/api/share';
 import { getUserPage } from '@/app/lib/api/user';
 import {
   getUserPageById,
@@ -20,6 +21,7 @@ import {
 } from '@/app/lib/api/users';
 import { type CollectionModel } from '@/app/types/Collection';
 import { type AnyContentModel, type ContentCollectionModel } from '@/app/types/Content';
+import { type FailSoftRead } from '@/app/types/FailSoftRead';
 import { isContentCollection, isContentImage, isGifContent } from '@/app/utils/contentTypeGuards';
 
 export const TAB_KEYS = ['collections', 'images', 'saved', 'following'] as const;
@@ -29,13 +31,29 @@ export type TabKey = (typeof TAB_KEYS)[number];
 const DEFAULT_TAB: TabKey = 'collections';
 
 /**
+ * The sections a share-link recipient is offered. Saved and Following are the owner's private
+ * bookmarks and are absent from the backend's recipient view by design.
+ */
+export const SHARE_TAB_KEYS = ['collections', 'images'] as const satisfies readonly [
+  TabKey,
+  ...TabKey[],
+];
+
+/**
  * Whose space is being rendered.
  *
  * `self` is the signed-in user viewing their own space; `admin` is an admin observing another
- * user's. The distinction is not cosmetic — it decides which reads run AND whether the personal
- * action controls are armed. See {@link UserSpace} for why admin mode renders them off.
+ * user's; `share` is a link recipient looking at the owner's work. The distinction is not
+ * cosmetic — it decides which reads run AND whether the personal action controls are armed. See
+ * {@link UserSpace} for why the other two modes render them off.
+ *
+ * `share` carries the raw token on the first landing (the URL is the only place it exists) and
+ * omits it afterwards, when the cookie identifies the link instead.
  */
-export type UserSpaceMode = 'self' | { mode: 'admin'; userId: number };
+export type UserSpaceMode =
+  | 'self'
+  | { mode: 'admin'; userId: number }
+  | { mode: 'share'; token?: string };
 
 /** Narrow an untrusted `?tab=` value to a known key, falling back to the default section. */
 export function resolveTabKey(raw: string | string[] | undefined): TabKey {
@@ -123,6 +141,20 @@ export interface UserSpaceData {
   followedCollectionIds: number[];
   /** Ids the save toggle seeds from. Empty in admin mode, for the same reason. */
   savedImageIds: number[];
+  /**
+   * Which section chips to offer, in order.
+   *
+   * All four for the owner and for an admin. A share recipient gets Collections and Images only:
+   * Saved and Following are the owner's private bookmarks, which the backend deliberately keeps
+   * out of the recipient view. Rendering them empty would be worse than omitting them — an empty
+   * "Saved" tab reads as a claim that the owner has saved nothing, which is not what we know.
+   */
+  visibleKeys: readonly [TabKey, ...TabKey[]];
+  /**
+   * Whose work a recipient is looking at, for the share banner. Null outside share mode, and also
+   * null for an owner who has never set a display name.
+   */
+  ownerName: string | null;
 }
 
 /**
@@ -141,6 +173,16 @@ async function loadAdminUserPage(userId: number): Promise<CollectionModel | null
     if (error instanceof ApiError && error.status === 404) return null;
     throw error;
   }
+}
+
+/**
+ * The recipient view behind a share link: the token on first landing, the cookie thereafter.
+ *
+ * Both arms already map a missing or reset link to null, so the caller's `null` -> 404 path
+ * covers a dead link without this needing to distinguish the two.
+ */
+async function loadShareView(target: { mode: 'share'; token?: string }): Promise<ShareView | null> {
+  return target.token ? await getShareView(target.token) : await getCurrentShareView();
 }
 
 /**
@@ -181,19 +223,45 @@ export async function loadUserSpace(
   activeKey: TabKey = DEFAULT_TAB
 ): Promise<UserSpaceData | null> {
   const isSelf = target === 'self';
+  const isShare = target !== 'self' && target.mode === 'share';
+
+  // A recipient owns no bookmarks here, so both fail-soft reads are a genuine empty rather than a
+  // skipped read reported as a failure. Saved/Following are not offered as sections at all in this
+  // mode (see `visibleKeys`); this only keeps the shape uniform for the code below.
+  const noBookmarks = Promise.resolve<FailSoftRead<never>>({ ok: true, items: [] });
 
   // The catalog read stays INSIDE the Promise.all rather than being awaited after it: on the
   // Following tab it is needed, and awaiting it downstream would serialize it behind the page read
   // instead of overlapping with it — trading a wasted read on three tabs for a slower fourth.
-  const [collection, saved, followed, catalog] = await Promise.all([
-    isSelf ? getUserPage() : loadAdminUserPage(target.userId),
-    isSelf ? listSavedImagesServer() : listSavedImagesByUserServer(target.userId),
+  const [pageRead, saved, followed, catalog] = await Promise.all([
+    isSelf
+      ? getUserPage()
+      : isShare
+        ? loadShareView(target as { mode: 'share'; token?: string })
+        : loadAdminUserPage((target as { mode: 'admin'; userId: number }).userId),
+    isSelf
+      ? listSavedImagesServer()
+      : isShare
+        ? noBookmarks
+        : listSavedImagesByUserServer((target as { mode: 'admin'; userId: number }).userId),
     isSelf
       ? listFollowedCollectionIdsServer()
-      : listFollowedCollectionIdsByUserServer(target.userId),
-    activeKey === 'following' ? getAllCollections(0, 500) : Promise.resolve<CollectionModel[]>([]),
+      : isShare
+        ? noBookmarks
+        : listFollowedCollectionIdsByUserServer(
+            (target as { mode: 'admin'; userId: number }).userId
+          ),
+    // Never fetched in share mode: the Following section is not offered, so the catalog it exists
+    // to hydrate would be a ~0.5s read serving a tab the recipient cannot reach.
+    activeKey === 'following' && !isShare
+      ? getAllCollections(0, 500)
+      : Promise.resolve<CollectionModel[]>([]),
   ]);
 
+  // Share mode's read carries the owner's name alongside the page; the other two return the page
+  // alone. Unwrapped here so the rest of the function sees one shape.
+  const shareView = isShare ? (pageRead as ShareView | null) : null;
+  const collection = isShare ? (shareView?.page ?? null) : (pageRead as CollectionModel | null);
   if (!collection) return null;
 
   // A failed read has no `items` to take — see {@link FailSoftRead}. `[]` here is only ever the
@@ -273,5 +341,7 @@ export async function loadUserSpace(
     // `/user/saves/images` already returns the full saved set, so derive the ids from it rather
     // than issuing a second `/user/saves` ids-only read (single-fetch rule).
     savedImageIds: isSelf ? savedImages.map(i => i.id) : [],
+    visibleKeys: isShare ? SHARE_TAB_KEYS : TAB_KEYS,
+    ownerName: shareView?.ownerName ?? null,
   };
 }

--- a/app/lib/api/share.ts
+++ b/app/lib/api/share.ts
@@ -1,0 +1,217 @@
+/**
+ * User share links — the "guest pass" a signed-in user hands to a friend, client or parent.
+ *
+ * Two audiences, two idioms, matching the rest of this directory:
+ *
+ * - Owner-side reads run server-side through `fetchReadApi` (session cookie forwarded), mirroring
+ *   {@link getUserPage} including its "null on 401" contract.
+ * - Owner-side mutations run client-side as raw `fetch` to `/api/proxy/api/read/user/share/...`,
+ *   the same shape as `personal.ts` — these are POST/PUT/DELETE on the READ channel because the
+ *   backend scopes them to the session principal rather than to the admin surface.
+ */
+import { ApiError, fetchReadApi } from '@/app/lib/api/core';
+import { type CollectionModel } from '@/app/types/Collection';
+import { logger } from '@/app/utils/logger';
+
+const SHARE = '/api/proxy/api/read/user/share';
+
+/** Throw an `ApiError` carrying the backend message (or a status fallback) for a non-OK response. */
+async function throwFromResponse(res: Response): Promise<never> {
+  let detail: unknown;
+  const contentType = res.headers.get('content-type') || '';
+  try {
+    detail = contentType.includes('application/json') ? await res.json() : await res.text();
+  } catch {
+    detail = '';
+  }
+  const message =
+    typeof detail === 'string' && detail
+      ? detail
+      : detail && typeof detail === 'object'
+        ? ((detail as { message?: string }).message ?? JSON.stringify(detail))
+        : `API error: ${res.status}`;
+  throw new ApiError(message, res.status);
+}
+
+/** What a recipient sees: whose work it is, plus the page itself. */
+export interface ShareView {
+  ownerName: string | null;
+  page: CollectionModel;
+}
+
+/** The owner's view of their own link. */
+export interface ShareSettings {
+  exists: boolean;
+  /**
+   * The live raw token, so the page can render a copyable link and re-send it.
+   *
+   * Null when it cannot be recovered — a link minted before the backend stored a decryptable copy.
+   * That is NOT an error state: the link still works for whoever holds it, we simply cannot show
+   * it, so the UI offers a reset rather than reporting a failure.
+   */
+  token: string | null;
+  createdAt: string | null;
+  rotatedAt: string | null;
+  lastUsedAt: string | null;
+  optedInCollectionIds: number[];
+  candidateCollections: CollectionModel[];
+}
+
+export interface ShareEmailResult {
+  sent: boolean;
+  reason: string | null;
+}
+
+/**
+ * The recipient view behind a share token.
+ *
+ * Returns null on 404, which covers an unknown token and a reset one alike — the backend cannot
+ * tell them apart by design, and neither should the page.
+ */
+export async function getShareView(token: string): Promise<ShareView | null> {
+  try {
+    return await fetchReadApi<ShareView>(`share/${encodeURIComponent(token)}`, {
+      cache: 'no-store',
+    });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * The recipient view for a visitor who already holds the cookie — the "way back" after they have
+ * walked off into a collection. Null when the cookie is absent or its link has since been reset.
+ */
+export async function getCurrentShareView(): Promise<ShareView | null> {
+  try {
+    return await fetchReadApi<ShareView>('share/view', { cache: 'no-store' });
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 401 || error.status === 404)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/** The signed-in user's own link. Null on 401, matching {@link getUserPage}. */
+export async function getShareSettings(): Promise<ShareSettings | null> {
+  try {
+    return await fetchReadApi<ShareSettings>('user/share', { cache: 'no-store' });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Outcome of the owner-side settings read.
+ *
+ * `{ ok: true, settings: null }` is a genuine "you have no link yet"; `{ ok: false }` is "the read
+ * failed, so nothing is known". Same distinction {@link FailSoftRead} draws for the list reads, and
+ * for the same reason: collapsing the two would have the Share card offer "Create a link" to
+ * someone who already has one in circulation, which is a claim we cannot support from a failure.
+ */
+export type ShareSettingsRead = { ok: true; settings: ShareSettings | null } | { ok: false };
+
+/**
+ * Fail-soft wrapper for {@link getShareSettings}, so a share-read failure degrades one card rather
+ * than taking down the whole `/user` page.
+ */
+export async function readShareSettings(): Promise<ShareSettingsRead> {
+  try {
+    return { ok: true, settings: await getShareSettings() };
+  } catch (error) {
+    logger.error('share', 'Could not load share settings', error);
+    return { ok: false };
+  }
+}
+
+/**
+ * Plant the share cookie for a token that arrived in the URL, so the recipient keeps their view
+ * while browsing the rest of the site.
+ *
+ * Runs from the browser on purpose. The backend owns the cookie's attributes (HttpOnly, Lax, the
+ * rolling 30-day window) and sets them on this response; the BFF proxy forwards `Set-Cookie`
+ * through. A Server Component cannot set cookies, and re-declaring those attributes in a Server
+ * Action would duplicate them in a second place that could drift from the backend.
+ */
+export async function plantShareCookie(token: string): Promise<void> {
+  const res = await fetch(`/api/proxy/api/read/share/${encodeURIComponent(token)}`, {
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+}
+
+/**
+ * Mint the link, or reset it.
+ *
+ * Destructive: anyone holding the previous link loses access immediately. Re-sending to a new
+ * person does NOT need this — {@link getShareSettings} returns the live link precisely so that
+ * sending it again is a copy rather than a reset.
+ */
+export async function rotateShareLink(): Promise<ShareSettings> {
+  const res = await fetch(`${SHARE}/rotate`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+  return (await res.json()) as ShareSettings;
+}
+
+/**
+ * Email the link that is already in circulation. Does not mint a new one, so emailing a second
+ * person cannot cut off the first.
+ */
+export async function emailShareLink(toEmail: string): Promise<ShareEmailResult> {
+  const res = await fetch(`${SHARE}/email`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ toEmail }),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+  return (await res.json()) as ShareEmailResult;
+}
+
+/** Add a collection the user was granted access to into their shared view. */
+export async function addShareCollection(collectionId: number): Promise<void> {
+  const res = await fetch(`${SHARE}/collections/${collectionId}`, {
+    method: 'PUT',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+}
+
+/** Take a collection back out of the shared view. */
+export async function removeShareCollection(collectionId: number): Promise<void> {
+  const res = await fetch(`${SHARE}/collections/${collectionId}`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    await throwFromResponse(res);
+  }
+}
+
+/** Build the shareable URL from a raw token, against the browser's own origin. */
+export function buildShareUrl(token: string, origin: string): string {
+  return `${origin.replace(/\/+$/, '')}/s/${token}`;
+}

--- a/app/s/[token]/ShareBanner.module.scss
+++ b/app/s/[token]/ShareBanner.module.scss
@@ -1,0 +1,25 @@
+/* ShareBanner — standing "you are viewing X's work" context for a share recipient. */
+
+.banner {
+  margin-bottom: var(--space-3);
+
+  /* Inset while the content grids below run full-bleed on mobile, released at the desktop
+     breakpoint where .sections regains its own side padding. Mirrors /user's .topBar and the
+     shared FilterToolbar, which bracket the same grids. */
+  padding-inline: var(--page-padding-mobile);
+
+  @media (width >= 768px) {
+    padding-inline: 0;
+  }
+}
+
+.text {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-on-surface-muted);
+}
+
+.name {
+  font-weight: 600;
+  color: var(--color-on-surface);
+}

--- a/app/s/[token]/ShareBanner.tsx
+++ b/app/s/[token]/ShareBanner.tsx
@@ -1,0 +1,34 @@
+import styles from './ShareBanner.module.scss';
+
+export interface ShareBannerProps {
+  /** The sharer's display name, or null when they have never set one. */
+  ownerName: string | null;
+}
+
+/**
+ * Standing context for a share recipient: whose work this is, and that they are looking at it
+ * read-only.
+ *
+ * Persistent rather than dismissible on purpose. The recipient arrived by clicking a link in a
+ * message, has no account, and will walk off into collections from here — without a standing
+ * marker, "whose site am I on and why can I see this?" has no answer anywhere on the page.
+ *
+ * Falls back to an unnamed phrasing rather than hiding: the fact that this is a shared view is the
+ * load-bearing half, and it holds whether or not the owner ever set a display name.
+ */
+export function ShareBanner({ ownerName }: ShareBannerProps) {
+  return (
+    <aside className={styles.banner} aria-label="Shared view">
+      <p className={styles.text}>
+        {ownerName ? (
+          <>
+            You are viewing <strong className={styles.name}>{ownerName}</strong>&apos;s work,
+            shared with you.
+          </>
+        ) : (
+          <>You are viewing work that was shared with you.</>
+        )}
+      </p>
+    </aside>
+  );
+}

--- a/app/s/[token]/ShareSession.tsx
+++ b/app/s/[token]/ShareSession.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { plantShareCookie } from '@/app/lib/api/share';
+import { logger } from '@/app/utils/logger';
+
+export interface ShareSessionProps {
+  /** The raw token from the URL. Never rendered — only exchanged for the cookie. */
+  token: string;
+}
+
+/**
+ * Plants the share cookie for a link that has just been opened, so the recipient keeps their view
+ * while walking around the rest of the site instead of being confined to this page.
+ *
+ * Renders nothing. It exists because a Server Component cannot set cookies: the page above SSRs
+ * the view from the token directly, and this fires once on mount to have the backend issue the
+ * cookie (the BFF proxy forwards its `Set-Cookie` through). Re-declaring the cookie's attributes
+ * in a Server Action instead would put HttpOnly / SameSite / max-age in a second place that could
+ * drift from the backend that owns them.
+ *
+ * The cost is one extra request on the first landing only — every later visit is served from the
+ * cookie. A failure is logged and swallowed: the page the visitor asked for is already rendered
+ * above, and the link in their messages keeps working, so an error banner would report a problem
+ * they do not have.
+ */
+export function ShareSession({ token }: ShareSessionProps) {
+  useEffect(() => {
+    let cancelled = false;
+    plantShareCookie(token).catch((error: unknown) => {
+      if (!cancelled) {
+        // The token is deliberately not included — it is a bearer credential.
+        logger.error('share', 'Could not start the share session', error);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return null;
+}

--- a/app/s/[token]/page.module.scss
+++ b/app/s/[token]/page.module.scss
@@ -1,0 +1,9 @@
+/* The page scaffold (container/main, max-width, centering, responsive side padding) and the
+   SiteHeader come from the shared <PageShell>, exactly as on /user. This module only owns the
+   share-view-specific bits. */
+
+.sections {
+  /* Same vertical rhythm as /user's own sections block — this is the same view, rendered for a
+     guest rather than its owner, so it should not sit differently on the page. */
+  padding: var(--space-3) 0 var(--space-5);
+}

--- a/app/s/[token]/page.tsx
+++ b/app/s/[token]/page.tsx
@@ -1,0 +1,76 @@
+import { type Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { PageShell } from '@/app/components/ui/PageShell/PageShell';
+import { UserSpace } from '@/app/components/UserSpace/UserSpace';
+import { loadUserSpace, resolveTabKey } from '@/app/components/UserSpace/userSpaceData';
+import { resolveSsrViewport } from '@/app/utils/ssrViewport';
+
+import styles from './page.module.scss';
+import { ShareBanner } from './ShareBanner';
+import { ShareSession } from './ShareSession';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Emit `<meta name="referrer" content="no-referrer">` into `<head>` so the raw share token in the
+ * URL is never sent in a `Referer` header to third-party resources. Set via Next's metadata API —
+ * a bare `<meta>` in the JSX body is inert, because browsers only honor the referrer directive
+ * inside `<head>`. Same reasoning as the invite route.
+ */
+export const metadata: Metadata = { referrer: 'no-referrer' };
+
+interface SharePageProps {
+  params: Promise<{ token: string }>;
+  searchParams: Promise<{ tab?: string | string[] }>;
+}
+
+/**
+ * A shared view of one user's work, opened from a link they sent.
+ *
+ * The recipient is a guest, not a borrower: they see the owner's collections and tagged images,
+ * and can walk into those collections, but they hold no grants of their own. That cap lives
+ * entirely in the backend — this page renders {@link UserSpace} with `me={null}`, the same switch
+ * `/admin/users/[id]` uses, which disarms every personal-action control in the stack.
+ *
+ * Only Collections and Images are offered. Saved and Following are the owner's private bookmarks
+ * and are absent from the backend's recipient view, so the section chips are narrowed rather than
+ * rendered empty — an empty "Saved" tab would assert the owner has saved nothing, which is not
+ * what we know.
+ *
+ * A dead link (unknown or reset) is a 404. The backend cannot tell those apart by design — a reset
+ * leaves no trace of the old token — and neither should this page.
+ */
+export default async function SharePage({ params, searchParams }: SharePageProps) {
+  const { token } = await params;
+  const { tab } = await searchParams;
+
+  const activeKey = resolveTabKey(tab);
+  const [data, ssrViewport] = await Promise.all([
+    loadUserSpace({ mode: 'share', token }, activeKey),
+    resolveSsrViewport(),
+  ]);
+  if (!data) notFound();
+
+  // `?tab=saved` on a shared link resolves to a section this view does not offer. Clamp rather
+  // than 404 — a stale or hand-edited query string should land on the page, not on an error.
+  const safeKey = data.visibleKeys.includes(activeKey) ? activeKey : data.visibleKeys[0];
+
+  return (
+    <PageShell pageType="default" collectionSlug={data.collection.slug}>
+      <ShareSession token={token} />
+
+      <div className={styles.sections}>
+        <ShareBanner ownerName={data.ownerName} />
+
+        <UserSpace
+          data={data}
+          activeKey={safeKey}
+          basePath={`/s/${token}`}
+          me={null}
+          ssrViewport={ssrViewport}
+        />
+      </div>
+    </PageShell>
+  );
+}

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -3,11 +3,13 @@ import { notFound } from 'next/navigation';
 import { MeProvider } from '@/app/components/auth/MeProvider';
 import { AccountCard } from '@/app/components/Personal/AccountCard';
 import { AdminCard } from '@/app/components/Personal/AdminCard';
+import { ShareCard } from '@/app/components/Personal/ShareCard';
 import { SendMessageButton } from '@/app/components/SendMessageButton/SendMessageButton';
 import { PageShell } from '@/app/components/ui/PageShell/PageShell';
 import { UserSpace } from '@/app/components/UserSpace/UserSpace';
 import { loadUserSpace, resolveTabKey } from '@/app/components/UserSpace/userSpaceData';
 import { meServer } from '@/app/lib/api/auth';
+import { readShareSettings } from '@/app/lib/api/share';
 import { resolveSsrViewport } from '@/app/utils/ssrViewport';
 
 import styles from './page.module.scss';
@@ -48,9 +50,10 @@ export default async function UserPage({ searchParams }: UserPageProps) {
   const { tab } = await searchParams;
   const activeKey = resolveTabKey(tab);
 
-  const [data, ssrViewport] = await Promise.all([
+  const [data, ssrViewport, share] = await Promise.all([
     loadUserSpace('self', activeKey),
     resolveSsrViewport(),
+    readShareSettings(),
   ]);
   if (!data) notFound();
 
@@ -73,6 +76,7 @@ export default async function UserPage({ searchParams }: UserPageProps) {
             railExtras={
               <>
                 <AccountCard email={principal.email} />
+                <ShareCard read={share} />
                 {principal.isAdmin && <AdminCard />}
               </>
             }

--- a/tests/components/Personal/ShareCard.test.tsx
+++ b/tests/components/Personal/ShareCard.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for ShareCard — the /user block that shows the owner's share link and the controls for
+ * sending and revoking it.
+ *
+ * Mirrors the AccountCard test style: mock the share API and drive each control. The assertions
+ * concentrate on the two claims the card must never get wrong — that a failed read is not
+ * presented as "you have no link", and that sending to someone does not quietly reset the link
+ * out from under whoever already has it.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { ShareCard } from '@/app/components/Personal/ShareCard';
+import { ApiError } from '@/app/lib/api/core';
+import * as shareApi from '@/app/lib/api/share';
+import { type CollectionModel } from '@/app/types/Collection';
+
+jest.mock('@/app/lib/api/share', () => ({
+  ...jest.requireActual('@/app/lib/api/share'),
+  rotateShareLink: jest.fn(),
+  emailShareLink: jest.fn(),
+  addShareCollection: jest.fn(),
+  removeShareCollection: jest.fn(),
+}));
+
+const mockRotate = shareApi.rotateShareLink as jest.MockedFunction<typeof shareApi.rotateShareLink>;
+const mockEmail = shareApi.emailShareLink as jest.MockedFunction<typeof shareApi.emailShareLink>;
+const mockAdd = shareApi.addShareCollection as jest.MockedFunction<
+  typeof shareApi.addShareCollection
+>;
+
+const collection = (id: number, title: string) =>
+  ({ id, title, slug: `c-${id}` }) as unknown as CollectionModel;
+
+function settings(overrides: Partial<shareApi.ShareSettings> = {}): shareApi.ShareSettings {
+  return {
+    exists: true,
+    token: 'tok-123',
+    createdAt: null,
+    rotatedAt: null,
+    lastUsedAt: null,
+    optedInCollectionIds: [],
+    candidateCollections: [],
+    ...overrides,
+  };
+}
+
+describe('ShareCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the live link so it can be sent again without a reset', () => {
+    render(<ShareCard read={{ ok: true, settings: settings() }} />);
+
+    // The whole point: the link is readable on every visit, not only the one that made it.
+    expect(screen.getByText(`${window.location.origin}/s/tok-123`)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument();
+  });
+
+  it('does not offer to create a link when the read failed', () => {
+    render(<ShareCard read={{ ok: false }} />);
+
+    // A failure says nothing about whether a link exists. Offering "Create a link" here would
+    // read as "you have none" to someone whose link is out there working.
+    expect(screen.queryByRole('button', { name: /create a link/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/unavailable right now/i)).toBeInTheDocument();
+  });
+
+  it('offers to create one only when the read genuinely says there is none', () => {
+    render(<ShareCard read={{ ok: true, settings: null }} />);
+
+    expect(screen.getByRole('button', { name: /create a link/i })).toBeInTheDocument();
+  });
+
+  it('emails the existing link without minting a new one', async () => {
+    mockEmail.mockResolvedValue({ sent: true, reason: null });
+    render(<ShareCard read={{ ok: true, settings: settings() }} />);
+
+    fireEvent.change(screen.getByLabelText(/send the link to this email/i), {
+      target: { value: 'mum@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(mockEmail).toHaveBeenCalledWith('mum@example.com'));
+    // Sending to a second person must never cut off the first.
+    expect(mockRotate).not.toHaveBeenCalled();
+    expect(await screen.findByText(/sent to mum@example.com/i)).toBeInTheDocument();
+  });
+
+  it('says so plainly when email is switched off, rather than claiming it sent', async () => {
+    mockEmail.mockResolvedValue({ sent: false, reason: 'email-disabled' });
+    render(<ShareCard read={{ ok: true, settings: settings() }} />);
+
+    fireEvent.change(screen.getByLabelText(/send the link to this email/i), {
+      target: { value: 'mum@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(await screen.findByText(/email is not switched on/i)).toBeInTheDocument();
+  });
+
+  it('replaces the displayed link after a reset', async () => {
+    mockRotate.mockResolvedValue(settings({ token: 'tok-new' }));
+    render(<ShareCard read={{ ok: true, settings: settings() }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /reset link/i }));
+
+    expect(
+      await screen.findByText(`${window.location.origin}/s/tok-new`)
+    ).toBeInTheDocument();
+  });
+
+  it('offers granted galleries as opt-ins, unchecked by default', async () => {
+    mockAdd.mockResolvedValue();
+    render(
+      <ShareCard
+        read={{
+          ok: true,
+          settings: settings({ candidateCollections: [collection(9, 'Someone Else Wedding')] }),
+        }}
+      />
+    );
+
+    const box = screen.getByRole('checkbox', { name: /someone else wedding/i });
+    // A gallery someone else let them into is not theirs to pass on by default.
+    expect(box).not.toBeChecked();
+
+    fireEvent.click(box);
+    await waitFor(() => expect(mockAdd).toHaveBeenCalledWith(9));
+  });
+
+  it('surfaces a link that cannot be shown as a reset prompt, not an error', () => {
+    render(<ShareCard read={{ ok: true, settings: settings({ token: null }) }} />);
+
+    expect(screen.getByText(/reset it to get one you can copy/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reset link/i })).toBeInTheDocument();
+  });
+
+  it('explains an expired session rather than a generic failure', async () => {
+    mockRotate.mockRejectedValue(new ApiError('nope', 401));
+    render(<ShareCard read={{ ok: true, settings: settings() }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /reset link/i }));
+
+    expect(await screen.findByText(/session has expired/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/UserSpace/UserSpace.sectionSwitch.test.tsx
+++ b/tests/components/UserSpace/UserSpace.sectionSwitch.test.tsx
@@ -22,6 +22,7 @@ import { render, screen } from '@testing-library/react';
 
 import { UserSpace } from '@/app/components/UserSpace/UserSpace';
 import {
+  TAB_KEYS,
   type TabKey,
   type UserSpaceData,
   type UserSpaceSection,
@@ -104,6 +105,8 @@ function makeData(): UserSpaceData {
     },
     followedCollectionIds: [7],
     savedImageIds: [3],
+    visibleKeys: TAB_KEYS,
+    ownerName: null,
   };
 }
 

--- a/tests/components/UserSpace/UserSpace.test.tsx
+++ b/tests/components/UserSpace/UserSpace.test.tsx
@@ -13,7 +13,8 @@ import { FollowsProvider } from '@/app/components/Personal/FollowsContext';
 import { FormError } from '@/app/components/ui/Field/FormError';
 import { EmptyState } from '@/app/components/ui/StatusText/EmptyState';
 import { UserSpace } from '@/app/components/UserSpace/UserSpace';
-import { type TabKey, type UserSpaceData } from '@/app/components/UserSpace/userSpaceData';
+import { TAB_KEYS,
+type TabKey,   type UserSpaceData } from '@/app/components/UserSpace/userSpaceData';
 import { type MeResponse } from '@/app/types/Auth';
 
 const principal: MeResponse = {
@@ -66,6 +67,8 @@ function makeData(overrides: Partial<UserSpaceData> = {}): UserSpaceData {
     },
     followedCollectionIds: [7, 9],
     savedImageIds: [3],
+    visibleKeys: TAB_KEYS,
+    ownerName: null,
     ...overrides,
   };
 }

--- a/tests/components/UserSpace/userSpaceData.share.test.ts
+++ b/tests/components/UserSpace/userSpaceData.share.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `loadUserSpace`'s share mode — the recipient view behind a share link.
+ *
+ * The properties under test are the ones that separate a guest from the owner: which reads run,
+ * which sections are offered, and that none of the owner's private bookmark reads are issued on
+ * their behalf.
+ */
+
+import { loadUserSpace, SHARE_TAB_KEYS } from '@/app/components/UserSpace/userSpaceData';
+import * as collectionsApi from '@/app/lib/api/collections';
+import * as personalApi from '@/app/lib/api/personal';
+import * as shareApi from '@/app/lib/api/share';
+import { type CollectionModel } from '@/app/types/Collection';
+
+jest.mock('@/app/lib/api/share');
+jest.mock('@/app/lib/api/personal');
+jest.mock('@/app/lib/api/user');
+jest.mock('@/app/lib/api/users');
+jest.mock('@/app/lib/api/collections');
+
+const mockGetShareView = shareApi.getShareView as jest.MockedFunction<typeof shareApi.getShareView>;
+const mockGetCurrentShareView = shareApi.getCurrentShareView as jest.MockedFunction<
+  typeof shareApi.getCurrentShareView
+>;
+const mockGetAllCollections = collectionsApi.getAllCollections as jest.MockedFunction<
+  typeof collectionsApi.getAllCollections
+>;
+
+const page = {
+  slug: 'user',
+  title: 'Ada',
+  content: [
+    { id: 1, contentType: 'COLLECTION', title: 'Wedding' },
+    { id: 2, contentType: 'IMAGE', imageUrl: 'https://cdn/2.jpg' },
+  ],
+} as unknown as CollectionModel;
+
+describe('loadUserSpace — share mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllCollections.mockResolvedValue([]);
+  });
+
+  it('resolves the view from the token on first landing', async () => {
+    mockGetShareView.mockResolvedValue({ ownerName: 'Ada', page });
+
+    const data = await loadUserSpace({ mode: 'share', token: 'tok-123' });
+
+    expect(mockGetShareView).toHaveBeenCalledWith('tok-123');
+    expect(mockGetCurrentShareView).not.toHaveBeenCalled();
+    expect(data?.ownerName).toBe('Ada');
+    expect(data?.collection.slug).toBe('user');
+  });
+
+  it('falls back to the cookie when no token is given', async () => {
+    mockGetCurrentShareView.mockResolvedValue({ ownerName: 'Ada', page });
+
+    await loadUserSpace({ mode: 'share' });
+
+    expect(mockGetCurrentShareView).toHaveBeenCalled();
+    expect(mockGetShareView).not.toHaveBeenCalled();
+  });
+
+  it('offers only Collections and Images', async () => {
+    mockGetShareView.mockResolvedValue({ ownerName: 'Ada', page });
+
+    const data = await loadUserSpace({ mode: 'share', token: 'tok-123' });
+
+    // Saved and Following are the owner's private bookmarks. Rendering them empty would assert
+    // the owner has none, which is not what the recipient view tells us.
+    expect(data?.visibleKeys).toEqual(SHARE_TAB_KEYS);
+    expect(data?.visibleKeys).not.toContain('saved');
+    expect(data?.visibleKeys).not.toContain('following');
+  });
+
+  it('issues none of the owner-scoped bookmark reads', async () => {
+    mockGetShareView.mockResolvedValue({ ownerName: 'Ada', page });
+
+    const data = await loadUserSpace({ mode: 'share', token: 'tok-123' });
+
+    expect(personalApi.listSavedImagesServer).not.toHaveBeenCalled();
+    expect(personalApi.listFollowedCollectionIdsServer).not.toHaveBeenCalled();
+    // Nothing here is the recipient's to have saved or followed, so the toggles seed empty.
+    expect(data?.savedImageIds).toEqual([]);
+    expect(data?.followedCollectionIds).toEqual([]);
+  });
+
+  it('skips the collection catalog even on the following tab', async () => {
+    mockGetShareView.mockResolvedValue({ ownerName: 'Ada', page });
+
+    await loadUserSpace({ mode: 'share', token: 'tok-123' }, 'following');
+
+    // A ~0.5s read serving a tab the recipient cannot reach.
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a dead link so the page can 404', async () => {
+    mockGetShareView.mockResolvedValue(null);
+
+    expect(await loadUserSpace({ mode: 'share', token: 'gone' })).toBeNull();
+  });
+});


### PR DESCRIPTION
Frontend for the share links backend (edens.zac.backend #156, merged). A signed-in user gets a link on `/user` they can copy or email; the recipient opens it and sees the owner's work in the standard collection layout, and can walk into those collections without an account.

## The recipient view needed no new component

`UserSpace` already accepts `me={null}` — its own docblock calls that *"the single switch that disarms every personal-action control"*, which is exactly share-recipient semantics, and `/admin/users/[id]` already passes it. So `/s/[token]` renders the same view the owner sees, with the personal controls off.

`loadUserSpace` gains a third mode beside `'self'` and `'admin'`. It carries the raw token on first landing (the URL is the only place it exists) and omits it afterwards, when the cookie identifies the link. Share mode issues none of the owner-scoped bookmark reads, and skips the ~0.5s collection catalog even on the Following tab since that section is unreachable.

## Two places this refuses to guess

**Only Collections and Images are offered**, via a new `visibleKeys` on `UserSpaceData`. Saved and Following are the owner's private bookmarks and are absent from the backend's recipient view — rendering them empty would assert the owner has saved nothing, which is not what we know.

**The settings read is a discriminated `ShareSettingsRead`, not a nullable.** A failed read must not have the Share card offer "Create a link" to someone whose link is out in the world working. That is the distinction the existing `FailSoftRead` type exists to protect, applied to a non-list read — and it is also why a share-read failure degrades one card instead of taking down `/user`.

## Security details carried over

`/s/[token]` copies the invite route's `metadata: { referrer: 'no-referrer' }` so the token never leaves in a `Referer` header — set via the metadata API, because a bare `<meta>` in the JSX body is inert.

The cookie is planted by a client component rather than a Server Action. A Server Component cannot set cookies, and re-declaring HttpOnly / SameSite / max-age in a Server Action would put them in a second place that could drift from the backend that owns them. Cost is one extra request on first landing only; a failure is logged and swallowed, since the page is already rendered and the link in the recipient's messages keeps working.

**No BFF change was needed** — the production anonymous-reject covers only `api/admin/` and `api/edit/`, while `/api/read/share/**` must stay anonymous-reachable.

## The share card

Copy, email, per-gallery opt-ins, and reset. The link is shown in full on every visit, not just the one that created it: sending it to a second person months later must not require a reset, because a reset cuts off whoever already holds the first copy. Reset therefore sits below a rule, away from the everyday controls, and says plainly what it does.

Granted galleries are opt-in and unchecked by default — a gallery someone else let you into is not yours to pass on without a deliberate act.

## Verification

216 suites / 3915 tests green (15 new), `tsc --noEmit` clean, lint clean.

## Not included

The home-page re-entry tile. `GET /api/read/share/view` resolves the recipient view from the cookie alone, so the "way back" works from the banner today; surfacing the owner's tile on the home page is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)